### PR TITLE
fix(cli): don't let changes within `buildDir` trigger nuxt reload

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -63,7 +63,7 @@ export default defineNuxtCommand({
       if (file.includes(currentNuxt.options.buildDir)) {
         return
       }
-      if (['nuxt.config', 'modules', 'pages'].some(pattern => file.includes(pattern))) {
+      if (file.includes('nuxt.config') || file.includes('modules') || file.includes('pages')) {
         dLoad(true)
       }
     })


### PR DESCRIPTION
Issue was that _built_ files were triggering nuxt reload, leading to vicious cycle.

Seems particularly triggered wepback given that it output files like `/framework/playground/.nuxt/dist/server/playground_pages_index_vue.cjs` which matched 'pages'.

resolves nuxt/nuxt.js#11737