### PR TITLE
fix(nuxt3): add support for custom templates

### DIFF
--- a/packages/nuxt3/src/app.ts
+++ b/packages/nuxt3/src/app.ts
@@ -30,6 +30,16 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp) {
       data: {}
     } as NuxtTemplate))
 
+  // Custom templates (created with addTemplate)
+  const customTemplates = nuxt.options.build.templates.map(t => ({
+    path: t.dst,
+    src: t.src,
+    data: {
+      options: t.options
+    }
+  }))
+  app.templates = app.templates.concat(customTemplates)
+
   // Extend templates
   await nuxt.callHook('app:templates', app)
 


### PR DESCRIPTION
(for example, if `addPlugin` or `addTemplate` is called from `@nuxt/kit`)