### PR TITLE
fix(compat): only move `server.js` if it has been regenerated

### DIFF
--- a/packages/nitro/src/compat.ts
+++ b/packages/nitro/src/compat.ts
@@ -91,7 +91,9 @@ export default function nuxt2CompatModule (this: ModuleContainer) {
     if (name === 'server') {
       const jsServerEntry = resolve(nuxt.options.buildDir, 'dist/server/server.js')
       if (await pathExists(jsServerEntry)) {
-        await move(jsServerEntry, jsServerEntry.replace(/.js$/, '.cjs'))
+        await move(jsServerEntry, jsServerEntry.replace(/.js$/, '.cjs'), {
+          overwrite: true
+        })
         await writeFile(jsServerEntry.replace(/.js$/, '.mjs'), 'export { default } from "./server.cjs"', 'utf8')
       }
     } else if (name === 'client') {


### PR DESCRIPTION
In some situations Nuxt Does not regenerate `server.js` and it cause file not found exception. 
This PR ensures `server.js` existence before moving it to `server.cjs`

<img width="1112" alt="Screen Shot 2021-08-31 at 5 41 11 PM" src="https://user-images.githubusercontent.com/2047945/131508398-5915a2d1-c923-4db7-8630-90c457e472f9.png">
