### PR TITLE
fix(vite): exclude optimising `vue-router`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -49,7 +49,9 @@ export async function bundle (nuxt: Nuxt) {
         vue: {},
         css: {},
         optimizeDeps: {
-          exclude: []
+          exclude: [
+            'vue-router'
+          ]
         },
         esbuild: {
           jsxFactory: 'h',


### PR DESCRIPTION
Workaround.

Issue introduced in nuxt/framework#252. I experienced similar issue with composition API using `nuxt/vite` previously when using `.mjs` extension - perhaps there is an issue with the shared context vue provides and native modules? cc: @antfu 

nuxt/nuxt.js#11048

