### PR TITLE
fix(nitro): emit chunk names without `#`

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -88,6 +88,9 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
         } else if (lastModule.includes('assets')) {
           prefix = 'assets'
         }
+        if (chunkInfo.name.includes('#')) {
+          return join('chunks', prefix, chunkInfo.name.replace(/#/g, '-') + '.mjs')
+        }
         return join('chunks', prefix, '[name].mjs')
       },
       inlineDynamicImports: nitroContext.inlineDynamicImports,


### PR DESCRIPTION
resolves nuxt/nuxt.js#11787