### PR TITLE
docs: better update for `@nuxtjs/composition-api` replacement

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -106,7 +106,7 @@ Avoid the usage of `__dirname` and `__filename` as much as possible.
 - Remove `@nuxtjs/typescript-build`: Bridge enables same functionality
 - Remove `@nuxtjs/typescript-runtime` and `nuxt-ts`: Nuxt 2 has built-in runtime support
 - Remove `@nuxt/nitro`: Bridge injects same functionality
-- Remove `@nuxtjs/composition-api` from dependencies and modules. Bridge provides a Nuxt 3 compatible composition-api layer and help to remove dependency. Enjoy new auto import functionality and progressively migrate imports from `@nuxtjs/composition-api` to `#app`.
+- Remove `@nuxtjs/composition-api` from your dependencies (and from your modules in `nuxt.config`). Bridge provides a legacy composition API layer that handles imports within your files from `@nuxtjs/composition-api` until you've fully finished migrating to native Bridge/Nuxt 3 composables (which you will import from by `#app`, or via auto-imports).
 
 ### Ensure everything goes well
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The documentation currently suggest to remove `@nuxtjs/composition-api`. In this PR, it is clarified that the imports should come now from `@vue/composition-api`.

What is still unclear to me is how to replace some of the other features of the nuxtjs package like `useRouter` or `onGlobalSetup`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

