### PR TITLE
fix: vite build

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -66,7 +66,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     let start = Date.now()
     // debounce
     if (start - lastBuild < 300) {
-      await sleep(300 - (start - lastBuild))
+      await sleep(300 - (start - lastBuild) + 1)
       start = Date.now()
       if (start - lastBuild < 300) {
         return


### PR DESCRIPTION
Before this fix, when build with `vite: true`, this error is thrown:

```
 ERROR  Rollup error: Could not resolve './entry' from ./entry?commonjs-external     
```

After a bit of digging, I found out it is because `entry.js` is generate by vite, while the vite build runs after we import the `server.js`.

I still not fully understand what the hooks going on, the current fix work, but might introduce some pref cost (not sure). Let me know if you have a better solution