### PR TITLE
fix(nitro): detect `NETLIFY_LOCAL`

### DIFF
--- a/packages/nitro/src/utils/index.ts
+++ b/packages/nitro/src/utils/index.ts
@@ -67,7 +67,7 @@ export function resolvePath (nitroContext: NitroInput, path: string | ((nitroCon
 }
 
 export function detectTarget () {
-  if (process.env.NETLIFY) {
+  if (process.env.NETLIFY || process.env.NETLIFY_LOCAL) {
     return 'netlify'
   }
 


### PR DESCRIPTION
Currently Netlify deploys are detected by looking for the `NETLIFY` env var. This means that if a user deploys to Netlify from the `netlify` cli it is not recognized and the preset is not enabled. This PR adds a check for `NETLIFY_LOCAL`, which is now set when building via the Netlify CLI.