### PR TITLE
fix(nuxt3): move export to top level

### DIFF
--- a/packages/nuxt3/src/components/templates.ts
+++ b/packages/nuxt3/src/components/templates.ts
@@ -55,7 +55,7 @@ declare module 'vue' {
   export interface GlobalComponents {
 ${options.components.map(c => `    '${c.pascalName}': typeof import('${relative(options.buildDir, c.filePath)}')['${c.export}']`).join(',\n')}
   }
-
-  export {}
-}`
+}
+export {}
+`
 }


### PR DESCRIPTION
### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Previously the generated global components file was overwriting the entire `vue` typing. This PR fixes that issue by moving the export (which places us in a module augmentation context) out of `declare module`.