### PR TITLE
fix(bridge): handle `ssr: false`

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -66,8 +66,10 @@ export function setupNitroBridge () {
   // Set up webpack plugin for node async loading
   nuxt.hook('webpack:config', (webpackConfigs) => {
     const serverConfig = webpackConfigs.find(config => config.name === 'server')
-    serverConfig.plugins = serverConfig.plugins || []
-    serverConfig.plugins.push(new AsyncLoadingPlugin())
+    if (serverConfig) {
+      serverConfig.plugins = serverConfig.plugins || []
+      serverConfig.plugins.push(new AsyncLoadingPlugin())
+    }
   })
 
   // Nitro client plugin


### PR DESCRIPTION
Add guard to handle missing server config

When use `ssr: false` in `nuxt.config`, Bridge raise undefined error in webpack config. Can be reproduces in https://github.com/docusgen/mdc/tree/feat/shiki