### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/content/2.concepts/2.server-engine.md
+++ b/docs/content/2.concepts/2.server-engine.md
@@ -48,7 +48,7 @@ The server in Nuxt 2 is not standalone, but requires part of nuxt core to be inv
 
 This dist is generated when running `nuxt build` into a [`.output`](/docs/directory-structure/output) directory.
 
-The output is combined with both runtime code to run your Nuxt server in any environment (including experimental browser Service Workers!) and serve you static files, making it a true [hybrid framework](/concepts/hybrid-rendering) for the JAMStack. In addition, a native storage layer is implemented, supporting multi source, drivers and local assets.
+The output is combined with both runtime code to run your Nuxt server in any environment (including experimental browser Service Workers!) and serve you static files, making it a true hybrid framework for the Jamstack. In addition, a native storage layer is implemented, supporting multi source, drivers and local assets.
 
 ::alert{type="info" icon=IconCode}
 Checkout the Nitro engine on GitHub: [framework/packages/nitro](https://github.com/nuxt/framework/tree/main/packages/nitro)

--- a/docs/content/3.docs/1.usage/index.md
+++ b/docs/content/3.docs/1.usage/index.md
@@ -3,5 +3,5 @@ title: 'Usage'
 layout.aside: true
 layout.asideClass: ''
 navigation.collapse: false
-navigation.redirect: /docs/basics/introduction
+navigation.redirect: /docs/usage/data-fetching
 ---

--- a/docs/content/3.docs/2.directory-structure/6.layouts.md
+++ b/docs/content/3.docs/2.directory-structure/6.layouts.md
@@ -10,7 +10,7 @@ Nuxt provides a customizable layouts framework you can use throughout your appli
 
 Page layouts are placed in the `layouts/` directory and will be automatically loaded via asynchronous import when used. If you create a `layouts/default.vue` this will be used for all pages in your app. Other layouts are used by setting a `layout` property as part of your component options.
 
-If you have only single layout for application, you can alternatively use [app.vue](/docs/structure/app).
+If you have only single layout for application, you can alternatively use [app.vue](/docs/directory-structure/app).
 
 ### Example: a custom layout
 

--- a/docs/content/3.docs/2.directory-structure/8.modules.md
+++ b/docs/content/3.docs/2.directory-structure/8.modules.md
@@ -7,7 +7,7 @@ head.title: Local modules directory
 
 # Local modules directory
 
-Nuxt has a powerful [modules engine](/concepts/modules).
+Nuxt has a powerful modules engine
 
 # Creating Modules
 

--- a/docs/content/3.docs/3.deployment/5.pm2.md
+++ b/docs/content/3.docs/3.deployment/5.pm2.md
@@ -54,4 +54,4 @@ module.exports = {
 
 ## More information
 
-See [more information on the server preset](/presets/server).
+See [more information on the [server preset](/docs/deployment/presets/server).

--- a/docs/content/3.docs/3.deployment/index.md
+++ b/docs/content/3.docs/3.deployment/index.md
@@ -5,5 +5,5 @@ layout:
 navigation:
   collapse: false
   exclusive: false
-  redirect: /docs/deployment/azure
+  redirect: /docs/deployment/presets
 ---

--- a/docs/scripts/nuxt.config.md
+++ b/docs/scripts/nuxt.config.md
@@ -14,6 +14,6 @@ export default {
 }
 ```
 
-Learn more about all the different [config properties](/docs/config)
+Learn more about all the different config properties
 
 <!-- GENERATED_CONFIG_DOCS -->


### PR DESCRIPTION
Fixes a load of broken links in the docs. I've tried to edit them to point to either the correct link or an alternative. If there's no alternative that makes sense, I've removed the link.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

