### PR TITLE
fix(bridge): add additional vue composition-api resolutions

### DIFF
--- a/packages/bridge/src/capi.ts
+++ b/packages/bridge/src/capi.ts
@@ -14,8 +14,11 @@ export function setupCAPIBridge (_options: any) {
 
   // Add composition-api support
   const vueCapiEntry = require.resolve('@vue/composition-api/dist/vue-composition-api.mjs')
-  nuxt.options.alias['@vue/composition-api/dist/vue-composition-api.mjs'] = vueCapiEntry
+  nuxt.options.alias['@vue/composition-api/dist/vue-composition-api.common.js'] = vueCapiEntry
+  nuxt.options.alias['@vue/composition-api/dist/vue-composition-api.common.prod.js'] = vueCapiEntry
   nuxt.options.alias['@vue/composition-api/dist/vue-composition-api.esm.js'] = vueCapiEntry
+  nuxt.options.alias['@vue/composition-api/dist/vue-composition-api.js'] = vueCapiEntry
+  nuxt.options.alias['@vue/composition-api/dist/vue-composition-api.mjs'] = vueCapiEntry
   nuxt.options.alias['@vue/composition-api'] = vueCapiEntry
   const capiPluginPath = resolve(distDir, 'runtime/capi.plugin.mjs')
   addPluginTemplate({ filename: 'capi.plugin.mjs', src: capiPluginPath })


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/bridge#212

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This PR implements the suggestions in nuxt/bridge#212 to help prevent footguns where fully resolved imports from `@vue/composition-api` are then resolved a second time (or which cause mismatches between libraries).

### 📝 Checklist

- [x] I have linked an issue or discussion.

