### PR TITLE
fix(bridge): alias direct references to vue files

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -12,9 +12,11 @@ export function setupAppBridge (_options: any) {
   // Alias vue to a vue3-compat version of vue2
   nuxt.options.alias['#vue'] = nuxt.options.alias.vue || resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
   for (const alias of [
+    // vue 3 helper packages
     '@vue/shared',
     '@vue/reactivity',
     ...[
+      // vue 2 dist files
       'vue/dist/vue.common.dev',
       'vue/dist/vue.common',
       'vue/dist/vue.common.prod',


### PR DESCRIPTION
### 🔗 Linked issue

related to nuxt/bridge#226

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's perhaps an abundance of caution, but we can forestall some issues with packages importing direct files within `vue` by adding aliases.

Mind you, it's hiding the root cause, but as the root cause is in 3rd-party libraries we'll not always be able to control this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

