### PR TITLE
fix(nuxt3): re-resolve app entrypoint when `app.vue` is moved/deleted

### DIFF
--- a/packages/nuxt3/src/builder.ts
+++ b/packages/nuxt3/src/builder.ts
@@ -14,6 +14,9 @@ export async function build (nuxt: Nuxt) {
     watch(nuxt)
     nuxt.hook('builder:watch', async (event, path) => {
       if (event !== 'change' && /app|plugins/i.test(path)) {
+        if (path.match(/app/i)) {
+          app.main = null
+        }
         await generateApp(nuxt, app)
       }
     })


### PR DESCRIPTION
resolves nuxt/nuxt.js#11070