### PR TITLE
fix(cli): restart on `app.vue` creation removal

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -65,7 +65,7 @@ export default defineNuxtCommand({
       if (['addDir', 'unlinkDir'].includes(_event) && file.match(/pages$/)) {
         dLoad(true, `pages/ ${_event === 'addDir' ? 'created' : 'removed'}`)
       }
-      if (['add', 'unlink'].includes(_event) && file.match(/app\.(js|ts|mjs|tsx|vue)$/)) {
+      if (['add', 'unlink'].includes(_event) && file.match(/app\.(js|ts|mjs|jsx|tsx|vue)$/)) {
         dLoad(true, `${relative(rootDir, file)}/ ${_event === 'add' ? 'created' : 'removed'}`)
       }
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

First attempt to resolves ~~#596~~ ~> nuxt/nuxt.js#11910


### ❓ Type of change

<!-- What types of changes does your code introduce? Put `x's in all the boxes that apply: -->

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [x] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: nuxt/framework#1337" -->

The fix works for creation but we have some error console happening **when removing the entry** or weird behavior.

When removing `app.vue`:
![Screenshot 2021-09-29 at 19 56 44](https://user-images.githubusercontent.com/904724/135323282-07a5283d-cb81-4aa9-bb22-0ca4494e7007.png)

I got back the tutorial but have a SSR rendering error (it need a manual restart to disappear)

When removing `pages/index.vue`:
![Screenshot 2021-09-29 at 19 58 47](https://user-images.githubusercontent.com/904724/135323499-177dd407-e202-4054-8141-0932871f43f4.png)

I got back the tutorial on first reload but then the server hangs with the `uncaught error during route navigation:`

**Bonus:** we shall improve the log when restarting the server (maybe having the ℹ️  icon next to it?)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

