### PR TITLE
feat(nitro): allow presets to specify output entrypoint

### DIFF
--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -34,6 +34,7 @@ export interface NitroContext {
     dir: string
     serverDir: string
     publicDir: string
+    entry: string
   }
   storage: StorageOptions,
   assets: AssetOptions,
@@ -90,7 +91,8 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
     output: {
       dir: '{{ _nuxt.rootDir }}/.output',
       serverDir: '{{ output.dir }}/server',
-      publicDir: '{{ output.dir }}/public'
+      publicDir: '{{ output.dir }}/public',
+      entry: 'index.mjs'
     },
     storage: { mounts: { } },
     assets: {

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -70,7 +70,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
     input: resolvePath(nitroContext, nitroContext.entry),
     output: {
       dir: nitroContext.output.serverDir,
-      entryFileNames: 'index.mjs',
+      entryFileNames: nitroContext.output.entry,
       chunkFileNames (chunkInfo) {
         let prefix = ''
         const modules = Object.keys(chunkInfo.modules)


### PR DESCRIPTION
Allow presets to specify the generated entrypoint filename. See #372