### PR TITLE
feat: global runtimeConfig access through `#config` import

### DIFF
--- a/packages/app/src/_templates/plugins.mjs
+++ b/packages/app/src/_templates/plugins.mjs
@@ -1,3 +1,4 @@
+import config from '#app/plugins/config.server'
 import head from '#app/plugins/head'
 import preload from '#app/plugins/preload.server'
 
@@ -14,6 +15,7 @@ export const clientPlugins = [
 ]
 
 export const serverPlugins = [
+  config,
   ...commonPlugins,
   preload,
   <%= app.plugins.filter(p => p.mode === 'server').map(p => utils.importName(p.src)).join(',\n  ') %>

--- a/packages/app/src/legacy.ts
+++ b/packages/app/src/legacy.ts
@@ -3,6 +3,8 @@ import type { App } from 'vue'
 import type { Component } from '@vue/runtime-core'
 import mockContext from 'unenv/runtime/mock/proxy'
 import type { Nuxt } from './nuxt'
+// @ts-ignore
+import $config from '#config'
 
 type Route = any
 type Store = any
@@ -150,8 +152,7 @@ export const legacyPlugin = (nuxt: Nuxt) => {
       }
 
       if (p === '$config') {
-        // TODO: needs implementation
-        return mock('Accessing runtime config is not yet supported in Nuxt3.')
+        return $config
       }
 
       if (p === 'ssrContext') {

--- a/packages/app/src/plugins/config.server.ts
+++ b/packages/app/src/plugins/config.server.ts
@@ -1,0 +1,6 @@
+import { defineNuxtPlugin } from '@nuxt/app'
+import $config from '#config'
+
+export default defineNuxtPlugin((nuxt) => {
+  nuxt.payload.config = $config
+})

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -222,9 +222,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
     rollupConfig.plugins.push(externals(defu(nitroContext.externals as any, {
       outDir: nitroContext.output.serverDir,
       moduleDirectories,
-      external: [
-        ...(nitroContext._nuxt.dev ? [nitroContext._nuxt.buildDir] : [])
-      ],
+      external: [],
       inline: [
         '#',
         '~',

--- a/packages/nitro/src/runtime/app/config.ts
+++ b/packages/nitro/src/runtime/app/config.ts
@@ -2,7 +2,7 @@ import destr from 'destr'
 import defu from 'defu'
 
 // Bundled runtime config
-export const runtimeConfig = process.env.RUNTIME_CONFIG as any
+export const runtimeConfig = (typeof window !== 'undefined' ? { public: (window as any).__NUXT__.config } : process.env.RUNTIME_CONFIG as any) || {}
 
 // Allow override from process.env and deserialize
 for (const type of ['private', 'public']) {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -37,7 +37,10 @@ export async function buildServer (ctx: ViteBuildContext) {
           if (!['UNUSED_EXTERNAL_IMPORT'].includes(warning.code)) {
             rollupWarn(warning)
           }
-        }
+        },
+        external: [
+          '#config'
+        ]
       }
     },
     plugins: [

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -35,6 +35,7 @@ export async function bundle (nuxt: Nuxt) {
             ...nuxt.options.alias,
             '#build': nuxt.options.buildDir,
             '#app': nuxt.options.appDir,
+            '#config': require.resolve('@nuxt/nitro/dist/runtime/app/config'),
             '~': nuxt.options.srcDir,
             '@': nuxt.options.srcDir,
             'web-streams-polyfill/ponyfill/es2018': 'unenv/runtime/mock/empty',

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -45,6 +45,7 @@ function serverStandalone (ctx: WebpackConfigContext) {
   ]
 
   if (!Array.isArray(ctx.config.externals)) { return }
+  ctx.config.externals.push('#config')
   ctx.config.externals.push(({ request }, cb) => {
     if (
       request[0] === '.' ||

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -111,6 +111,7 @@ function baseAlias (ctx: WebpackConfigContext) {
   ctx.alias = {
     '#app': options.appDir,
     '#build': options.buildDir,
+    '#config': '@nuxt/nitro/dist/runtime/app/config',
     ...options.alias,
     ...ctx.alias
   }
@@ -237,6 +238,10 @@ function getEnv (ctx: WebpackConfigContext) {
     const isNative = ['boolean', 'number'].includes(typeof value)
     _env['process.env.' + key] = isNative ? value : JSON.stringify(value)
   })
+
+  if (ctx.isClient) {
+    _env['process.env'] = '{}'
+  }
 
   return _env
 }


### PR DESCRIPTION
Alternative approach to https://github.com/nuxt/framework/pull/248 using global import of `#config` instead.

**Key notes**:
* this seems to require `nitroContext._nuxt.buildDir` to be removed nitro externals - but there was clearly a reason this was there - cc @pi0 

closes nuxt/nuxt.js#10943