### PR TITLE
fix(vite): rewrite ssr asset hash

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -9,6 +9,7 @@ import { replace } from './plugins/replace'
 import { transformNuxtSetup } from './plugins/transformSetup'
 import { wpfs } from './utils/wpfs'
 import type { ViteBuildContext, ViteOptions } from './vite'
+import { ssrAssetsServe } from './plugins/ssr-assets'
 
 export async function buildClient (ctx: ViteBuildContext) {
   const clientConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
@@ -38,6 +39,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       replace({ 'process.env': 'import.meta.env' }),
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'client'),
       vitePlugin(ctx.config.vue),
+      ssrAssetsServe(ctx.nuxt),
       transformNuxtSetup()
     ],
     server: {

--- a/packages/vite/src/plugins/ssr-assets.ts
+++ b/packages/vite/src/plugins/ssr-assets.ts
@@ -1,0 +1,50 @@
+import fs from 'fs-extra'
+import { Nuxt } from '@nuxt/kit'
+import { resolve, extname } from 'upath'
+import type { Plugin } from 'vite'
+
+/**
+ * Rewrite hashed assets in SSR back to their original file.
+ *
+ * For example:
+ * '/_nuxt/assets/logo.21aaaacb.svg' -> '/assets/logo.svg'
+ */
+export function ssrAssetsServe (nuxt: Nuxt) {
+  return <Plugin>{
+    name: 'nuxt:assets-serve',
+    enforce: 'pre',
+    configureServer (server) {
+      const ssrManifestPath = resolve(nuxt.options.buildDir, 'dist/server/ssr-manifest.json')
+      let assetMap: Record<string, string>
+
+      async function readManifest () {
+        assetMap = {}
+        if (!fs.existsSync(ssrManifestPath)) {
+          return
+        }
+        const ssrManifest: Record<string, string[]> = await fs.readJSON(ssrManifestPath)
+        Object.entries(ssrManifest).forEach(([key, value]) => {
+          value.forEach((path) => {
+            if (extname(path) === extname(key)) {
+              assetMap[path] = '/' + key
+            }
+          })
+        })
+      }
+
+      server.watcher.add(ssrManifestPath)
+      server.watcher.on('change', (path) => {
+        if (path === ssrManifestPath) {
+          readManifest()
+        }
+      })
+      server.middlewares.use((req, _, next) => {
+        if (assetMap[req.url]) {
+          req.url = assetMap[req.url]
+        }
+        next()
+      })
+      readManifest()
+    }
+  }
+}

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -35,6 +35,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     build: {
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
       ssr: true,
+      ssrManifest: true,
       rollupOptions: {
         output: {
           entryFileNames: 'server.mjs',


### PR DESCRIPTION
When using Vite with ssr enabled. Assets path are hashed which make the dev server failed to find the file.

This PR using ssr-manifest gets the asset mapping the rewrites the URL with a server middleware to serve the correct file.