### PR TITLE
fix(app): finish hydration when the page is loaded

### DIFF
--- a/packages/app/src/entry.ts
+++ b/packages/app/src/entry.ts
@@ -42,13 +42,14 @@ if (process.client) {
     await nuxt.hooks.callHook('app:created', app)
     await nuxt.hooks.callHook('app:beforeMount', app)
 
+    nuxt.hooks.hookOnce('page:finished', () => {
+      nuxt.isHydrating = false
+    })
+
     app.mount('#__nuxt')
 
     await nuxt.hooks.callHook('app:mounted', app)
     await nextTick()
-    nuxt.hooks.hookOnce('page:finished', () => {
-      nuxt.isHydrating = false
-    })
   }
 
   entry().catch((error) => {


### PR DESCRIPTION
Note that this currently requires the user to use `NuxtPage` or implement `nuxt.isHydrating = false` themselves.

resolves nuxt/nuxt.js#11053