### PR TITLE
feat(nuxt3): preliminary app error handling

### DIFF
--- a/examples/with-errors/app.vue
+++ b/examples/with-errors/app.vue
@@ -1,0 +1,12 @@
+<template>
+  <router-link to="/">
+    Handled asyncdata error
+  </router-link>
+  <router-link to="/unhandled">
+    Unhandled asyncdata error
+  </router-link>
+  <router-link to="/404">
+    Unknown page
+  </router-link>
+  <nuxt-page />
+</template>

--- a/examples/with-errors/nuxt.config.ts
+++ b/examples/with-errors/nuxt.config.ts
@@ -1,0 +1,4 @@
+import { defineNuxtConfig } from 'nuxt3'
+
+export default defineNuxtConfig({
+})

--- a/examples/with-errors/package.json
+++ b/examples/with-errors/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example-with-errors",
+  "private": true,
+  "devDependencies": {
+    "nuxt3": "latest"
+  },
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs"
+  }
+}

--- a/examples/with-errors/pages/_error.vue
+++ b/examples/with-errors/pages/_error.vue
@@ -1,0 +1,19 @@
+<template>
+  <h2>Error page</h2>
+  <div v-for="(error, index) in errors" :key="error.message">
+    <h2 v-if="error.name">
+      {{ error.name }}
+    </h2>
+    <blockquote v-if="error.message">
+      {{ error.message }}
+    </blockquote>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    errors: Array
+  }
+}
+</script>

--- a/examples/with-errors/pages/index.vue
+++ b/examples/with-errors/pages/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h2>Handled error</h2>
+    <div v-if="error">
+      We handled this error ("{{ error.message }}") so no error page for us!
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { error } = await useAsyncData('error-async-handled', async () => {
+  await new Promise(resolve => setTimeout(resolve, 1000))
+  throw new Error('Throwing this error just because I can.')
+})
+</script>

--- a/examples/with-errors/pages/unhandled.vue
+++ b/examples/with-errors/pages/unhandled.vue
@@ -1,0 +1,13 @@
+<template>
+  <main>
+    <h2>Unhandled error</h2>
+    {{ data }}
+  </main>
+</template>
+
+<script setup lang="ts">
+const { data } = await useAsyncData('error-async-unhandled' + Math.random(), async () => {
+  await new Promise(resolve => setTimeout(resolve, 1000))
+  throw new Error('Throwing this error just because I can.')
+})
+</script>

--- a/examples/with-errors/plugins/error.js
+++ b/examples/with-errors/plugins/error.js
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin((nuxt) => {
+  if (process.server && nuxt.ssrContext.url.includes('/error-in-plugin') && !nuxt.ssrContext.errors.length) {
+    throw new Error('error-in-plugin')
+  }
+})

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -69,9 +69,17 @@ export async function renderMiddleware (req, res: ServerResponse) {
   }
 
   // Render app
-  const rendered = await renderToString(ssrContext)
+  let rendered = await renderToString(ssrContext)
 
   // Handle errors
+
+  // nuxt3
+  if (ssrContext.errors?.filter(Boolean).length) {
+    // An unhandled error occurred but could not be rendered
+    rendered = await renderToString(ssrContext)
+  }
+
+  // nuxt2
   if (ssrContext.error) {
     throw ssrContext.error
   }
@@ -100,8 +108,8 @@ export async function renderMiddleware (req, res: ServerResponse) {
     res.setHeader('Content-Type', 'text/html;charset=UTF-8')
   }
 
-  const error = ssrContext.nuxt && ssrContext.nuxt.error
-  res.statusCode = error ? error.statusCode : 200
+  const error = ssrContext.nuxt?.error || ssrContext.errors?.[0]
+  res.statusCode = error ? error.statusCode || 500 : 200
   res.end(data, 'utf-8')
 }
 

--- a/packages/nuxt3/src/app/composables/errors.ts
+++ b/packages/nuxt3/src/app/composables/errors.ts
@@ -1,0 +1,53 @@
+import { toRef } from 'vue'
+import { useNuxtApp } from '#app'
+
+export interface NuxtError {
+  name?: string
+  statusCode?: string
+  message?: string
+  stack?: string
+}
+
+export const normalizeError = (e: any): NuxtError => {
+  if (!e) {
+    return null
+  }
+  return {
+    name: e.name,
+    statusCode: e.statusCode,
+    message: e.message || e.toString(),
+    stack: process.dev ? e.stack : undefined
+  }
+}
+
+export const useError = () => {
+  const nuxt = useNuxtApp()
+  const { errors } = useNuxtErrors()
+
+  const errorKey = errors.value.push(null) - 1
+
+  return {
+    get: () => errors.value[errorKey],
+    set: (e: any) => {
+      errors.value[errorKey] = normalizeError(e)
+      nuxt.callHook('error:captured', errors.value)
+    },
+    unset: () => { errors.value[errorKey] = null }
+  }
+}
+
+export const useNuxtErrors = () => {
+  const nuxt = useNuxtApp()
+
+  const errors = toRef(nuxt.payload, 'errors')
+
+  return {
+    errors,
+    addError: (e: any) => {
+      errors.value.push(normalizeError(e))
+      nuxt.callHook('error:captured', errors.value)
+    },
+    resetErrors: () => errors.value.forEach((_err, index) => { errors.value[index] = null }),
+    unhandledErrors: computed(() => errors.value.filter(Boolean))
+  }
+}

--- a/packages/nuxt3/src/app/composables/index.ts
+++ b/packages/nuxt3/src/app/composables/index.ts
@@ -1,5 +1,6 @@
 export { defineNuxtComponent } from './component'
 export { useAsyncData } from './asyncData'
