### PR TITLE
fix(kit): make `resolvePath` case-sensitive

### DIFF
--- a/packages/kit/src/utils/resolve.ts
+++ b/packages/kit/src/utils/resolve.ts
@@ -54,7 +54,7 @@ function resolvePath (path: string, opts: ResolveOptions = {}) {
     }
     // resolvedPath/index.[ext]
     const resolvedPathwithIndex = join(resolvedPath, 'index' + ext)
-    if (isDirectory && existsSyncSensitive(resolvedPathwithIndex, resolvedPathFiles)) {
+    if (isDirectory && existsSyncSensitive(resolvedPathwithIndex)) {
       return resolvedPathwithIndex
     }
   }
@@ -68,7 +68,7 @@ function resolvePath (path: string, opts: ResolveOptions = {}) {
   throw new Error(`Cannot resolve "${path}" from "${resolvedPath}"`)
 }
 
-export function existsSyncSensitive (path: string, files?: string[]) {
+function existsSyncSensitive (path: string, files?: string[]) {
   if (!existsSync(path)) { return false }
   const _files = files || readdirSync(dirname(path))
   return _files.includes(basename(path))


### PR DESCRIPTION
The issue with `App.vue` reported in the linked issues is MacOS-specific and is caused in the playground by `tryResolvePath` resolving `App.vue` with `app.vue` (as `existsSync` returns true) and thereby generating the following entrypoint:

```js
export { default } from './playground/App.vue'
```

This 'works' as MacOS is case-insensitive but it's not the correct path, hence HMR issue.

resolves nuxt/nuxt.js#10933, resolves nuxt/nuxt.js#10922