### PR TITLE
fix(nitro): remove depd alias

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -38,7 +38,6 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
     alias: {
       // General
       debug: 'unenv/runtime/npm/debug',
-      depd: 'unenv/runtime/npm/depd',
       consola: 'unenv/runtime/npm/consola',
       // Vue 2
       encoding: 'unenv/runtime/mock/proxy',


### PR DESCRIPTION
As there is no `depd` runtime replacement available via [`unenv`](https://github.com/unjs/unenv/tree/main/src/runtime/npm), I've removed the aliasing here.

Related: https://github.com/unjs/unenv/pull/3