### PR TITLE
feat(app): pass inject/provide helpers as second argument to plugins

### DIFF
--- a/packages/app/src/nuxt.ts
+++ b/packages/app/src/nuxt.ts
@@ -84,7 +84,7 @@ export function createNuxt (options: CreateOptions) {
 
 export function applyPlugin (nuxt: Nuxt, plugin: Plugin) {
   if (typeof plugin !== 'function') { return }
-  return callWithNuxt(nuxt, () => plugin(nuxt))
+  return callWithNuxt(nuxt, () => plugin(nuxt, nuxt.provide))
 }
 
 export async function applyPlugins (nuxt: Nuxt, plugins: Plugin[]) {


### PR DESCRIPTION
this may be a deliberate choice but if so, it will make it harder for module authors to create plugins for both 2/3