### PR TITLE
chore: change `Nuxt3` to `Nuxt 3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://discord.nuxtjs.org/"><img src="https://badgen.net/badge/Discord/join-us/7289DA" alt="Discord"></a>
  </p>
 
-Welcome to Nuxt3 repository ✨
+Welcome to Nuxt 3 repository ✨
 
 <table>
 <tbody>

--- a/docs/content/4.community/1.getting-help.md
+++ b/docs/content/4.community/1.getting-help.md
@@ -24,6 +24,6 @@ And finally, just ask the question! There's no need to [ask permission to ask a 
 
 Something isn't working the way that the docs say that it should. You're not sure if it's a bug. You've searched through the open issues and discussions but you can't find anything.
 
-In that case, the best thing to do is to try to reproduce the bug in a minimal way, apart from the rest of your project. This is a great way to solve problems. There's [a Nuxt3 starter sandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v3) you can fire up in the browser for exactly this purpose.
+In that case, the best thing to do is to try to reproduce the bug in a minimal way, apart from the rest of your project. This is a great way to solve problems. There's [a Nuxt 3 starter sandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v3) you can fire up in the browser for exactly this purpose.
 
-Even if you can't create a minimal reproduction, [please do report the bug](/community/reporting-bugs). Nuxt3 is still in active development, and every issue helps make it better.
+Even if you can't create a minimal reproduction, [please do report the bug](/community/reporting-bugs). Nuxt 3 is still in active development, and every issue helps make it better.

--- a/docs/content/4.community/2.reporting-bugs.md
+++ b/docs/content/4.community/2.reporting-bugs.md
@@ -16,7 +16,7 @@ Search through the [open issues](https://github.com/nuxt/framework/issues) and [
 
 It's important to be able to reproduce the bug reliably - in a minimal way and apart from the rest of your project. This narrows down what could be causing the issue and makes it possible for someone not only to find the cause, but also to test a potential solution.
 
-Start with [this Nuxt3 sandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v3-sandbox) and add the **minimum** amount of code necessary to reproduce the bug you're experiencing.
+Start with [this Nuxt 3 sandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v3-sandbox) and add the **minimum** amount of code necessary to reproduce the bug you're experiencing.
 
 Once you've reproduced the issue, remove as much code from your reproduction as you can (while still recreating the bug). Time spent making the reproduction as minimal as possible will make a huge difference to whoever sets out to fix the issue.
 

--- a/docs/content/4.community/3.contribution.md
+++ b/docs/content/4.community/3.contribution.md
@@ -20,7 +20,7 @@ Before you fix a bug or add a feature, ensure there's an issue that describes it
 
 ### Setup your dev environment
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) the [Nuxt3 repository](https://github.com/nuxt/framework) to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
+1. [Fork](https://help.github.com/articles/fork-a-repo/) the [Nuxt 3 repository](https://github.com/nuxt/framework) to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 
 2. Run `yarn` to install the dependencies.
 

--- a/packages/bridge/src/meta.ts
+++ b/packages/bridge/src/meta.ts
@@ -23,7 +23,7 @@ export const setupMeta = async (opts: SetupMetaOptions) => {
   }
 
   if (nuxt.options.head && typeof nuxt.options.head === 'function') {
-    throw new TypeError(`${msgPrefix} The head() function in \`nuxt.config\` has been deprecated and in nuxt3 will need to be moved to \`app.vue\`. ${checkDocsMsg}`)
+    throw new TypeError(`${msgPrefix} The head() function in \`nuxt.config\` has been deprecated and in Nuxt 3 will need to be moved to \`app.vue\`. ${checkDocsMsg}`)
   }
 
   const runtimeDir = resolve(distDir, 'runtime/meta')

--- a/packages/nuxt3/src/app/legacy.ts
+++ b/packages/nuxt3/src/app/legacy.ts
@@ -128,11 +128,11 @@ export const legacyPlugin = (nuxt: NuxtApp) => {
     get (nuxt, p: keyof LegacyContext | keyof LegacyContext['ssrContext']) {
       // Unsupported keys
       if (unsupported.has(p)) {
-        return mock(`Accessing ${p} is not supported in Nuxt3.`)
+        return mock(`Accessing ${p} is not supported in Nuxt 3.`)
       }
 
       if (todo.has(p)) {
-        return mock(`Accessing ${p} is not yet supported in Nuxt3.`)
+        return mock(`Accessing ${p} is not yet supported in Nuxt 3.`)
       }
 
       // vue-router implementation
@@ -151,7 +151,7 @@ export const legacyPlugin = (nuxt: NuxtApp) => {
 
       if (p === '$config') {
         // TODO: needs implementation
-        return mock('Accessing runtime config is not yet supported in Nuxt3.')
+        return mock('Accessing runtime config is not yet supported in Nuxt 3.')
       }
 
       if (p === 'ssrContext') {


### PR DESCRIPTION
Change "Nuxt3" to "Nuxt 3" in docs and error messages

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

