### PR TITLE
fix(nitro): generate correct Netlify entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Temporary Items
 .vercel_build_output
 .build-*
 .env
+.netlify

--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -9,6 +9,7 @@ import type { NodeExternalsOptions } from './rollup/plugins/externals'
 import type { StorageOptions } from './rollup/plugins/storage'
 import type { AssetOptions } from './rollup/plugins/assets'
 import type { ServerMiddleware } from './server/middleware'
+import type { RollupConfig } from './rollup/config'
 
 export interface NitroContext {
   timing: boolean
@@ -20,7 +21,7 @@ export interface NitroContext {
   entry: string
   node: boolean
   preset: string
-  rollupConfig?: any
+  rollupConfig?: RollupConfig
   renderer: string
   serveStatic: boolean
   middleware: ServerMiddleware[]

--- a/packages/nitro/src/presets/netlify.ts
+++ b/packages/nitro/src/presets/netlify.ts
@@ -7,7 +7,7 @@ import { lambda } from './lambda'
 
 export const netlify: NitroPreset = extendPreset(lambda, {
   output: {
-    dir: '{{ _nuxt.rootDir }}/netlify/functions',
+    dir: '{{ _nuxt.rootDir }}/.netlify/functions-internal',
     publicDir: '{{ _nuxt.rootDir }}/dist'
   },
   hooks: {
@@ -24,6 +24,9 @@ export const netlify: NitroPreset = extendPreset(lambda, {
         contents = currentRedirects + '\n' + contents
       }
       await writeFile(redirectsPath, contents)
+    },
+    'nitro:rollup:before' (ctx: NitroContext) {
+      ctx.rollupConfig.output.entryFileNames = 'server.ts'
     }
   },
   ignore: [

--- a/packages/nitro/src/runtime/entries/netlify_builder.ts
+++ b/packages/nitro/src/runtime/entries/netlify_builder.ts
@@ -1,6 +1,5 @@
-// @ts-ignore
-import { builderFunction } from '@netlify/functions'
+import { builder } from '@netlify/functions'
 // @ts-ignore
 import { handler as _handler } from '#nitro/entries/lambda'
 
-export const handler = builderFunction(_handler)
+export const handler = builder(_handler)


### PR DESCRIPTION
The Netlify functions bundler expects an entrypoint to be found at `functionname/functionname.js` or `functionname/functionname.ts`. Currently the generated entrypoint is `server/index.mjs`. This PR adds an additional file `server.ts` that re-exports `handler` from `index.mjs`, enabling the bundler to find the function. It generates a TypeScript file because that forces the bundler to use `esbuild`, which is required for ESM support. The bundler should soon support `.mjs` entrypoints, at which point we can change this to generate a `server.mjs` file instead.

The reason I generated an additional file is because I wasn't able to work out how to work out how to make unbuild generate a different filename. Setting `rollupConfig.output.entryFileNames` in the preset didn't seem to have any effect.