### PR TITLE
 chore: dedupe lockfile 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,18 +2684,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/compiler-core@npm:3.2.13"
-  dependencies:
-    "@babel/parser": ^7.15.0
-    "@vue/shared": 3.2.13
-    estree-walker: ^2.0.2
-    source-map: ^0.6.1
-  checksum: 26835b94bb9b5b9a36953b238917d652c97c11bc6d4fb0b9b49f8791abe296e429dc06f0c8e784c45bc5266b4a0bc300a23103f17a7f943afa6390e322f64c3d
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-core@npm:3.2.16":
   version: 3.2.16
   resolution: "@vue/compiler-core@npm:3.2.16"
@@ -2708,16 +2696,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-dom@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/compiler-dom@npm:3.2.13"
-  dependencies:
-    "@vue/compiler-core": 3.2.13
-    "@vue/shared": 3.2.13
-  checksum: d5627b2f358100f3af8fef1f74ca4e32a36cda606af6d8a132c90f1de452a0b60fac15efcdd015663d6f08a6e7c81237326f837ddc46ed5b22bf5072aadac255
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-dom@npm:3.2.16":
   version: 3.2.16
   resolution: "@vue/compiler-dom@npm:3.2.16"
@@ -2725,24 +2703,6 @@ __metadata:
     "@vue/compiler-core": 3.2.16
     "@vue/shared": 3.2.16
   checksum: 0bf167f0e425fe1fa636de81f3ecd56ad53191eac34ed7a160d5cf5401088c663bedc4251bcb83970d079fd829c3d65bd5964e2e5b5db8b5059fc3916d825b57
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-sfc@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/compiler-sfc@npm:3.2.13"
-  dependencies:
-    "@babel/parser": ^7.15.0
-    "@vue/compiler-core": 3.2.13
-    "@vue/compiler-dom": 3.2.13
-    "@vue/compiler-ssr": 3.2.13
-    "@vue/ref-transform": 3.2.13
-    "@vue/shared": 3.2.13
-    estree-walker: ^2.0.2
-    magic-string: ^0.25.7
-    postcss: ^8.1.10
-    source-map: ^0.6.1
-  checksum: 295e2b13d6d8f3d77210d805390a2d76a7d27c1510a6b5ca883c4c1f7dc289cafdc76f99656bdf7b6d1a5ce744a21dab01401809614b8639c5978cf4831190a3
   languageName: node
   linkType: hard
 
@@ -2761,16 +2721,6 @@ __metadata:
     postcss: ^8.1.10
     source-map: ^0.6.1
   checksum: 3653f938371ce6cbf2c81d280b85a30faa9e6b2b7e0481270eec808b1c4208372c86149d786604082c11698440c86a7547306435cd9e494713d4986030868255
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-ssr@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/compiler-ssr@npm:3.2.13"
-  dependencies:
-    "@vue/compiler-dom": 3.2.13
-    "@vue/shared": 3.2.13
-  checksum: 41b49ad70e4993b82821402146e9d81de0a5d2db67d2161b9c04ba3da0e2a2ca287bc64bc3ff212afd38beedb0faa1db095215c85eec6007d9656bc0b228ed75
   languageName: node
   linkType: hard
 
@@ -2822,34 +2772,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/reactivity@npm:3.2.13"
-  dependencies:
-    "@vue/shared": 3.2.13
-  checksum: 0d4b219ecb5a22bbbab5791aaa9c9648ba771cf19f0498fa10dc19b29d3c4f891dc1a3a417affba07f469a4d7613abc536fa4c75a1c098f769c0123ae0d5c4ec
-  languageName: node
-  linkType: hard
-
 "@vue/reactivity@npm:3.2.16":
   version: 3.2.16
   resolution: "@vue/reactivity@npm:3.2.16"
   dependencies:
     "@vue/shared": 3.2.16
   checksum: 6a752bc31130abda3177076bf1131b8f0492338e70368c58dc768c6e9ce3bcdbb79d21a322052c1b534f632110968044c1a376cc29cf69db31a104cc6596565e
-  languageName: node
-  linkType: hard
-
-"@vue/ref-transform@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/ref-transform@npm:3.2.13"
-  dependencies:
-    "@babel/parser": ^7.15.0
-    "@vue/compiler-core": 3.2.13
-    "@vue/shared": 3.2.13
-    estree-walker: ^2.0.2
-    magic-string: ^0.25.7
-  checksum: f42e2380ee2b717646a7ae4d6608c600ca761a4d3189d3328fa955535158f9f548dac204f7fc5806b78be89ca434c5843dd9645c9860605d297ad5813ad66121
   languageName: node
   linkType: hard
 
