### PR TITLE
feat(nitro): allow custom module directories

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -205,7 +205,8 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
     resolve(nitroContext._nuxt.rootDir, 'node_modules'),
     resolve(MODULE_DIR, 'node_modules'),
     resolve(MODULE_DIR, '../node_modules'),
-    'node_modules'
+    'node_modules',
+    ...env.moduleDirectories
   ]
 
   // Externals Plugin


### PR DESCRIPTION
Blocked by: https://github.com/unjs/unenv/pull/4

Not sure if there is a better implementation alternative 🙈

Custom / own `moduleDirectories` are right now the "easiest" way to support monorepo architectures.
(Of course, there are better ideas e.g. traversing folders til finding a `yarn.lock`)

Resolves nuxt/bridge#123 