### PR TITLE
fix(bridge): disable `nuxt-swc` by default

### DIFF
--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -11,7 +11,7 @@ export default defineNuxtModule({
     app: true,
     // TODO: Remove from 2.16
     postcss8: true,
-    swc: true
+    swc: false
   },
   async setup (opts, nuxt) {
     if (opts.nitro) {


### PR DESCRIPTION
this is a hotfix to prevent nitro installs from failing - we will need to fix within `nuxt-swc` itself

resolves nuxt/bridge#110