### PR TITLE
fix(nitro): replace optional chaining due to CF preset

### DIFF
--- a/packages/nitro/src/runtime/app/vue2.ts
+++ b/packages/nitro/src/runtime/app/vue2.ts
@@ -8,7 +8,8 @@ const __VUE_SSR_CONTEXT__ = global.__VUE_SSR_CONTEXT__ = {}
 export function renderToString (component, context) {
   return new Promise((resolve, reject) => {
     _renderer.renderToString(component, context, (err, result) => {
-      const styles = [__VUE_SSR_CONTEXT__, context].map(c => c?._styles?.default).filter(Boolean)
+      // No optional chaining because it breaks CF workers.
+      const styles = [__VUE_SSR_CONTEXT__, context].map(c => c && c._styles && c._styles.default).filter(Boolean)
       if (!context._styles) { context._styles = {} }
       context._styles.default = {
         ids: [...styles.map(s => s.ids)],


### PR DESCRIPTION
Resolves nuxt/nuxt.js#10932.

I've replaced optional chaining in the global style injection code from Vue 2 because CF workers have an issue with it.