### PR TITLE
docs: add nuxt 2 note for public directory

### DIFF
--- a/docs/content/3.docs/2.directory-structure/11.public.md
+++ b/docs/content/3.docs/2.directory-structure/11.public.md
@@ -7,3 +7,7 @@ head.title: Public directory
 # Public directory
 
 The `public/` directory is directly served at server root and contains public files that have to keep their names (e.g. `robots.txt`) _or_ likely won't change (e.g. `favicon.ico`).
+
+::alert{icon=💡}
+This is known as the [`static/`](https://nuxtjs.org/docs/directory-structure/static) directory in Nuxt 2.
+::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

- NA

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

In Nuxt 2, we currently use `static/` as the default directory for serving public files. 
https://nuxtjs.org/docs/directory-structure/static

By changing the default name to `public/`, some users (including myself) may find it a bit confused at first when scanning through the directory structure.
https://v3.nuxtjs.org/docs/directory-structure/public

So it's probably better to have some additional information/explanation about this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.