### PR TITLE
fix(nitro): pass query params to localCall in service worker

### DIFF
--- a/packages/nitro/src/runtime/entries/service-worker.ts
+++ b/packages/nitro/src/runtime/entries/service-worker.ts
@@ -21,7 +21,7 @@ async function handleEvent (url, event) {
   }
   const r = await localCall({
     event,
-    url: url.pathname,
+    url: url.pathname + url.search,
     host: url.hostname,
     protocol: url.protocol,
     headers: event.request.headers,


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the title above.
Example: fix(nitro): fix assets dir handling
-->

## 🔗 Linked issue

resolve nuxt/bridge#106 
<!-- ❗ Please ensure there is an open issue  -->
...

## 🖊️ Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation (updates to the documentation or readme)
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancenment (improving an exisiting functionality like performance)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## 📚 Description

Join search params with pathname in service worker so edge middleware can have access to query params
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: nuxt/framework#1337" -->

## 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