@@ -2866,16 +2794,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/runtime-core@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/runtime-core@npm:3.2.13"
-  dependencies:
-    "@vue/reactivity": 3.2.13
-    "@vue/shared": 3.2.13
-  checksum: 97bf724983ad532764a64c77bf66660251266aebbaf04f9629e62f5855b50627f6371535ae63b6e1b5dd7cff437d674ebc4c7da46f62c2bfa32df997567505f3
-  languageName: node
-  linkType: hard
-
 "@vue/runtime-core@npm:3.2.16":
   version: 3.2.16
   resolution: "@vue/runtime-core@npm:3.2.16"
@@ -2883,17 +2801,6 @@ __metadata:
     "@vue/reactivity": 3.2.16
     "@vue/shared": 3.2.16
   checksum: 650f2dbfe12e64f7004647e3d8b86f117912834400a1ab77e3a87cf26300f5eaf4699e8d1562d87d0591b18bad625199a6c702980147bb7969d6b802207c86f3
-  languageName: node
-  linkType: hard
-
-"@vue/runtime-dom@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/runtime-dom@npm:3.2.13"
-  dependencies:
-    "@vue/runtime-core": 3.2.13
-    "@vue/shared": 3.2.13
-    csstype: ^2.6.8
-  checksum: 0cfc2a5c7f75316c5aa4420b85d63292a820c2a4406513874f46f272a2fb94a2ab95cdf3d63691ee858d29e98d5640f72a91f54efc6de1979c504fe565adf93a
   languageName: node
   linkType: hard
 
@@ -2908,18 +2815,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/server-renderer@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/server-renderer@npm:3.2.13"
-  dependencies:
-    "@vue/compiler-ssr": 3.2.13
-    "@vue/shared": 3.2.13
-  peerDependencies:
-    vue: 3.2.13
-  checksum: 6ad393ec441ab563a5c57060ee53e307ed3abbeb7a75fe20f2ae855f312609b493a9b50f80e5d8592e36e32a5e315aa5e7713178e779604adf78e0a43365bf10
-  languageName: node
-  linkType: hard
-
 "@vue/server-renderer@npm:3.2.16, @vue/server-renderer@npm:^3.2.16":
   version: 3.2.16
   resolution: "@vue/server-renderer@npm:3.2.16"
@@ -2929,13 +2824,6 @@ __metadata:
   peerDependencies:
     vue: 3.2.16
   checksum: 007c947b377fe897d04bf39ea62f3136f02056e0a17fb2b8039605765688e2647c43c05901a09f99d46e81a1d4a6365fdd31f1d9391b7ba539f30612413ca57c
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.2.13":
-  version: 3.2.13
-  resolution: "@vue/shared@npm:3.2.13"
-  checksum: 47217e224f6bdd48418f5bc2dd56a9309a91a32a3a7c5b63a1192cc55086baebacc1cf7c8cb5b0641abb2b6c63e87091518cd4e5d328a2fa87f4088f45259635
   languageName: node
   linkType: hard
 
@@ -7414,7 +7302,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"glob@npm:7.1.7, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:7.1.7":
   version: 7.1.7
   resolution: "glob@npm:7.1.7"
   dependencies:
@@ -7428,7 +7316,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.2.0":
+"glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -14100,20 +13988,7 @@ typescript@^4.4.3:
   languageName: node
   linkType: hard
 
-"vue@npm:3.2.13, vue@npm:^3":
-  version: 3.2.13
-  resolution: "vue@npm:3.2.13"
-  dependencies:
-    "@vue/compiler-dom": 3.2.13
-    "@vue/compiler-sfc": 3.2.13
-    "@vue/runtime-dom": 3.2.13
-    "@vue/server-renderer": 3.2.13
-    "@vue/shared": 3.2.13
-  checksum: bf14b923c06fd4118900d10e848a7bbe6f34697987ed4b839e0a5097577cf640517a9be94352d190e535422f4ec0163332fc8c74f21b6ef8b17a15af91e1d491
-  languageName: node
-  linkType: hard
-
-"vue@npm:3.2.16, vue@npm:^3.2.16":
+"vue@npm:3.2.16, vue@npm:^3, vue@npm:^3.2.16":
   version: 3.2.16
   resolution: "vue@npm:3.2.16"
   dependencies:


### PR DESCRIPTION
### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Looks like renovate isn't great at deduping when upgrading (https://github.com/nuxt/framework/pull/554) - and we're getting a vue mismatch which triggers with the following error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vue-router' imported from /framework/playground/.nuxt/dist/server/server.mjs
    at packageResolve (internal/modules/esm/resolve.js:650:9)
    at moduleResolve (internal/modules/esm/resolve.js:691:18)
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:805:11)
    at Loader.resolve (internal/modules/esm/loader.js:88:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:241:28)
    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:72:40)
    at link (internal/modules/esm/module_job.js:71:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```
