### PR TITLE
fix: components template path

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -67,7 +67,7 @@ export default defineNuxtModule({
 
       app.templates.push({
         filename: 'components.mjs',
-        src: resolve(distDir, 'pages/runtime/components.tmpl.mjs'),
+        src: resolve(distDir, 'components/runtime/components.tmpl.mjs'),
         options: { components }
       })
 


### PR DESCRIPTION
I latest release of Nuxt 3 components auto-load does not work, and raise `Error: Template not found` error.