### PR TITLE
fix(nitro): show all ERR_MODULE_NOT_FOUND errors

### DIFF
--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -15,10 +15,10 @@ const getSSRApp = cachedImport(() => import('#build/dist/server/server.mjs'))
 const getSSRRenderer = cachedResult(async () => {
   // Load client manifest
   const clientManifest = await getClientManifest()
-  if (!clientManifest) { throw new Error('client.manifest is missing') }
+  if (!clientManifest) { throw new Error('client.manifest is not available') }
   // Load server bundle
   const createSSRApp = await getSSRApp()
-  if (!createSSRApp) { throw new Error('Server bundle is missing') }
+  if (!createSSRApp) { throw new Error('Server bundle is not available') }
   // Create renderer
   const { renderToString } = await import('#nitro-renderer')
   return createRenderer((createSSRApp), { clientManifest, renderToString, publicPath: clientManifest.publicPath || '/_nuxt' }).renderToString
@@ -141,13 +141,7 @@ function _interopDefault (e) {
 }
 
 function cachedImport <M> (importer: () => Promise<M>) {
-  return cachedResult(() => importer().then(_interopDefault).catch((err) => {
-    if (err.code === 'ERR_MODULE_NOT_FOUND') {
-      console.warn(err)
-      return null
-    }
-    throw err
-  }))
+  return cachedResult(() => importer().then(_interopDefault))
 }
 
 function cachedResult <T> (fn: () => Promise<T>): () => Promise<T> {


### PR DESCRIPTION
### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description
If there is an error loading cached import because of a missing module we just get this (inexplicable) error.
```
Server Side Rendering Error: Error: Server bundle is missing
    at file:///Users/daniel/code/nuxt/framework/playground/.nuxt/nitro/index.mjs:113:11
    at async renderMiddleware (file:///Users/daniel/code/nuxt/framework/playground/.nuxt/nitro/index.mjs:156:22)
    at async handle (file:///Users/daniel/code/nuxt/framework/node_modules/h3/dist/index.mjs:571:19)
```
### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

