### PR TITLE
fix(nitro): ensure that nitro runtime is not externalized

### DIFF
--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -26,7 +26,8 @@ export function externals (opts: NodeExternalsOptions): Plugin {
       const _id = id.split('node_modules/').pop()
 
       // Resolve relative paths and exceptions
-      if (_id.startsWith('.') || opts.ignore.find(i => _id.startsWith(i))) {
+      // Ensure to take absolute and relative id
+      if (_id.startsWith('.') || opts.ignore.find(i => _id.startsWith(i) || id.startsWith(i))) {
         return null
       }
 


### PR DESCRIPTION
Resolves nuxt/nuxt.js#10969.

Because the relative id is checked in `externals` but some ignore paths are absolute, the runtime does not match. This PR ensures that also the absolute id is checked against the ignore list.