### PR TITLE
fix: remove `vue` alias

### DIFF
--- a/packages/nuxt3/src/nuxt.ts
+++ b/packages/nuxt3/src/nuxt.ts
@@ -54,7 +54,6 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   const { appDir } = await import('@nuxt/app/meta')
   options.appDir = appDir
   options._majorVersion = 3
-  options.alias.vue = normalize(require.resolve('vue/dist/vue.esm-bundler.js'))
   options.buildModules.push(normalize(require.resolve('@nuxt/pages/module')))
   options.buildModules.push(normalize(require.resolve('@nuxt/meta/module')))
   options.buildModules.push(normalize(require.resolve('@nuxt/component-discovery/module')))

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -49,9 +49,7 @@ export async function bundle (nuxt: Nuxt) {
         vue: {},
         css: {},
         optimizeDeps: {
-          exclude: [
-            'vue-router'
-          ]
+          exclude: []
         },
         esbuild: {
           jsxFactory: 'h',


### PR DESCRIPTION
resolves nuxt/nuxt.js#11048

Only niggling question is what issue the alias was meant to resolve in the first place - may possibly be unneeded now that we are using native es modules on server? cc: @pi0 