### PR TITLE
fix(bridge): detect conflict with `@nuxt/typescript-build` usage

### DIFF
--- a/packages/bridge/src/typescript.ts
+++ b/packages/bridge/src/typescript.ts
@@ -16,7 +16,7 @@ export function setupTypescript () {
 
   // Error if `@nuxt/typescript-build` is added
   if (nuxt.options.buildModules.includes('@nuxt/typescript-build')) {
-    throw new Error('Please remove `@nuxt/typescript-build` from `buildModules` to avoid conflict with bridge.')
+    throw new Error('Please remove `@nuxt/typescript-build` from `buildModules` or set `bridge.typescript: false` to avoid conflict with bridge.')
   }
 
   nuxt.options.build.babel.plugins.unshift(babelPlugin)


### PR DESCRIPTION
### 🔗 Linked issue

related to nuxt/bridge#270

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This PR doesn't inject babel plugin if it already exists. This way, a user can configure the plugin options if needed.

### 📝 Checklist

- [x] I have linked an issue or discussion.
