### PR TITLE
fix(app): use esm syntax for webpack module hot

### DIFF
--- a/packages/app/src/entry.ts
+++ b/packages/app/src/entry.ts
@@ -26,8 +26,9 @@ if (process.server) {
 if (process.client) {
   // TODO: temporary webpack 5 HMR fix
   // https://github.com/webpack-contrib/webpack-hot-middleware/issues/390
-  if (process.dev && module.hot) {
-    module.hot.accept()
+  // @ts-ignore
+  if (process.dev && import.meta.webpackHot) {
+    import.meta.webpackHot.accept()
   }
 
   entry = async function initApp () {


### PR DESCRIPTION
Docs: https://webpack.js.org/api/module-variables/#importmetawebpackhot

We could also add a check for whether `module.hot` exists and use whichever exists but we're moving into a strict esm world so 🤷.

resolves nuxt/nuxt.js#11073 