### PR TITLE
fix(nuxi): don't restart when build directory changes

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -60,7 +60,7 @@ export default defineNuxtCommand({
     const watcher = chokidar.watch([rootDir], { ignoreInitial: true, depth: 1 })
     watcher.on('all', (_event, file) => {
       if (file.startsWith(currentNuxt.options.buildDir)) { return }
-      if (file.match(/nuxt\.config\.(js|ts|mjs|cjs)$|pages$/)) {
+      if (file.match(/nuxt\.config\.(js|ts|mjs|cjs)$/)) {
         dLoad(true, `${relative(rootDir, file)} updated`)
       }
       if (['addDir', 'unlinkDir'].includes(_event) && file.match(/pages$/)) {


### PR DESCRIPTION
### 🔗 Linked issue

noticed when partially reproducing nuxt/nuxt.js#11863

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

When using `nuxi` in a nuxt2 environment, it is restarting server every time `.nuxt` directory `pages/` is recreated, resulting in an infinite loop.

This ignores files located within `.nuxt` directory (for purposes of restarting nuxt). This should have little effect on nuxt3 behaviour as we are almost free of the shackles of templates.

Better solutions welcome!