### PR TITLE
feat(nitro): support esbuild options config

### DIFF
--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -33,7 +33,7 @@ export interface NitroContext {
   preset: string
   rollupConfig?: RollupConfig
   esbuild?: {
-    options?: () => EsbuildOptions
+    options?: EsbuildOptions
   }
   moduleSideEffects: string[]
   renderer: string

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -156,15 +156,11 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
   }))
 
   // ESBuild
-  const esbuildOptions = {
+  rollupConfig.plugins.push(esbuild({
     target: 'es2019',
-    sourceMap: true
-  }
-  const getEsbuildOptions = nitroContext.esbuild?.options
-  if (typeof getEsbuildOptions === 'function') {
-    Object.assign(esbuildOptions, getEsbuildOptions())
-  }
-  rollupConfig.plugins.push(esbuild(esbuildOptions))
+    sourceMap: true,
+    ...nitroContext.esbuild?.options
+  }))
 
   // Dynamic Require Support
   rollupConfig.plugins.push(dynamicRequire({


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the title above.
Example: fix(nitro): fix assets dir handling
-->

## 🔗 Linked issue

<!-- ❗ Please ensure there is an open issue  -->
Resolves nuxt/nuxt.js#11803 

## 🖊️ Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (a non-breaking change which adds functionality)

## 📚 Description

Add `esbuild` and `esbuild.options` in `nitro` config, so that user can customize esbuild options like `target` in nuxt config by:

```js
export default {
  nitro: {
    esbuild: {
      options() {
        return { target: 'es2019' }
      }
    }
  }
}
```

## 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

