### PR TITLE
fix: missing imports for `getCurrentInstance`

### DIFF
--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -1,4 +1,4 @@
-import { onBeforeMount, onUnmounted, ref } from 'vue'
+import { onBeforeMount, onUnmounted, ref, getCurrentInstance } from 'vue'
 import type { Ref } from 'vue'
 import { NuxtApp, useNuxtApp } from '#app'
 


### PR DESCRIPTION
fix nuxt/nuxt.js#11890 

I guess somehow we should exclude the auto-imports types on development (leave it for later)