### PR TITLE
fix(nitro): use file url for `#build` alias in windows dev

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -211,7 +211,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
       '#nitro-renderer': normalize(require.resolve(resolve(nitroContext._internal.runtimeDir, 'app', renderer))),
       '#config': normalize(require.resolve(resolve(nitroContext._internal.runtimeDir, 'app/config'))),
       '#nitro-vue-renderer': vue2ServerRenderer,
-      // Only file and data URLs are supported by the default ESM loader on Windows
+      // Only file and data URLs are supported by the default ESM loader on Windows (#427)
       '#build': nitroContext._nuxt.dev && process.platform === 'win32'
         ? pathToFileURL(nitroContext._nuxt.buildDir).href
         : nitroContext._nuxt.buildDir,


### PR DESCRIPTION
This is raised as an issue when `worker_threads` imports the nitro entry in dev.
https://github.com/nuxt/framework/blob/858e31c7fce0167042e9ca2ca181dddf35878a90/packages/nitro/src/server/dev.ts#L33-L34

As far as I can tell the only absolute file imports in the dev entry file should be from `#build` (`#server-middleware` gets inlined).

resolves nuxt/nuxt.js#11752