### PR TITLE
fix(kit): ensure nuxt context is always set to current nuxt

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -38,8 +38,8 @@ export function defineNuxtModule<OptionsT extends ModuleOptions> (input: NuxtMod
     const resolvedOptions = applyDefaults(mod.defaults as any, userOptions) as OptionsT
 
     // Ensure nuxt instance exists (nuxt2 compatibility)
-    if (!nuxtCtx.use()) {
-      nuxtCtx.set(nuxt)
+    if (nuxt.options._majorVersion !== 3 || !nuxtCtx.use()) {
+      nuxtCtx.set(nuxt, true)
       // @ts-ignore
       if (!nuxt.__nuxtkit_close__) {
         nuxt.hook('close', () => nuxtCtx.unset())


### PR DESCRIPTION
Currently there are _two_ nuxt contexts but only one require cache in the case of a full static generation that _skips_ webpack build. This means that a module (like nitro) only changes nuxt settings or adds hooks on the first nuxt instance, not the second. We were unaware of this as an issue for `@nuxt/kit` (via `unctx`) until the bridge PR migrated nitro to a kit module (https://github.com/nuxt/framework/pull/459).

Might be worth considering merging https://github.com/nuxt/nuxt.js/pull/8460 for nuxt 2.16+.

But we likely also need this PR (for older versions of nuxt) which ensures that the context is always set to the _current_ version of nuxt.

resolves nuxt/bridge#111
