### PR TITLE
docs: update link to Netlify docs

### DIFF
--- a/docs/content/3.docs/3.deployment/4.netlify.md
+++ b/docs/content/3.docs/3.deployment/4.netlify.md
@@ -18,7 +18,7 @@ Nitro will auto-detect that you are in a [Netlify](https://www.netlify.com) envi
 
 ## Deployment
 
-Just push to your git repository [as you would normally for Netlify](https://docs.netlify.com/configure-builds/getting-started/).
+Just push to your git repository [as you would normally for Netlify](https://docs.netlify.com/configure-builds/get-started/).
 
 ## More information
 


### PR DESCRIPTION
### ❓ Fix wrong link in docs

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There was a wrong link in the Deployment/Netlify documentation page: https://docs.netlify.com/configure-builds/getting-started/ - it gives 404 error. 
I've changed it to https://docs.netlify.com/configure-builds/get-started/ - now it's fine :)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.