+export { normalizeError, useError, useNuxtErrors } from './errors'
 export { useHydration } from './hydrate'
 export { useState } from './state'
 export { useFetch } from './fetch'

--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -57,5 +57,18 @@ export default defineNuxtModule({
         ].join('\n')
       }
     })
+
+    // Add error page template
+    addTemplate({
+      filename: 'error.js',
+      getContents: () => {
+        const errorPage = resolve(nuxt.options.srcDir, nuxt.options.dir.pages, '_error.vue')
+        if (existsSync(errorPage)) {
+          return `export { default } from '${errorPage}'`
+        } else {
+          return `export { default } from '${resolve(runtimeDir, 'error.js')}'`
+        }
+      }
+    })
   }
 })

--- a/packages/nuxt3/src/pages/runtime/error.js
+++ b/packages/nuxt3/src/pages/runtime/error.js
@@ -1,0 +1,46 @@
+import { h } from 'vue'
+import { error404, error500, errorDev } from '@nuxt/design'
+
+function extractBody (html) {
+  const { bodyAttrs, content } = html.match(/<body(?<bodyAttrs>[^>]*)>(?<content>[\s\S]*)<\/body>/)?.groups || {}
+  return '<div' + bodyAttrs + '>' + content + '</div>'
+}
+
+function extractStyle (html) {
+  const { style } = html.match(/<style>(?<style>[\s\S]*)<\/style>/)?.groups || []
+  return style
+}
+
+function templateToVNode (html) {
+  const style = extractStyle(html)
+  const body = extractBody(html)
+
+  return h('div', {
+    innerHTML: '<style>' + style + '</style>' + body
+  })
+}
+
+export default {
+  props: {
+    errors: Array
+  },
+  setup (props) {
+    return () => {
+      const error =
+        props.errors.find(e => e && e.statusCode === 404) || props.errors[0] || {}
+
+      const template = error.statusCode === 404
+        ? error404
+        : process.dev
+          ? errorDev
+          : error500
+
+      return templateToVNode(template({
+        ...error,
+        statusCode: error.statusCode || 500,
+        statusMessage: error.name,
+        description: error.message
+      }))
+    }
+  }
+}

--- a/packages/nuxt3/src/pages/runtime/page.vue
+++ b/packages/nuxt3/src/pages/runtime/page.vue
@@ -1,6 +1,9 @@
 <template>
   <RouterView v-slot="{ Component }">
-    <NuxtLayout v-if="Component" :name="layout || updatedComponentLayout || Component.type.layout">
+    <Suspense v-if="unhandledErrors.length" :key="$route.fullPath" @pending="() => onSuspensePending()" @resolve="() => onSuspenseResolved()">
+      <ErrorPage :errors="unhandledErrors" />
+    </Suspense>
+    <NuxtLayout v-else-if="Component" :name="layout || updatedComponentLayout || Component.type.layout">
       <transition name="page" mode="out-in">
         <!-- <keep-alive> -->
         <Suspense @pending="() => onSuspensePending(Component)" @resolve="() => onSuspenseResolved(Component)">
@@ -9,18 +12,20 @@
         <!-- <keep-alive -->
       </transition>
     </NuxtLayout>
-    <!-- TODO: Handle 404 placeholder -->
   </RouterView>
 </template>
 
 <script>
-import { getCurrentInstance, ref } from 'vue'
+import { ref } from 'vue'
 
 import NuxtLayout from './layout'
+import ErrorPage from '#build/error'
+import { useNuxtErrors } from '#app/composables/errors'
+import { useNuxtApp } from '#app'
 
 export default {
   name: 'NuxtPage',
-  components: { NuxtLayout },
+  components: { ErrorPage, NuxtLayout },
   props: {
     layout: {
       type: String,
@@ -31,20 +36,28 @@ export default {
     // Disable HMR reactivity in production
     const updatedComponentLayout = process.dev ? ref(null) : null
 
-    const { $nuxt } = getCurrentInstance().proxy
+    const nuxt = useNuxtApp()
 
     function onSuspensePending (Component) {
       if (process.dev) {
-        updatedComponentLayout.value = Component.type.layout || null
+        updatedComponentLayout.value = Component?.type?.layout || null
       }
-      return $nuxt.callHook('page:start', Component)
+      return nuxt.callHook('page:start', Component)
     }
 
     function onSuspenseResolved (Component) {
-      return $nuxt.callHook('page:finish', Component)
+      return nuxt.callHook('page:finish', Component)
     }
 
+    const { unhandledErrors, addError } = useNuxtErrors()
+
+    onErrorCaptured((e) => {
+      addError(e)
+      return false
+    })
+
     return {
+      unhandledErrors,
       updatedComponentLayout,
       onSuspensePending,
       onSuspenseResolved

--- a/yarn.lock
+++ b/yarn.lock
@@ -9263,6 +9263,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"example-with-errors@workspace:examples/with-errors":
+  version: 0.0.0-use.local
+  resolution: "example-with-errors@workspace:examples/with-errors"
+  dependencies:
+    nuxt3: latest
+  languageName: unknown
+  linkType: soft
+
 "example-with-layouts@workspace:examples/with-layouts":
   version: 0.0.0-use.local
   resolution: "example-with-layouts@workspace:examples/with-layouts"


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/559

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds basic error handling support for Nuxt3. It's not a complete implementation, and in fact may need to be somewhat reworked depending on how we want to integrate error handling across the entire stack.

For now:

* asyncData supports "handled" errors
* catches errors in plugins, router (404)
* renders error page within `RouterView`

Notably, we should update `@nuxt/design` to give us proper error `.vue` files (in lieu of user-customised ones) - and note that as the error files are rendered _within_ app.vue/layout it may be worth a more minimal design.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] Update `@nuxt/design` to give us proper error `.vue` files
- [ ] I have updated the documentation accordingly.
