### PR TITLE
fix(nitro): disable Nitro externals in worker preset

### DIFF
--- a/packages/nitro/src/presets/worker.ts
+++ b/packages/nitro/src/presets/worker.ts
@@ -4,5 +4,6 @@ export const worker: NitroPreset = {
   entry: null, // Abstract
   node: false,
   minify: true,
+  externals: false,
   inlineDynamicImports: true // iffe does not support code-splitting
 }


### PR DESCRIPTION
Disable nitro externals in worker target.

## 🔗 Linked issue
resolves nuxt/bridge#104


## 🖊️ Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation (updates to the documentation or readme)
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancenment (improving an exisiting functionality like performance)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: nuxt/framework#1337" -->

## 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

