### PR TITLE
fix(nuxt3): enable auto-imports for sfc script with type

### DIFF
--- a/packages/nuxt3/src/auto-imports/transform.ts
+++ b/packages/nuxt3/src/auto-imports/transform.ts
@@ -15,7 +15,6 @@ const importAsRE = /^.*\sas\s+/
 const seperatorRE = /[,[\]{}\n]/g
 const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
 const singlelineCommentsRE = /^\s*\/\/.*$/gm
-const vueScriptLangRe = /(\?|&)type=script&(.*&)?lang\.((c|m)?j|t)sx?(&|$)/
 
 function stripeComments (code: string) {
   return code
@@ -31,7 +30,7 @@ export const TransformPlugin = createUnplugin((map: IdentifierMap) => {
     enforce: 'post',
     transformInclude (id) {
       const { pathname, search } = parseURL(id)
-      const query = parseQuery(search)
+      const { type } = parseQuery(search)
 
       if (id.includes('node_modules')) {
         return false
@@ -40,7 +39,7 @@ export const TransformPlugin = createUnplugin((map: IdentifierMap) => {
       // vue files
       if (
         pathname.endsWith('.vue') &&
-        (query.type === 'template' || !search || vueScriptLangRe.test(search))
+        (type === 'template' || type === 'script' || !search)
       ) {
         return true
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Found this issue locally

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

auto-import transform is not enabled for script with type attribute like:

```vue
<script lang="jsx">
export default defineComponent({})
</script>

<script lang="ts">
export default defineComponent({})
</script>

<script lang="tsx">
export default defineComponent({})
</script>
```

This pr is adding corresponding checking in auto-imports transform plugin.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

