### PR TITLE
fix(bridge): resolve `browser` condition above `main` for client

### DIFF
--- a/packages/bridge/src/resolve.ts
+++ b/packages/bridge/src/resolve.ts
@@ -10,7 +10,7 @@ type ResolverOptions = Omit<UserResolveOptions, 'fileSystem'> & { fileSystem?: e
 
 const DEFAULTS: UserResolveOptions = {
   fileSystem: new enhancedResolve.CachedInputFileSystem(fs, 4000),
-  extensions: ['.ts', '.mjs', '.cjs', '.js', '.json']
+  extensions: ['.ts', '.tsx', '.mjs', '.cjs', '.js', '.jsx', '.json', '.vue']
 }
 
 // Abstracted resolver factory which can be used in rollup, webpack, etc.


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/bridge#278

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`browser` field was being ignored so consola was resolving to `main` instead, which contained node dependencies. This is likely to be true for other deps.

### 📝 Checklist

- [x] I have linked an issue or discussion.
