### PR TITLE
chore(nuxt3): remove last `upath` reference

### DIFF
--- a/packages/nuxt3/src/components/templates.ts
+++ b/packages/nuxt3/src/components/templates.ts
@@ -1,5 +1,5 @@
 
-import { relative } from 'upath'
+import { relative } from 'pathe'
 
 import type { Component } from './types'
 


### PR DESCRIPTION
### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`upath` was being inlined because of a stray import following merge of https://github.com/nuxt/framework/pull/553
