### PR TITLE
fix(vite): prod build hang, close #336

### DIFF
--- a/packages/nuxt3/src/builder.ts
+++ b/packages/nuxt3/src/builder.ts
@@ -22,7 +22,10 @@ export async function build (nuxt: Nuxt) {
 
   await bundle(nuxt)
   await nuxt.callHook('build:done', { nuxt })
-  await nuxt.callHook('close', nuxt)
+
+  if (!nuxt.options.dev) {
+    await nuxt.callHook('close', nuxt)
+  }
 }
 
 function watch (nuxt: Nuxt) {


### PR DESCRIPTION
Vite build hooked `close` event for server to exit, which in our build, does not invoked properly

https://github.com/nuxt/framework/blob/be255772b26cb78398af020a1dbb5d367425218f/packages/vite/src/client.ts#L61-L61