### PR TITLE
feat(app): add global `$config` helper for runtimeConfig

### DIFF
--- a/packages/app/src/_templates/plugins/client.mjs
+++ b/packages/app/src/_templates/plugins/client.mjs
@@ -1,5 +1,7 @@
+import config from '#app/plugins/config'
 <%= utils.importSources(app.plugins.filter(p => !p.mode || p.mode !== 'server').map(p => p.src)) %>
 
 export default [
+  config,
   <%= app.plugins.filter(p => !p.mode || p.mode !== 'server').map(p => utils.importName(p.src)).join(',\n  ') %>
 ]

--- a/packages/app/src/_templates/plugins/server.mjs
+++ b/packages/app/src/_templates/plugins/server.mjs
@@ -1,8 +1,10 @@
+import config from '#app/plugins/config'
 import preload from '#app/plugins/preload.server'
 
 <%= utils.importSources(app.plugins.filter(p => !p.mode || p.mode !== 'client').map(p => p.src)) %>
 
 export default [
+  config,
   preload,
   <%= app.plugins.filter(p => !p.mode || p.mode !== 'client').map(p => utils.importName(p.src)).join(',\n  ') %>
 ]

--- a/packages/app/src/legacy.ts
+++ b/packages/app/src/legacy.ts
@@ -150,8 +150,8 @@ export const legacyPlugin = (nuxt: Nuxt) => {
       }
 
       if (p === '$config') {
-        // TODO: needs implementation
-        return mock('Accessing runtime config is not yet supported in Nuxt3.')
+        // @ts-ignore
+        return typeof $config !== 'undefined' ? $config : {}
       }
 
       if (p === 'ssrContext') {

--- a/packages/app/src/nuxt.ts
+++ b/packages/app/src/nuxt.ts
@@ -29,6 +29,7 @@ export interface Nuxt {
     renderMeta?: () => Promise<NuxtMeta> | NuxtMeta
   }
   payload: {
+    config: Record<string, any>
     serverRendered?: true
     data?: Record<string, any>
     rendered?: Function

--- a/packages/app/src/plugins/config.ts
+++ b/packages/app/src/plugins/config.ts
@@ -1,0 +1,24 @@
+import { defineNuxtPlugin } from '@nuxt/app'
+
+function freeze (object: Record<string, any>) {
+  const propNames = Object.getOwnPropertyNames(object)
+
+  for (const name of propNames) {
+    const value = object[name]
+
+    if (value && typeof value === 'object') {
+      freeze(value)
+    }
+  }
+
+  return Object.freeze(object)
+}
+
+export default defineNuxtPlugin((nuxt) => {
+  if (process.client) {
+    globalThis.$config = freeze(nuxt.payload.config)
+  } else {
+    // @ts-ignore
+    nuxt.payload.config = $config
+  }
+})

--- a/packages/app/types/shims.d.ts
+++ b/packages/app/types/shims.d.ts
@@ -9,6 +9,7 @@ declare global {
   namespace NodeJS {
     interface Global {
       $fetch: $Fetch
+      $config: Record<string, any>
     }
     interface Process {
       browser: boolean
@@ -33,3 +34,5 @@ declare module 'vue' {
     $nuxt: Nuxt
   }
 }
+
+export { }

--- a/packages/nitro/src/runtime/app/config.ts
+++ b/packages/nitro/src/runtime/app/config.ts
@@ -1,6 +1,20 @@
 import destr from 'destr'
 import defu from 'defu'
 
+function freeze (object: Record<string, any>) {
+  const propNames = Object.getOwnPropertyNames(object)
+
+  for (const name of propNames) {
+    const value = object[name]
+
+    if (value && typeof value === 'object') {
+      freeze(value)
+    }
+  }
+
+  return Object.freeze(object)
+}
+
 // Bundled runtime config
 export const runtimeConfig = process.env.RUNTIME_CONFIG as any
 
@@ -12,5 +26,5 @@ for (const type of ['private', 'public']) {
 }
 
 // Export merged config
-export const config = defu(runtimeConfig.private, runtimeConfig.public)
+export const config = freeze(defu(runtimeConfig.private, runtimeConfig.public))
 export default config

--- a/packages/nitro/src/runtime/server/index.ts
+++ b/packages/nitro/src/runtime/server/index.ts
@@ -1,8 +1,8 @@
-import '../app/config'
 import { createApp, useBase } from 'h3'
 import { createFetch } from 'ohmyfetch'
 import destr from 'destr'
 import { createCall, createFetch as createLocalFetch } from 'unenv/runtime/fetch/index'
+import $config from '../app/config'
 import { timingMiddleware } from './timing'
 import { handleError } from './error'
 // @ts-ignore
@@ -25,3 +25,4 @@ export const localFetch = createLocalFetch(localCall, globalThis.fetch)
 export const $fetch = createFetch({ fetch: localFetch })
 
 globalThis.$fetch = $fetch
+globalThis.$config = $config

--- a/packages/nitro/src/runtime/types.d.ts
+++ b/packages/nitro/src/runtime/types.d.ts
@@ -2,7 +2,6 @@ declare global {
   namespace NodeJS {
     interface Global {
       __timing__: any
-      $config: any
     }
   }
 }

--- a/packages/nitro/types/shims.d.ts
+++ b/packages/nitro/types/shims.d.ts
@@ -7,6 +7,7 @@ declare global {
   namespace NodeJS {
     interface Global {
       $fetch: $Fetch
+      $config: Record<string, any>
     }
   }
 }


### PR DESCRIPTION
**Note**: as we are providing a _global_ helper it should probably not be mutable on the server-side, so for isomorphic purposes this PR freezes both objects. Thoughts welcome. Would likely be simpler to add `req.$config` -> `nuxt.$config` which of course could be mutable, but perhaps that is better addressed via something like `nuxt/session`?

closes nuxt/nuxt.js#10943