### PR TITLE
fix(vite): make vite server strict by default

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -62,8 +62,8 @@ export async function bundle (nuxt: Nuxt) {
               nuxt.options.buildDir,
               nuxt.options.appDir,
               nuxt.options.srcDir,
-              '/__webpack_hmr',
-              '/_nuxt'
+              nuxt.options.rootDir,
+              ...nuxt.options.modulesDir
             ]
           }
         },


### PR DESCRIPTION
Vite are going to make this strict by default in next minor version. Opt-in for Nuxt3 to have more secure dev environment.

https://vitejs.dev/config/#server-fs-strict