### PR TITLE
chore: use vue exports of compiler-sfc and server-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^14.17.18",
     "@types/object-hash": "^2",
-    "@vue/server-renderer": "^3.2.16",
     "chai": "^4.3.4",
     "esbuild": "^0.13.2",
     "eslint": "^7.32.0",

--- a/packages/nitro/build.config.ts
+++ b/packages/nitro/build.config.ts
@@ -17,7 +17,6 @@ export default defineBuildConfig({
     'ora',
     'vue-bundle-renderer',
     'vue-server-renderer',
-    '@vue/server-renderer',
     'vue'
   ]
 })

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -28,7 +28,6 @@
     "@rollup/pluginutils": "^4.1.1",
     "@types/jsdom": "^16.2.13",
     "@vercel/nft": "^0.15.0",
-    "@vue/server-renderer": "^3.2.16",
     "archiver": "^5.3.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",

--- a/packages/nitro/src/runtime/app/vue3.ts
+++ b/packages/nitro/src/runtime/app/vue3.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { renderToString as render } from '@vue/server-renderer'
+import { renderToString as render } from 'vue/server-renderer/index.mjs'
 
 export const renderToString: typeof render = (...args) => {
   return render(...args).then(result => `<div id="__nuxt">${result}</div>`)

--- a/packages/nuxt3/package.json
+++ b/packages/nuxt3/package.json
@@ -22,7 +22,6 @@
     "@nuxt/vite-builder": "^0.10.0",
     "@nuxt/webpack-builder": "^0.10.0",
     "@vue/reactivity": "3.2.16",
-    "@vue/server-renderer": "^3.2.16",
     "@vue/shared": "3.2.16",
     "@vueuse/head": "^0.6.0",
     "chokidar": "^3.5.2",

--- a/packages/vite/build.config.ts
+++ b/packages/vite/build.config.ts
@@ -7,7 +7,6 @@ export default defineBuildConfig({
   ],
   dependencies: [
     '@nuxt/kit',
-    '@vue/compiler-sfc',
     'vue'
   ]
 })

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@nuxt/kit": "^0.10.0",
     "@vitejs/plugin-vue": "^1.9.1",
-    "@vue/compiler-sfc": "^3.2.16",
     "chokidar": "^3.5.2",
     "consola": "^2.15.3",
     "debounce": "^1.2.1",

--- a/packages/webpack/build.config.ts
+++ b/packages/webpack/build.config.ts
@@ -8,7 +8,6 @@ export default defineBuildConfig({
   ],
   dependencies: [
     '@nuxt/kit',
-    '@vue/compiler-sfc',
     '@vue/babel-preset-jsx',
     'postcss',
     'postcss-import-resolver',

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -16,7 +16,6 @@
     "@nuxt/friendly-errors-webpack-plugin": "^2.5.1",
     "@nuxt/kit": "^0.10.0",
     "@vue/babel-preset-jsx": "^1.2.4",
-    "@vue/compiler-sfc": "^3.2.16",
     "autoprefixer": "^10.3.5",
     "babel-loader": "^8.2.2",
     "consola": "^2.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,7 +1502,6 @@ __metadata:
     "@types/node-fetch": ^3.0.2
     "@types/serve-static": ^1.13.10
     "@vercel/nft": ^0.15.0
-    "@vue/server-renderer": ^3.2.16
     archiver: ^5.3.0
     chalk: ^4.1.2
     chokidar: ^3.5.2
@@ -1570,7 +1569,6 @@ __metadata:
     "@nuxt/kit": ^0.10.0
     "@types/debounce": ^1.2.1
     "@vitejs/plugin-vue": ^1.9.1
-    "@vue/compiler-sfc": ^3.2.16
     chokidar: ^3.5.2
     consola: ^2.15.3
     debounce: ^1.2.1
@@ -1598,7 +1596,6 @@ __metadata:
     "@types/webpack-hot-middleware": ^2.25.5
     "@types/webpack-virtual-modules": ^0
     "@vue/babel-preset-jsx": ^1.2.4
-    "@vue/compiler-sfc": ^3.2.16
     autoprefixer: ^10.3.5
     babel-loader: ^8.2.2
     consola: ^2.15.3
@@ -2706,7 +2703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-sfc@npm:3.2.16, @vue/compiler-sfc@npm:^3.2.16":
+"@vue/compiler-sfc@npm:3.2.16":
   version: 3.2.16
   resolution: "@vue/compiler-sfc@npm:3.2.16"
   dependencies:
@@ -2815,7 +2812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/server-renderer@npm:3.2.16, @vue/server-renderer@npm:^3.2.16":
+"@vue/server-renderer@npm:3.2.16":
   version: 3.2.16
   resolution: "@vue/server-renderer@npm:3.2.16"
   dependencies:
@@ -9910,7 +9907,6 @@ fsevents@~2.3.2:
     "@types/mocha": ^9.0.0
     "@types/node": ^14.17.18
     "@types/object-hash": ^2
-    "@vue/server-renderer": ^3.2.16
     chai: ^4.3.4
     esbuild: ^0.13.2
     eslint: ^7.32.0
@@ -9979,7 +9975,6 @@ fsevents@~2.3.2:
     "@types/hash-sum": ^1.0.0
     "@types/lodash": ^4.14.173
     "@vue/reactivity": 3.2.16
-    "@vue/server-renderer": ^3.2.16
     "@vue/shared": 3.2.16
     "@vueuse/head": ^0.6.0
     chokidar: ^3.5.2


### PR DESCRIPTION
### 📚 Description

For vue 3.2.13+, we can import directly from `vue/server-renderer` and `vue/compiler-sfc` rather than adding to our own dependencies: [vue docs](https://github.com/vuejs/vue-next/blob/master/packages/compiler-sfc/README.md)

This PR is a quick removal of our dependencies for the purpose of testing.

### 📝 Checklist

- [ ] ~~Confirm no issues with pnp~~ see nuxt/nuxt.js#11823
- [x] Confirm we're not now accidentally inlining `@vue/compiler-sfc` and `@vue/server-renderer` in the affected packages
- [x] test with external package

