### PR TITLE
fix: use `globalThis` instead of `global`

### DIFF
--- a/packages/app/src/_templates/plugins.client.js
+++ b/packages/app/src/_templates/plugins.client.js
@@ -1,11 +1,12 @@
 import { $fetch } from 'ohmyfetch'
-import _global from '@nuxt/un/runtime/global'
 import logs from 'nuxt/app/plugins/logs.client.dev'
 import progress from 'nuxt/app/plugins/progress.client'
 <% const plugins = app.plugins.filter(p => p.mode === 'client').map(p => p.src) %>
 <%= nxt.importSources(plugins) %>
 
-_global.$fetch = $fetch
+if (!globalThis.$fetch) {
+  globalThis.$fetch = $fetch
+}
 
 const plugins = [
   progress,

--- a/packages/nitro/src/rollup/plugins/static.ts
+++ b/packages/nitro/src/rollup/plugins/static.ts
@@ -50,7 +50,7 @@ export function dirnames (): Plugin {
     name: 'dirnames',
     renderChunk (code, chunk) {
       return {
-        code: code + (chunk.isEntry ? 'global.mainDir="undefined"!=typeof __dirname?__dirname:require.main.filename;' : ''),
+        code: code + (chunk.isEntry ? 'globalThis.mainDir="undefined"!=typeof __dirname?__dirname:require.main.filename;' : ''),
         map: null
       }
     }

--- a/packages/nitro/src/rollup/plugins/timing.ts
+++ b/packages/nitro/src/rollup/plugins/timing.ts
@@ -3,25 +3,18 @@ import type { Plugin, RenderedChunk } from 'rollup'
 
 export interface Options { }
 
-const TIMING = 'global.__timing__'
+const TIMING = 'globalThis.__timing__'
 
 const iife = code => `(function() { ${code.trim()} })();`.replace(/\n/g, '')
 
-// https://gist.github.com/pi0/1476085924f8a2eb1df85929c20cb43f
-const POLYFILL = `const global="undefined"!=typeof globalThis?globalThis:void 0!==o?o:"undefined"!=typeof self?self:{};
-global.process = global.process || {};
-const o=Date.now(),t=()=>Date.now()-o;global.process.hrtime=global.process.hrtime||(o=>{const e=Math.floor(.001*(Date.now()-t())),a=.001*t();let l=Math.floor(a)+e,n=Math.floor(a%1*1e9);return o&&(l-=o[0],n-=o[1],n<0&&(l--,n+=1e9)),[l,n]});`
-
-const HELPER = POLYFILL + iife(`
-const hrtime = global.process.hrtime;
-const start = () => hrtime();
-const end = s => { const d = hrtime(s); return ((d[0] * 1e9) + d[1]) / 1e6; };
-
+const HELPER = iife(`
+const start = () => Date.now();
+const end = s => Date.now() - s;
 const _s = {};
 const metrics = [];
-const logStart = id => { _s[id] = hrtime(); };
+const logStart = id => { _s[id] = Date.now(); };
 const logEnd = id => { const t = end(_s[id]); delete _s[id]; metrics.push([id, t]); console.debug('>', id + ' (' + t + 'ms)'); };
-${TIMING} = { hrtime, start, end, metrics, logStart, logEnd };
+${TIMING} = { start, end, metrics, logStart, logEnd };
 `)
 
 export function timing (_opts: Options = {}): Plugin {

--- a/packages/nitro/src/runtime/app/config.ts
+++ b/packages/nitro/src/runtime/app/config.ts
@@ -8,7 +8,7 @@ for (const type of ['private', 'public']) {
   }
 }
 
-const $config = global.$config = {
+const $config = globalThis.$config = {
   ...runtimeConfig.public,
   ...runtimeConfig.private
 }

--- a/packages/nitro/src/runtime/app/nitro.client.js
+++ b/packages/nitro/src/runtime/app/nitro.client.js
@@ -1,9 +1,5 @@
-import _global from '@nuxt/un/runtime/global'
 import { $fetch } from 'ohmyfetch'
 
-_global.process = _global.process || {};
-
-// eslint-disable-next-line
-(function () { const o = Date.now(); const t = () => Date.now() - o; _global.process.hrtime = _global.process.hrtime || ((o) => { const e = Math.floor(0.001 * (Date.now() - t())); const a = 0.001 * t(); let l = Math.floor(a) + e; let n = Math.floor(a % 1 * 1e9); return o && (l -= o[0], n -= o[1], n < 0 && (l--, n += 1e9)), [l, n] }) })()
-
-global.$fetch = $fetch
+if (!globalThis.$fetch) {
+  globalThis.$fetch = $fetch
+}

--- a/packages/nitro/src/runtime/server/index.ts
+++ b/packages/nitro/src/runtime/server/index.ts
@@ -20,5 +20,8 @@ app.use(() => import('../app/render').then(e => e.renderMiddleware), { lazy: tru
 export const stack = app.stack
 export const handle = useBase(process.env.ROUTER_BASE, app)
 export const localCall = createCall(handle)
-export const localFetch = createLocalFetch(localCall, global.fetch)
-export const $fetch = global.$fetch = createFetch({ fetch: localFetch })
+export const localFetch = createLocalFetch(localCall, globalThis.fetch)
+
+export const $fetch = createFetch({ fetch: localFetch })
+
+globalThis.$fetch = $fetch

--- a/packages/nitro/src/runtime/server/timing.ts
+++ b/packages/nitro/src/runtime/server/timing.ts
@@ -1,4 +1,4 @@
-export const globalTiming = global.__timing__ || {
+export const globalTiming = globalThis.__timing__ || {
   start: () => 0,
   end: () => 0,
   metrics: []


### PR DESCRIPTION
Use `globalThis` instead of `global`. ideally we should also change `window` references to `globalThis` for maximum portability.

Read more: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

Support is almost perfect (92%) but still would be probably nice to add polyfill (some unjs libraries have internal polyfill)

This PR also removes use of `process.hrtime` with `Date` for less precise but more compatible timing