### PR TITLE
fix(nitro): always inline `.wasm`

### DIFF
--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -44,7 +44,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         if (_id.startsWith('.') || opts.inline.find(i => _id.startsWith(i) || id.startsWith(i))) {
           return null
         }
-        // Bundle ts
+        // Bundle ts and wasm (currently - see https://github.com/nuxt/framework/discussions/692)
         if (_id.endsWith('.ts') || _id.endsWith('.wasm')) {
           return null
         }


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/bridge#269

### ❓ Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This ensures that `.wasm` files are not treated as externals even if they are within `node_modules`.

### 📝 Checklist

- [x] I have linked an issue or discussion.

