### PR TITLE
fix(nitro): set requireReturnsDefault to 'auto'

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -250,7 +250,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // https://github.com/rollup/plugins/tree/master/packages/commonjs
   rollupConfig.plugins.push(commonjs({
-    requireReturnsDefault: true
+    requireReturnsDefault: 'auto'
   }))
 
   // https://github.com/rollup/plugins/tree/master/packages/json


### PR DESCRIPTION
This works better with libs that don't have default exports (e.g. graphql) while keeping fs mocks intact.