### PR TITLE
fix(vite): resolve vue aliases

### DIFF
--- a/packages/nuxt3/src/meta/module.ts
+++ b/packages/nuxt3/src/meta/module.ts
@@ -14,7 +14,7 @@ export default defineNuxtModule({
     const runtimeDir = nuxt.options.alias['#meta'] || resolve(distDir, 'meta/runtime')
 
     // Transpile @nuxt/meta and @vueuse/head
-    nuxt.options.build.transpile.push('nuxt3', '@vueuse/head')
+    nuxt.options.build.transpile.push('@vueuse/head')
 
     // Add #meta alias
     nuxt.options.alias['#meta'] = runtimeDir

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -4,12 +4,14 @@ import vuePlugin from '@vitejs/plugin-vue'
 import fse from 'fs-extra'
 import pDebounce from 'p-debounce'
 import consola from 'consola'
+import { resolveModule } from '@nuxt/kit'
 import { ViteBuildContext, ViteOptions } from './vite'
 import { wpfs } from './utils/wpfs'
 import { cacheDirPlugin } from './plugins/cache-dir'
 import { bundleRequest } from './dev-bundler'
 
 export async function buildServer (ctx: ViteBuildContext) {
+  const _resolve = id => resolveModule(id, { paths: ctx.nuxt.options.modulesDir })
   const serverConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
     define: {
       'process.server': true,
@@ -24,25 +26,25 @@ export async function buildServer (ctx: ViteBuildContext) {
       alias: {
         '#build/plugins': resolve(ctx.nuxt.options.buildDir, 'plugins/server'),
         // Alias vue
-        'vue/server-renderer': 'vue/server-renderer',
-        'vue/compiler-sfc': 'vue/compiler-sfc',
-        '@vue/reactivity': `@vue/reactivity/dist/reactivity.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`,
-        '@vue/shared': `@vue/shared/dist/shared.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`,
-        'vue-router': `vue-router/dist/vue-router.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`,
-        vue: `vue/dist/vue.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`
+        'vue/server-renderer': _resolve('vue/server-renderer'),
+        'vue/compiler-sfc': _resolve('vue/compiler-sfc'),
+        '@vue/reactivity': _resolve(`@vue/reactivity/dist/reactivity.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`),
+        '@vue/shared': _resolve(`@vue/shared/dist/shared.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`),
+        'vue-router': _resolve(`vue-router/dist/vue-router.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`),
+        vue: _resolve(`vue/dist/vue.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`)
       }
     },
     ssr: {
-      external: [
-        'axios'
-      ],
+      external: [],
       noExternal: [
         ...ctx.nuxt.options.build.transpile.filter(i => typeof i === 'string'),
         '.vue',
         'plugin-vue:',
         '#app',
-        'nuxt3',
-        '@nuxt/nitro'
+        'nuxt3/dist',
+        'nuxt3/src',
+        '@nuxt/nitro/dist',
+        '@nuxt/nitro/src'
       ]
     },
     build: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Potentially resolves nuxt/nuxt.js#11871

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a hotfix fox vite bundler that preresolves vue deps with respect of search path. Also only transpiling `nuxt3` as `nuxt3/node_modules` should be kept externalized.

Next step: Using externality

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

