### PR TITLE
fix(webpack): find asset modules of chunk

### DIFF
--- a/packages/webpack/src/plugins/vue/client.ts
+++ b/packages/webpack/src/plugins/vue/client.ts
@@ -102,7 +102,7 @@ export default class VueSSRClientPlugin {
 
           // Find all asset modules associated with the same chunk
           assetModules.forEach((m) => {
-            if (m.chunks.incudes(cid)) {
+            if (m.chunks.includes(cid)) {
               files.push.apply(files, m.assets.map(fileToIndex))
             }
           })


### PR DESCRIPTION
There is a typo in Vue SSR client that prevent loading assets modules

Resolves nuxt/nuxt.js#10954 