### PR TITLE
fix(nitro): import externals as esm namespace

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -274,7 +274,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // https://github.com/rollup/plugins/tree/master/packages/commonjs
   rollupConfig.plugins.push(commonjs({
-    esmExternals: true,
+    esmExternals: id => !id.startsWith('unenv/'),
     requireReturnsDefault: 'auto'
   }))
 


### PR DESCRIPTION
introduced in https://github.com/nuxt/framework/pull/252

```diff
- import { c as commonjsGlobal, g as getDefaultExportFromCjs } from '../_commonjsHelpers.mjs'
- import require$$2 from 'ufo'
- import require$$6 from 'node-fetch'
- import require$$0 from 'deepmerge'
+ import { c as commonjsGlobal, g as getDefaultExportFromNamespaceIfNotNamed, a as getDefaultExportFromCjs } from '../_commonjsHelpers.mjs'
+ import * as ufo from 'ufo'
+ import * as nodeFetch from 'node-fetch'
+ import * as deepmerge$1 from 'deepmerge'
```

**Notes**:
- not yet sure why treating `unenv` as an esm external causes side-effect-laden imports 🤔 

resolves nuxt/bridge#114 
