### PR TITLE
fix: rename `useNuxt` in global-imports to `useNuxtApp` 

### DIFF
--- a/packages/nuxt3/src/global-imports/identifiers.ts
+++ b/packages/nuxt3/src/global-imports/identifiers.ts
@@ -3,7 +3,7 @@ const identifiers = {
     'useAsyncData',
     'asyncData',
     'defineNuxtComponent',
-    'useNuxt',
+    'useNuxtApp',
     'defineNuxtPlugin'
   ],
   '#meta': [


### PR DESCRIPTION
Update global imports identifiers and rename `useNuxt` to `useNuxtApp` #460