### PR TITLE
refactor(nuxt3): rename runtime `nuxt` to `nuxtApp` equivalents

### DIFF
--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -3,9 +3,9 @@ import type { UnwrapRef, Ref } from 'vue'
 
 import { NuxtComponentPendingPromises } from './component'
 import { ensureReactive, useGlobalData } from './data'
-import { Nuxt, useNuxt } from '#app'
+import { NuxtApp, useNuxtApp } from '#app'
 
-export type AsyncDataFn<T> = (ctx?: Nuxt) => Promise<T>
+export type AsyncDataFn<T> = (ctx?: NuxtApp) => Promise<T>
 
 export interface AsyncDataOptions {
   server?: boolean
@@ -22,7 +22,7 @@ export interface AsyncDataState<T> {
 export type AsyncDataResult<T> = AsyncDataState<T> & Promise<AsyncDataState<T>>
 
 export function useAsyncData (defaults?: AsyncDataOptions) {
-  const nuxt = useNuxt()
+  const nuxt = useNuxtApp()
   const vm = getCurrentInstance()
   const onBeforeMountCbs: Array<() => void> = []
 

--- a/packages/nuxt3/src/app/composables/component.ts
+++ b/packages/nuxt3/src/app/composables/component.ts
@@ -3,7 +3,7 @@ import { defineComponent, getCurrentInstance } from 'vue'
 import type { ComponentInternalInstance, DefineComponent } from 'vue'
 import { useRoute } from 'vue-router'
 import type { LegacyContext } from '../legacy'
-import { useNuxt } from '../nuxt'
+import { useNuxtApp } from '../nuxt'
 import { asyncData } from './asyncData'
 
 export const NuxtComponentIndicator = '__nuxt_component'
@@ -29,7 +29,7 @@ export function enqueueNuxtComponent (p: Promise<void>) {
 }
 
 async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<string, any>>, fn: (context: LegacyContext) => Promise<Record<string, any>>) {
-  const nuxt = useNuxt()
+  const nuxt = useNuxtApp()
   const route = useRoute()
   const vm = getCurrentNuxtComponentInstance()
   const { fetchKey } = vm.proxy.$options

--- a/packages/nuxt3/src/app/composables/data.ts
+++ b/packages/nuxt3/src/app/composables/data.ts
@@ -1,6 +1,6 @@
 import { getCurrentInstance, isReactive, reactive } from 'vue'
 import type { UnwrapRef } from 'vue'
-import { useNuxt } from '#app'
+import { useNuxtApp } from '#app'
 
 export function ensureReactive<
   T extends Record<string, any>,
@@ -18,7 +18,7 @@ export function ensureReactive<
  * @param nuxt (optional) A Nuxt instance
  * @param vm (optional) A Vue component - by default it will use the current instance
  */
-export function useSSRRef (nuxt = useNuxt(), vm = getCurrentInstance()): string {
+export function useSSRRef (nuxt = useNuxtApp(), vm = getCurrentInstance()): string {
   if (!vm) {
     throw new Error('This must be called within a setup function.')
   }
@@ -44,7 +44,7 @@ export function useSSRRef (nuxt = useNuxt(), vm = getCurrentInstance()): string 
  * @param vm (optional) A Vue component - by default it will use the current instance
  */
 export function useData<T = Record<string, any>> (
-  nuxt = useNuxt(),
+  nuxt = useNuxtApp(),
   vm = getCurrentInstance()
 ): UnwrapRef<T> {
   const ssrRef = useSSRRef(nuxt, vm)
@@ -59,7 +59,7 @@ export function useData<T = Record<string, any>> (
  *
  * @param nuxt - (optional) A Nuxt instance
  */
-export function useGlobalData (nuxt = useNuxt()): Record<string, any> {
+export function useGlobalData (nuxt = useNuxtApp()): Record<string, any> {
   nuxt.payload.data = nuxt.payload.data || {}
   return nuxt.payload.data
 }

--- a/packages/nuxt3/src/app/composables/hydrate.ts
+++ b/packages/nuxt3/src/app/composables/hydrate.ts
@@ -1,4 +1,4 @@
-import { useNuxt } from '#app'
+import { useNuxtApp } from '#app'
 
 /**
  * Allows full control of the hydration cycle to set and receive data from the server.
@@ -7,8 +7,8 @@ import { useNuxt } from '#app'
  * @param get a function that returns the value to set the initial data
  * @param set a function that will receive the data on the client-side
  */
-export const useHydration = <T>(key: string, get: () => T, set: (value: T) => void) => {
-  const nuxt = useNuxt()
+export const useHydration = <T> (key: string, get: () => T, set: (value: T) => void) => {
+  const nuxt = useNuxtApp()
 
   if (process.server) {
     nuxt.hooks.hook('app:rendered', () => {

--- a/packages/nuxt3/src/app/legacy.ts
+++ b/packages/nuxt3/src/app/legacy.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import type { App } from 'vue'
 import type { Component } from '@vue/runtime-core'
 import mockContext from 'unenv/runtime/mock/proxy'
-import type { Nuxt } from './nuxt'
+import type { NuxtApp } from './nuxt'
 
 type Route = any
 type Store = any
@@ -123,7 +123,7 @@ const todo = new Set<keyof LegacyContext | keyof LegacyContext['ssrContext']>([
 
 const routerKeys: Array<keyof LegacyContext | keyof LegacyContext['ssrContext']> = ['route', 'params', 'query']
 
-export const legacyPlugin = (nuxt: Nuxt) => {
+export const legacyPlugin = (nuxt: NuxtApp) => {
   nuxt._legacyContext = new Proxy(nuxt, {
     get (nuxt, p: keyof LegacyContext | keyof LegacyContext['ssrContext']) {
       // Unsupported keys

--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -23,13 +23,13 @@ export interface RuntimeNuxtHooks {
   'page:finish': (Component?: VNode) => HookResult
 }
 
-export interface Nuxt {
+export interface NuxtApp {
   app: App
   globalName: string
 
   hooks: Hookable<RuntimeNuxtHooks>
-  hook: Nuxt['hooks']['hook']
-  callHook: Nuxt['hooks']['callHook']
+  hook: NuxtApp['hooks']['hook']
+  callHook: NuxtApp['hooks']['callHook']
 
   [key: string]: any
 
@@ -51,28 +51,28 @@ export interface Nuxt {
 
 export const NuxtPluginIndicator = '__nuxt_plugin'
 export interface Plugin {
-  (nuxt: Nuxt): Promise<void> | void
+  (nuxt: NuxtApp): Promise<void> | void
   [NuxtPluginIndicator]?: true
 }
 export interface LegacyPlugin {
-  (context: LegacyContext, provide: Nuxt['provide']): Promise<void> | void
+  (context: LegacyContext, provide: NuxtApp['provide']): Promise<void> | void
 }
 
 export interface CreateOptions {
-  app: Nuxt['app']
-  ssrContext?: Nuxt['ssrContext']
-  globalName?: Nuxt['globalName']
+  app: NuxtApp['app']
+  ssrContext?: NuxtApp['ssrContext']
+  globalName?: NuxtApp['globalName']
 }
 
 export function createNuxt (options: CreateOptions) {
-  const nuxt: Nuxt = {
+  const nuxt: NuxtApp = {
     provide: undefined,
     globalName: 'nuxt',
     state: {},
     payload: {},
     isHydrating: process.client,
     ...options
-  } as any as Nuxt
+  } as any as NuxtApp
 
   nuxt.hooks = createHooks<RuntimeNuxtHooks>()
   nuxt.hook = nuxt.hooks.hook
@@ -111,12 +111,12 @@ export function createNuxt (options: CreateOptions) {
   return nuxt
 }
 
-export function applyPlugin (nuxt: Nuxt, plugin: Plugin) {
+export function applyPlugin (nuxt: NuxtApp, plugin: Plugin) {
   if (typeof plugin !== 'function') { return }
   return callWithNuxt(nuxt, () => plugin(nuxt))
 }
 
-export async function applyPlugins (nuxt: Nuxt, plugins: Plugin[]) {
+export async function applyPlugins (nuxt: NuxtApp, plugins: Plugin[]) {
   for (const plugin of plugins) {
     await applyPlugin(nuxt, plugin)
   }
@@ -128,7 +128,7 @@ export function normalizePlugins (_plugins: Array<Plugin | LegacyPlugin>) {
   const plugins = _plugins.map((plugin) => {
     if (isLegacyPlugin(plugin)) {
       needsLegacyContext = true
-      return (nuxt: Nuxt) => plugin(nuxt._legacyContext!, nuxt.provide)
+      return (nuxt: NuxtApp) => plugin(nuxt._legacyContext!, nuxt.provide)
     }
     return plugin
   })
@@ -149,9 +149,9 @@ export function isLegacyPlugin (plugin: unknown): plugin is LegacyPlugin {
   return !plugin[NuxtPluginIndicator]
 }
 
-let currentNuxtInstance: Nuxt | null
+let currentNuxtInstance: NuxtApp | null
 
-export const setNuxtInstance = (nuxt: Nuxt | null) => {
+export const setNuxtInstance = (nuxt: NuxtApp | null) => {
   currentNuxtInstance = nuxt
 }
 
@@ -161,7 +161,7 @@ export const setNuxtInstance = (nuxt: Nuxt | null) => {
  * @param nuxt A Nuxt instance
  * @param setup The function to call
  */
-export async function callWithNuxt (nuxt: Nuxt, setup: () => any) {
+export async function callWithNuxt (nuxt: NuxtApp, setup: () => any) {
   setNuxtInstance(nuxt)
   const p = setup()
   setNuxtInstance(null)
@@ -171,7 +171,7 @@ export async function callWithNuxt (nuxt: Nuxt, setup: () => any) {
 /**
  * Returns the current Nuxt instance.
  */
-export function useNuxt (): Nuxt {
+export function useNuxtApp (): NuxtApp {
   const vm = getCurrentInstance()
 
   if (!vm) {

--- a/packages/nuxt3/src/meta/runtime/composables.ts
+++ b/packages/nuxt3/src/meta/runtime/composables.ts
@@ -2,7 +2,7 @@ import { isFunction } from '@vue/shared'
 import { computed } from '@vue/reactivity'
 import type { ComputedGetter } from '@vue/reactivity'
 import type { MetaObject } from '../types'
-import { useNuxt } from '#app'
+import { useNuxtApp } from '#app'
 
 /**
  * You can pass in a meta object, which has keys corresponding to meta tags:
@@ -13,5 +13,5 @@ import { useNuxt } from '#app'
  */
 export function useMeta (meta: MetaObject | ComputedGetter<MetaObject>) {
   const resolvedMeta = isFunction(meta) ? computed(meta) : meta
-  useNuxt()._useMeta(resolvedMeta)
+  useNuxtApp()._useMeta(resolvedMeta)
 }


### PR DESCRIPTION
relates to nuxt/nuxt.js#11454, as a first step