### PR TITLE
fix(nuxi): dx improvements when creating components/ directory

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -35,7 +35,7 @@ export default defineNuxtCommand({
         const message = `${reason ? reason + '. ' : ''}${isRestart ? 'Restarting' : 'Starting'} nuxt...`
         server.setApp(createLoadingHandler(message))
         if (isRestart) {
-          console.log(message)
+          consola.info(message)
         }
         if (currentNuxt) {
           await currentNuxt.close()
@@ -68,10 +68,13 @@ export default defineNuxtCommand({
         dLoad(true, `${relative(rootDir, file)} updated`)
       }
       if (['addDir', 'unlinkDir'].includes(_event) && file.match(/pages$/)) {
-        dLoad(true, `pages/ ${_event === 'addDir' ? 'created' : 'removed'}`)
+        dLoad(true, `Directory \`pages/\` ${_event === 'addDir' ? 'created' : 'removed'}`)
+      }
+      if (['addDir', 'unlinkDir'].includes(_event) && file.match(/components$/)) {
+        dLoad(true, `Directory \`components/\` ${_event === 'addDir' ? 'created' : 'removed'}`)
       }
       if (['add', 'unlink'].includes(_event) && file.match(/app\.(js|ts|mjs|jsx|tsx|vue)$/)) {
-        dLoad(true, `${relative(rootDir, file)}/ ${_event === 'add' ? 'created' : 'removed'}`)
+        dLoad(true, `\`${relative(rootDir, file)}\` ${_event === 'add' ? 'created' : 'removed'}`)
       }
     })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Sorry I did not created an issue for that small fix 🙏 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
When creating the `components/` directory, we need to restart the whole Nuxt server in order to activate the [components discovery](https://github.com/nuxt/framework/blob/fix/dx-improvements/packages/nuxt3/src/components/module.ts) module.

I added the `components` dir check to restart Nuxt.

I also used `consola` to have consistent logging and improved the messages.

<img width="330" alt="Screenshot 2021-10-12 at 14 28 30@2x" src="https://user-images.githubusercontent.com/904724/136956127-3ccbb491-b9a2-41a7-8963-739964799a9c.png">
<img width="455" alt="Screenshot 2021-10-12 at 14 29 03@2x" src="https://user-images.githubusercontent.com/904724/136956141-d5176234-72e8-4b93-a26e-69d06219ef6e.png">

