### PR TITLE
fix(nuxt3): don't call lifecycle methods outside of component

### DIFF
--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -1,5 +1,5 @@
 import { createHead, renderHeadToString } from '@vueuse/head'
-import { ref, watchEffect, onBeforeUnmount } from 'vue'
+import { ref, watchEffect, onBeforeUnmount, getCurrentInstance } from 'vue'
 import type { MetaObject } from '..'
 import { defineNuxtPlugin } from '#app'
 
@@ -17,6 +17,9 @@ export default defineNuxtPlugin((nuxt) => {
     watchEffect(() => {
       head.updateDOM()
     })
+
+    const vm = getCurrentInstance()
+    if (!vm) { return }
 
     onBeforeUnmount(() => {
       head.removeHeadObjs(headObj)


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt.js#11874

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

We avoid calling `onBeforeUnmounted` if there is no active instance.

### 📝 Checklist

- [x] I have linked an issue or discussion.
