### PR TITLE
fix(service-worker): handle static assets and api routes with edge re…

### DIFF
--- a/packages/nitro/src/runtime/entries/service-worker.ts
+++ b/packages/nitro/src/runtime/entries/service-worker.ts
@@ -2,10 +2,12 @@
 import '#polyfill'
 import { localCall } from '../server'
 
+const STATIC_ASSETS_BASE = process.env.NUXT_STATIC_BASE + '/' + process.env.NUXT_STATIC_VERSION
+
 addEventListener('fetch', (event: any) => {
   const url = new URL(event.request.url)
 
-  if (url.pathname.includes('.') /* is file */) {
+  if (url.pathname.includes('.') && !url.pathname.startsWith(STATIC_ASSETS_BASE) && !url.pathname.startsWith('/api')) {
     return
   }
 


### PR DESCRIPTION
On service worker entry there is guard to filter out files from handling with edge renderer. It filters out urls containing `.`.

- Add `STATIC_ASSETS_BASE` to this guard to make sure `_nuxt/static/...` files always handle by edge renderer

- Check `/api` to make sure Nitro APIs always handle with edge renderer, despite having `.` in url or not

partially close nuxt/nuxt.js#11776