### PR TITLE
fix(nitro): do not resolve node condition in exports for nodeless env

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -279,7 +279,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
     exportConditions: [
       'default',
       'module',
-      'node',
+      nitroContext.node !== false ? 'node' : 'browser',
       'import'
     ]
   }))


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt.js#11794 

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This should fix the situation where node-specific code is being imported into nodeless environments.