### PR TITLE
feat(kit): redirect common libs

### DIFF
--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -15,6 +15,9 @@ export * from './module/utils'
 export * from './utils/cjs'
 export * from './utils/resolve'
 
+// Lib redirection
+export * from './lib'
+
 // Types
 export * from './types/config'
 export * from './types/hooks'

--- a/packages/kit/src/lib.ts
+++ b/packages/kit/src/lib.ts
@@ -1,0 +1,10 @@
+// redirecting commonly used libraries so modules author
+// can use them without resintalling them
+
+import consola from 'consola'
+import defu from 'defu'
+
+export {
+  consola,
+  defu
+}


### PR DESCRIPTION
Just a random idea, no pressure on closing.

Thinking that probably all modules need to use `consola` to print out messages that fit with Nuxt's style, since we are already include many this "common libs" in the kit, why not just exposing them so the module authors could reuse them directly without reinstall them again. This also reduce the potential package duplicating due to different versions ranges.

This PR only redirects `consola` and `defu` as I have see them multiple times - not familiar with other packages so I'll leave them untouched for now.