### PR TITLE
chore(nitro): avoid optional chaining in nitro render fn

### DIFF
--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -110,7 +110,7 @@ async function renderHTML (payload, rendered, ssrContext) {
   const html = rendered.html
 
   if ('renderMeta' in ssrContext) {
-    rendered.meta = await ssrContext.renderMeta?.()
+    rendered.meta = await ssrContext.renderMeta()
   }
 
   const {


### PR DESCRIPTION
unneeded check