### PR TITLE
fix(nitro): fix EBUSY error on windows

### DIFF
--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -88,7 +88,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
           await copyFile(src, dst)
         }
         if (process.platform === 'win32') {
-          // https://github.com/nuxt/framework/issues/424
+          // Workaround for EBUSY on windows (#424)
           for (const file of tracedFiles) {
             await writeFile(file)
           }


### PR DESCRIPTION
Closes nuxt/nuxt.js#11825 by writing externals files (`.output/server/node_modules/*`) sequentially in windows.

Alternatively, we can use read+write instead of copy operation. Current PR is a _workaround_