### PR TITLE
fix(nitro): export named function rather than default export

### DIFF
--- a/packages/nitro/src/runtime/entries/azure_functions.ts
+++ b/packages/nitro/src/runtime/entries/azure_functions.ts
@@ -1,7 +1,7 @@
 import '#polyfill'
 import { localCall } from '../server'
 
-export default async function handle (context, req) {
+export async function handle (context, req) {
   const url = '/' + (req.params.url || '')
 
   const { body, status, statusText, headers } = await localCall({


### PR DESCRIPTION
Previously this was failing with test:
```
yarn nu build playground
cd playground/.output && func start
```
... because `handle` was being minified to `h`