### PR TITLE
chore: suppress peerDeps warnings pending upstream fixes

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,12 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
 
+packageExtensions:
+  rollup-plugin-esbuild@*:
+    peerDependencies:
+      rollup: "*"
+  '@nuxtjs/eslint-config-typescript@*':
+    peerDependencies:
+      eslint: "*"
+
 yarnPath: .yarn/releases/yarn-2.4.1.cjs


### PR DESCRIPTION
**Note**: we can't suppress the warning for `@nuxt/friendly-errors-webpack-plugin` as it does have a `peerDependency` set; we'd have to do it via `resolutions` which seems heavy-handed.

(But the PR submitted there does solve the issue.)

relates to nuxt/nuxt.js#11254