### PR TITLE
fix(components): don't ascend directories

### DIFF
--- a/packages/components/src/module.ts
+++ b/packages/components/src/module.ts
@@ -27,15 +27,16 @@ export default defineNuxtModule({
 
         dirOptions.level = Number(dirOptions.level || 0)
 
-        const enabled = isDirectory(dirPath)
-        if (!enabled && dirOptions.path !== '~/components') {
+        const present = isDirectory(dirPath)
+        if (!present && dirOptions.path !== '~/components') {
           // eslint-disable-next-line no-console
           console.warn('Components directory not found: `' + dirPath + '`')
         }
 
         return {
           ...dirOptions,
-          enabled,
+          // TODO: https://github.com/nuxt/framework/pull/251
+          enabled: true,
           path: dirPath,
           extensions,
           pattern: dirOptions.pattern || `**/*.{${extensions.join(',')},}`,


### PR DESCRIPTION
This has two fixes:
* don't ascend to `dirname` if directory doesn't exist (e.g. if `~/components` isn't present, then we likely shouldn't scan in every Vue file in project). However, this [may be intentional](https://github.com/nuxt/framework/commit/36a3d285d8aa72c870f700049406e935c4d730b5) and/or be caused by solving a different issue I'm unaware of - cc @pi0 
* for a component named `page-[id].vue` the following Pascal-cased component name would be generated: `Page[Id]` - which is obviously not wanted, so we can excise these invalid characters from the component.

Happy to split PR if that's better, but just wanted to get this out there.