### PR TITLE
fix(nitro): disable `moduleSideEffects` by default

### DIFF
--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -22,6 +22,7 @@ export interface NitroContext {
   node: boolean
   preset: string
   rollupConfig?: RollupConfig
+  moduleSideEffects: string[]
   renderer: string
   serveStatic: boolean
   middleware: ServerMiddleware[]
@@ -79,6 +80,7 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
     node: undefined,
     preset: undefined,
     rollupConfig: undefined,
+    moduleSideEffects: ['unenv/runtime/polyfill/'],
     renderer: undefined,
     serveStatic: undefined,
     middleware: [],

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -114,6 +114,11 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
       ) {
         rollupWarn(warning)
       }
+    },
+    treeshake: {
+      moduleSideEffects (id) {
+        return nitroContext.moduleSideEffects.some(match => id.startsWith(match))
+      }
     }
   }
 


### PR DESCRIPTION
Disable `moduleSideEffects` except if set in `context.moduleSideEffects`. By default, this array contains `unenv/runtime/polyfill`. Entries are matched as prefixes.

Fixes nuxt/nuxt.js#11030