### PR TITLE
fix(app): make `renderMeta` optional

### DIFF
--- a/packages/app/src/nuxt.ts
+++ b/packages/app/src/nuxt.ts
@@ -26,7 +26,7 @@ export interface Nuxt {
   _legacyContext?: LegacyContext
 
   ssrContext?: Record<string, any> & {
-    renderMeta: () => Promise<NuxtMeta> | NuxtMeta
+    renderMeta?: () => Promise<NuxtMeta> | NuxtMeta
   }
   payload: {
     serverRendered?: true

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -82,7 +82,7 @@ async function renderHTML (payload, rendered, ssrContext) {
   const html = rendered.html
 
   if ('renderMeta' in ssrContext) {
-    rendered.meta = await ssrContext.renderMeta()
+    rendered.meta = await ssrContext.renderMeta?.()
   }
 
   const {


### PR DESCRIPTION
to fix issue of default `ssrContext` not having a `renderMeta` function:
https://github.com/nuxt/framework/blob/1bd0b7429953fae3cc86a9183dffdcc913a0767c/packages/app/src/entry.ts#L13-L23