### PR TITLE
fix(bridge): add head type without circular type reference

### DIFF
--- a/packages/bridge/types.d.ts
+++ b/packages/bridge/types.d.ts
@@ -1,5 +1,6 @@
 import type {} from '@nuxt/nitro'
 import type { NuxtConfig as _NuxtConfig } from '@nuxt/kit'
+import type { ConfigSchema as _ConfigSchema } from '@nuxt/kit/schema/config'
 import type { MetaInfo } from 'vue-meta'
 
 export interface BridgeConfig {
@@ -18,14 +19,12 @@ export interface BridgeConfig {
 }
 
 // TODO: Also inherit from @nuxt/types.NuxtConfig for legacy type compat
-export interface NuxtConfig extends _NuxtConfig {
-  bridge?: Partial<BridgeConfig> | false
-  head?: _NuxtConfig['head'] | MetaInfo
-}
+export interface NuxtConfig extends _NuxtConfig {}
 
 declare module '@nuxt/kit' {
   interface ConfigSchema {
     bridge: BridgeConfig
+    head: _ConfigSchema['head'] | MetaInfo
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/bridge#264

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Redeclaring `ConfigScheme` does already add the props with the desired types in `NuxtConfig`
https://github.com/nuxt/framework/blob/645f8f93977a735b73b4ca40e2174246f3013cfa/packages/kit/src/types/config.ts#L19

There was a change by https://github.com/nuxt/framework/pull/844 but that does leave `head` not as good declared as before.

Resolves nuxt/bridge#264

### 📝 Checklist

- [xI have linked an issue or discussion.
- [] I have updated the documentation accordingly.
