### PR TITLE
fix(nitro): set esbuild `target: '2019'`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "version": "yarn && git add yarn.lock"
   },
   "resolutions": {
+    "esbuild": "^0.12",
     "nuxt3": "workspace:./packages/nuxt3"
   },
   "devDependencies": {

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -145,6 +145,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // ESBuild
   rollupConfig.plugins.push(esbuild({
+    target: 'es2019',
     sourceMap: true
   }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,25 +5636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.11.19, esbuild@npm:^0.11.6":
-  version: 0.11.23
-  resolution: "esbuild@npm:0.11.23"
-  bin:
-    esbuild: bin/esbuild
-  checksum: 9226fc3d74f7555c96778c5d9204312c578e9c11b472deebfbab52c4ac58b9efc3a40be529368f6ccbe257d0059c6b8fd142c179824a3227d055d912c7b5a94a
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.12.1, esbuild@npm:^0.12.5":
-  version: 0.12.6
-  resolution: "esbuild@npm:0.12.6"
-  bin:
-    esbuild: bin/esbuild
-  checksum: 5303e77b84575ab4c71b381d797723f57208dd314c2d85e12b7f23fcd9edebf9e2be4bf2a7a23384205cd953990a4694b07dec00bbab55a6a729b5ca5bf8f0dd
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.12.7":
+"esbuild@npm:^0.12":
   version: 0.12.7
   resolution: "esbuild@npm:0.12.7"
   bin:


### PR DESCRIPTION
* error introduced in 7d2cd2f356fbda153af4b0adb3be6b137d32df6c:
   ```
   Cannot find module '../app/render'
   Require stack:
   - /Users/daniel/code/nuxt/framework/playground/.nuxt/nitro/index.js
     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:941:15)
     at Function.Module._load (node:internal/modules/cjs/loader:774:27)
     at Module.require (node:internal/modules/cjs/loader:1013:19)
     at require (node:internal/modules/cjs/helpers:93:18)
     at ./packages/nitro/src/runtime/server/index.ts:18:15
     at processTicksAndRejections (node:internal/process/task_queues:96:5)
     at handle2 (./node_modules/h3/dist/index.js:558:19)
   ```
   code being produced was:
   ```
   app.use(() => Promise.resolve().then(() => __toModule(require("../app/render"))).then((e) => e.renderMiddleware), { lazy: true });
   ```
   but there was no corresponding file generated.
* context: https://github.com/nuxt/nuxt.js/issues/11716
* issue with playground build is unrelated