### PR TITLE
fix(vite): add transpile options to `noExternal` list

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -23,6 +23,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         'axios'
       ],
       noExternal: [
+        ...ctx.nuxt.options.build.transpile.filter(i => typeof i === 'string'),
         '@nuxt/app'
       ]
     },


### PR DESCRIPTION
closes nuxt/nuxt.js#11052