### PR TITLE
refactor(nitro): use `#` prefix for virtual and generated imports

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -174,7 +174,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
       ...nitroContext.middleware
     ]
     if (nitroContext.serveStatic) {
-      _middleware.unshift({ route: '/', handle: '~runtime/server/static' })
+      _middleware.unshift({ route: '/', handle: '#nitro/server/static' })
     }
     return _middleware
   }))
@@ -189,10 +189,10 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
   const vue2ServerRenderer = 'vue-server-renderer/' + (nitroContext._nuxt.dev ? 'build.dev.js' : 'build.prod.js')
   rollupConfig.plugins.push(alias({
     entries: {
-      '~runtime': nitroContext._internal.runtimeDir,
-      '~renderer': require.resolve(resolve(nitroContext._internal.runtimeDir, 'app', renderer)),
-      '~vueServerRenderer': vue2ServerRenderer,
-      '~build': nitroContext._nuxt.buildDir,
+      '#nitro': nitroContext._internal.runtimeDir,
+      '#nitro-renderer': require.resolve(resolve(nitroContext._internal.runtimeDir, 'app', renderer)),
+      '#nitro-vue-renderer': vue2ServerRenderer,
+      '#build': nitroContext._nuxt.buildDir,
       ...env.alias
     }
   }))

--- a/packages/nitro/src/rollup/plugins/assets.ts
+++ b/packages/nitro/src/rollup/plugins/assets.ts
@@ -38,7 +38,7 @@ export function statAsset (id) {
 
   if (!opts.inline) {
     return virtual({
-      '~nitro/assets': `
+      '#assets': `
 import { statSync, promises as fsp } from 'fs'
 import { resolve } from 'path'
 
@@ -68,7 +68,7 @@ export function getAsset (id) {
   }
 
   return virtual({
-    '~nitro/assets': {
+    '#assets': {
       async load () {
         const assets: Record<string, Asset> = {}
         for (const assetdir in opts.dirs) {

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -18,7 +18,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
     name: 'node-externals',
     resolveId (id) {
       // Internals
-      if (!id || id.startsWith('\x00') || id.includes('?')) {
+      if (!id || id.startsWith('\x00') || id.includes('?') || id.startsWith('#')) {
         return null
       }
 

--- a/packages/nitro/src/rollup/plugins/storage.ts
+++ b/packages/nitro/src/rollup/plugins/storage.ts
@@ -30,7 +30,7 @@ export function storage (opts: StorageOptions) {
   const driverImports = Array.from(new Set(mounts.map(m => m.driver)))
 
   return virtual({
-    '~nitro/storage': `
+    '#storage': `
 import { createStorage } from 'unstorage'
 ${driverImports.map(i => `import ${getImportName(i)} from '${i}'`).join('\n')}
 

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -2,13 +2,13 @@ import { createRenderer } from 'vue-bundle-renderer'
 import devalue from '@nuxt/devalue'
 import config from './config'
 // @ts-ignore
-import { renderToString } from '~renderer'
+import { renderToString } from '#nitro-renderer'
 // @ts-ignore
-import createApp from '~build/dist/server/server'
+import createApp from '#build/dist/server/server'
 // @ts-ignore
-import clientManifest from '~build/dist/server/client.manifest.json'
+import clientManifest from '#build/dist/server/client.manifest.json'
 // @ts-ignore
-import htmlTemplate from '~build/views/document.template.js'
+import htmlTemplate from '#build/views/document.template.js'
 
 function _interopDefault (e) { return e && typeof e === 'object' && 'default' in e ? e.default : e }
 

--- a/packages/nitro/src/runtime/app/vue2.ts
+++ b/packages/nitro/src/runtime/app/vue2.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { createRenderer } from '~vueServerRenderer'
+import { createRenderer } from '#nitro-vue-renderer'
 const _renderer = createRenderer({})
 
 // @ts-ignore

--- a/packages/nitro/src/runtime/entries/netlify_builder.ts
+++ b/packages/nitro/src/runtime/entries/netlify_builder.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { builderFunction } from '@netlify/functions'
 // @ts-ignore
-import { handler as _handler } from '~runtime/entries/lambda'
+import { handler as _handler } from '#nitro/entries/lambda'
 
 export const handler = builderFunction(_handler)


### PR DESCRIPTION
Use `#` prefix for aliases instead of `~` which is reserved for `srcDir` and clearly about being virtual/generated.

New public aliases:
- `#nitro` (points to nitro runtime)
- `#assets` (nitro assets API)
- `#storage` (nitro storage API)
- `#build` (build dir - `.nuxt`)
