### PR TITLE
fix(docs): change module import in useState example

### DIFF
--- a/docs/content/3.docs/1.usage/2.state.md
+++ b/docs/content/3.docs/1.usage/2.state.md
@@ -23,7 +23,7 @@ useState<T>(key: string, init?: (()=>T)): Ref<T>
 In this example, we use a server-only plugin to find about request locale.
 
 ```ts [plugins/locale.server.ts]
-import { defineNuxtPlugin, useState } from '#app'
+import { defineNuxtPlugin, useState } from 'nuxt3'
 
 export default defineNuxtPlugin((nuxt) => {
   const locale = useState(


### PR DESCRIPTION
### 🔗 Linked issue
[586](https://github.com/johnsoncodehk/volar/issues/586) from volar

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the example from state, `defineNuxtPlugin` and `useState` is imported from #app module. It should be imported from nuxt3

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

