### PR TITLE
fix(app): do not call handler twice on navigation

### DIFF
--- a/packages/app/src/composables/asyncData.ts
+++ b/packages/app/src/composables/asyncData.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, onBeforeMount, onUnmounted, Ref, ref, unref, UnwrapRef, watch } from 'vue'
+import { getCurrentInstance, onBeforeMount, onUnmounted, Ref, ref, unref, UnwrapRef } from 'vue'
 import { Nuxt, useNuxt } from '@nuxt/app'
 
 import { NuxtComponentPendingPromises } from './component'


### PR DESCRIPTION
This simply removes the client-side watching of the handler function.

**Note**: We could reimplement this with `watchEffect` (see 2d46332c39b36cd02cbc37eb62fcb2327d29a76f) but this is client-side nav only not on first load/hydration, which is confusingly inconsistent. Moving reimplementation of dynamic refetching to https://github.com/nuxt/nuxt.js/issues/11742.

closes nuxt/nuxt.js#11068