### PR TITLE
feat(nitro): support netlify zero-config deployments

### DIFF
--- a/packages/nitro/src/presets/netlify.ts
+++ b/packages/nitro/src/presets/netlify.ts
@@ -17,9 +17,10 @@ export const netlify: NitroPreset = extendPreset(lambda, {
       if (existsSync(redirectsPath)) {
         const currentRedirects = await readFile(redirectsPath, 'utf-8')
         if (currentRedirects.match(/^\/\* /m)) {
-          consola.warn('Not adding Nitro fallback as an existing fallback rule was found')
+          consola.info('Not adding Nitro fallback to `_redirects` (as an existing fallback was found).')
           return
         }
+        consola.info('Adding Nitro fallback to `_redirects` to handle all unmatched routes.')
         contents = currentRedirects + '\n' + contents
       }
       await writeFile(redirectsPath, contents)


### PR DESCRIPTION
Note that there are two current issues that are in hand with the Netlify team:
- node12 version for netlify platform defaults to v12.18.0 which lacks package exports pattern support and causes error with resolving `./ufo/dist/index.mjs` - but they will upgrade their default version of node 12 to address
- currently requires adding a build command in the Netlify UI - Netlify will auto-detect Nuxt and default to `npm run build`

**Note**: Given that the build (seemingly) has to be setup anyway on Netlify, I've opted to leave `dist` as is to avoid breaking existing `nuxt generate` setups.