### PR TITLE
fix(nuxt3): use built-in `<Link>` to render in `<head>` and prevent CLS

### DIFF
--- a/packages/nuxt3/src/app/app.tutorial.vue
+++ b/packages/nuxt3/src/app/app.tutorial.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center sm:pt-0">
-    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+    <Link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet" />
     <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
       <div class="flex justify-center pt-8 sm:justify-start sm:pt-0">
         <svg width="221" height="65" viewBox="0 0 221 65" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

At the moment because we're using native HTML `<link>` we have CLS when loading tutorial. This PR uses the Nuxt component `<Link>` to ensure the Tailwind CSS is added to `<head>`.
