### PR TITLE
feat: hybrid spa mode

### DIFF
--- a/packages/app/src/entry.spa.ts
+++ b/packages/app/src/entry.spa.ts
@@ -1,0 +1,56 @@
+import { createApp, nextTick } from 'vue'
+import { createNuxt, applyPlugins, normalizePlugins } from '@nuxt/app'
+// @ts-ignore
+import _plugins from '#build/plugins'
+// @ts-ignore
+import App from '#build/app'
+
+let entry: Function
+
+const plugins = normalizePlugins(_plugins)
+
+if (process.server) {
+  entry = async function createNuxtAppServer (ssrContext = {}) {
+    const app = createApp({ render: () => null })
+
+    const nuxt = createNuxt({ app, ssrContext })
+
+    await applyPlugins(nuxt, plugins)
+
+    await nuxt.hooks.callHook('app:created', app)
+
+    return app
+  }
+}
+
+if (process.client) {
+  // TODO: temporary webpack 5 HMR fix
+  // https://github.com/webpack-contrib/webpack-hot-middleware/issues/390
+  // @ts-ignore
+  if (process.dev && import.meta.webpackHot) {
+    import.meta.webpackHot.accept()
+  }
+
+  entry = async function initApp () {
+    const app = createApp(App)
+
+    const nuxt = createNuxt({ app })
+
+    await applyPlugins(nuxt, plugins)
+
+    await nuxt.hooks.callHook('app:created', app)
+    await nuxt.hooks.callHook('app:beforeMount', app)
+
+    app.mount('#__nuxt')
+
+    await nuxt.hooks.callHook('app:mounted', app)
+    await nextTick()
+    nuxt.isHydrating = false
+  }
+
+  entry().catch((error) => {
+    console.error('Error while mounting app:', error) // eslint-disable-line no-console
+  })
+}
+
+export default ctx => entry(ctx)

--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -77,7 +77,7 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
     node: undefined,
     preset: undefined,
     rollupConfig: undefined,
-    renderer: undefined,
+    renderer: !nuxtOptions.ssr ? 'vue-none' : undefined,
     serveStatic: undefined,
     middleware: [],
     scannedMiddleware: [],

--- a/packages/nitro/src/runtime/app/vue-none.ts
+++ b/packages/nitro/src/runtime/app/vue-none.ts
@@ -1,0 +1,2 @@
+const emptyTemplate = '<div id="__nuxt"></div>'
+export const renderToString = () => emptyTemplate

--- a/packages/pages/src/module.ts
+++ b/packages/pages/src/module.ts
@@ -22,7 +22,7 @@ export default defineNuxtModule({
       if (!existsSync(pagesDir)) {
         return
       }
-      app.plugins.push({ src: routerPlugin })
+      app.plugins.push({ src: routerPlugin, mode: nuxt.options.ssr ? 'all' : 'client' })
       if (app.main.includes('app.tutorial')) {
         app.main = resolve(runtimeDir, 'app.vue')
       }

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -60,11 +60,6 @@ export async function buildServer (ctx: ViteBuildContext) {
 
   const onBuild = () => ctx.nuxt.callHook('build:resources', wpfs)
 
-  if (!ctx.nuxt.options.ssr) {
-    await onBuild()
-    return
-  }
-
   let lastBuild = 0
   const build = async () => {
     let start = Date.now()

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -20,6 +20,7 @@ export interface ViteBuildContext {
 }
 
 export async function bundle (nuxt: Nuxt) {
+  const entry = nuxt.options.ssr ? 'entry' : 'entry.spa'
   const ctx: ViteBuildContext = {
     nuxt,
     config: vite.mergeConfig(
@@ -37,6 +38,7 @@ export async function bundle (nuxt: Nuxt) {
             ...nuxt.options.alias,
             '#app': nuxt.options.appDir,
             '#build': nuxt.options.buildDir,
+            '/__app/entry': resolve(nuxt.options.appDir, entry),
             '/__app': nuxt.options.appDir,
             '/__build': nuxt.options.buildDir,
             '~': nuxt.options.srcDir,
@@ -59,7 +61,7 @@ export async function bundle (nuxt: Nuxt) {
         build: {
           emptyOutDir: false,
           rollupOptions: {
-            input: resolve(nuxt.options.appDir, 'entry')
+            input: resolve(nuxt.options.appDir, entry)
           }
         },
         plugins: [

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -21,9 +21,11 @@ export function base (ctx: WebpackConfigContext) {
 function baseConfig (ctx: WebpackConfigContext) {
   const { options } = ctx
 
+  const entry = options.ssr ? 'entry' : 'entry.spa'
+
   ctx.config = {
     name: ctx.name,
-    entry: { app: [resolve(options.appDir, 'entry')] },
+    entry: { app: [resolve(options.appDir, entry)] },
     module: { rules: [] },
     plugins: [],
     externals: [],


### PR DESCRIPTION
> 'hybrid spa' concept for nuxt3 which basically just uses an empty `App.vue`; the client app then just mounts to the empty `__nuxt` div. There is still a server build that just serves this empty app.

**Potential benefits for this approach**
* simplifies maintenance - we don't have another rendering engine to construct
* users could still interact with their metadata in server-only plugins for better seo support
* paired with 'generate' mode (not yet implemented) we have fully static spa-mode

**Downsides**
* potentially less performant

**PR created for discussion**. Future tasks if we adopt this approach would be:
- [ ] nitro compat implementation
- [ ] tree-shaking plugins, which I think is necessary to solve anyway: nuxt/nuxt.js#11773
- [ ] loading screens