### PR TITLE
feat(composables): add `onGlobalSetup` composable

### DIFF
--- a/packages/app/src/_templates/entry.client.js
+++ b/packages/app/src/_templates/entry.client.js
@@ -1,14 +1,21 @@
 <%= nuxtOptions.vite ? "import('vite/dynamic-import-polyfill')" : '' %>
-import { createSSRApp, nextTick } from 'vue'
+import { createSSRApp, h, nextTick } from 'vue'
 import { createNuxt, applyPlugins } from '@nuxt/app'
 import plugins from './plugins'
 import clientPlugins from './plugins.client'
 import App from '<%= app.main %>'
 
 async function initApp () {
-  const app = createSSRApp(App)
+  const globalSetups = []
+  const app = createSSRApp({
+    render: () => h(App),
+    setup(_props, context) {
+      globalSetups.forEach(setup => setup(context))
+    }
+  })
 
   const nuxt = createNuxt({ app })
+  nuxt._globalSetups = globalSetups
 
   await applyPlugins(nuxt, plugins)
   await applyPlugins(nuxt, clientPlugins)

--- a/packages/app/src/_templates/entry.server.js
+++ b/packages/app/src/_templates/entry.server.js
@@ -1,13 +1,20 @@
-import { createApp } from 'vue'
+import { createApp, h } from 'vue'
 import { createNuxt, applyPlugins } from '@nuxt/app'
 import plugins from './plugins'
 import serverPlugins from './plugins.server'
 import App from '<%= app.main %>'
 
 export default async function createNuxtAppServer (ssrContext = {}) {
-  const app = createApp(App)
+  const globalSetups = []
+  const app = createApp({
+    render: () => h(App),
+    setup(_props, context) {
+      globalSetups.forEach(setup => setup(context))
+    }
+  })
 
   const nuxt = createNuxt({ app, ssrContext })
+  nuxt._globalSetups = globalSetups
 
   await applyPlugins(nuxt, plugins)
   await applyPlugins(nuxt, serverPlugins)

--- a/packages/app/src/composables/index.ts
+++ b/packages/app/src/composables/index.ts
@@ -1,4 +1,5 @@
 export { defineNuxtComponent } from './component'
 export { useAsyncData, asyncData } from './asyncData'
 export { useData } from './data'
+export { onGlobalSetup } from './lifecycle'
 export { useHydration } from './hydrate'

--- a/packages/app/src/composables/lifecycle.ts
+++ b/packages/app/src/composables/lifecycle.ts
@@ -1,0 +1,22 @@
+import type { SetupContext } from 'vue'
+
+import { useNuxt } from '@nuxt/app'
+
+/**
+ * Run a callback function in the global setup function. This should be called from a Nuxt plugin.
+ * @param setupFn The function to run in the setup function. It receives the global context only.
+ * @example
+    ```ts
+    import { onGlobalSetup } from '@nuxt/app'
+
+    export default () => {
+      onGlobalSetup(() => {
+        provide('globalKey', true)
+      })
+    }
+    ```
+ */
+export const onGlobalSetup = (setupFn: (context: SetupContext) => void) => {
+  const nuxt = useNuxt()
+  nuxt._globalSetups.push(setupFn)
+}

--- a/packages/app/src/nuxt/index.ts
+++ b/packages/app/src/nuxt/index.ts
@@ -1,5 +1,5 @@
 import Hookable from 'hookable'
-import type { App } from 'vue'
+import type { App, SetupContext } from 'vue'
 import { defineGetter } from '../utils'
 import { callWithNuxt } from './composables'
 
@@ -14,6 +14,7 @@ export interface Nuxt {
   [key: string]: any
 
   _asyncDataPromises?: Record<string, Promise<any>>
+  _globalSetups?: Array<(context: SetupContext) => void>
 
   ssrContext?: Record<string, any>
   payload: {

--- a/playground/pages/composables/on-global-setup.vue
+++ b/playground/pages/composables/on-global-setup.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    {{ test.bar }}
+  </div>
+</template>
+
+<script>
+import { inject } from 'vue'
+
+export default {
+  setup () {
+    const test = inject('test')
+
+    return { test }
+  }
+}
+</script>

--- a/playground/plugins/global-setup.ts
+++ b/playground/plugins/global-setup.ts
@@ -1,0 +1,8 @@
+import { provide } from 'vue'
+import { onGlobalSetup } from 'nuxt/app/composables'
+
+export default () => {
+  onGlobalSetup(() => {
+    provide('test', { bar: 42 })
+  })
+}


### PR DESCRIPTION
This adds a way to programmatically add callbacks to be run in the top-level Nuxt setup function. This is primarily used for provide/inject patterns. Libraries could ask users to put this in their `App.vue` themselves, but I think having a composable is needed for for libraries/plugins/modules to access this functionality and improve DX.

**[Current Nuxt 2 docs](https://composition-api.nuxtjs.org/lifecycle/onGlobalSetup)**

**Changes from Nuxt 2 implementation**:
 - this now does not receive `props` as it would just be an empty object

Test on local playground: http://localhost:3000/composables/on-global-setup - should render `42` (which has been provided by a nuxt plugin and injected in the page).
