### PR TITLE
fix(webpack): enable minimize for client production bundles

### DIFF
--- a/packages/kit/src/config/schema/build.ts
+++ b/packages/kit/src/config/schema/build.ts
@@ -291,7 +291,7 @@ export default {
   optimization: {
     runtimeChunk: 'single',
     /** Set minimize to false to disable all minimizers. (It is disabled in development by default) */
-    minimize: { $resolve: (val, get) => val ?? get('dev') },
+    minimize: { $resolve: (val, get) => val ?? !get('dev') },
     /** You can set minimizer to a customized array of plugins. */
     minimizer: undefined,
     splitChunks: {

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -71,14 +71,7 @@ function clientHMR (ctx: WebpackConfigContext) {
   config.plugins.push(new webpack.HotModuleReplacementPlugin())
 }
 
-function clientOptimization (ctx: WebpackConfigContext) {
-  const { options, config } = ctx
-
-  config.optimization = {
-    ...config.optimization,
-    ...options.build.optimization as any
-  }
-
+function clientOptimization (_ctx: WebpackConfigContext) {
   // TODO: Improve optimization.splitChunks.cacheGroups
 }
 


### PR DESCRIPTION
This pr is re-enabling `minimize` for client production bundles:

- Correct `optimization.minimize` default value: true -> prod, false -> dev
- Remove unnecessary `options.build.optimization` destructuring as the default config already in [baseConfig](https://github.com/nuxt/framework/blob/f980ef235f5184b36db69bb8b571563727b929d9/packages/webpack/src/presets/base.ts#L30-L33) and destructuring in clientOptimization will override esbuild or babel config 