### PR TITLE
fix(nitro): generate netlify `_redirects` in dist folder

### DIFF
--- a/packages/nitro/src/presets/netlify.ts
+++ b/packages/nitro/src/presets/netlify.ts
@@ -12,7 +12,7 @@ export const netlify: NitroPreset = extendPreset(lambda, {
   },
   hooks: {
     async 'nitro:compiled' (ctx: NitroContext) {
-      const redirectsPath = join(ctx._nuxt.rootDir, '_redirects')
+      const redirectsPath = join(ctx.output.publicDir, '_redirects')
       let contents = '/* /.netlify/functions/server 200'
       if (existsSync(redirectsPath)) {
         const currentRedirects = await readFile(redirectsPath, 'utf-8')


### PR DESCRIPTION
Netlify pulls in a generated `_redirects` file from the dist directory rather than the project root, so this is needed for zero-config support.