### PR TITLE
fix(kit): pass `options` object to lodash templates

### DIFF
--- a/packages/kit/src/module/utils.ts
+++ b/packages/kit/src/module/utils.ts
@@ -259,7 +259,7 @@ export function addVitePlugin (plugin: VitePlugin, options?: ExtendViteConfigOpt
 }
 
 export async function compileTemplate (template: NuxtTemplate, ctx: any) {
-  const data = { ...ctx, ...template.options }
+  const data = { ...ctx, options: template.options }
   if (template.src) {
     try {
       const srcContents = await fsp.readFile(template.src, 'utf-8')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as nuxt/framework#123 -->
Resolves [#936](https://github.com/nuxt/nuxt.js/issues/11962)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This change improves Developer Experience.

Simplifies passing options for a plugin to be interpolated by lodash.template

example: allows you to simply pass moduleOptions like so
```
export default defineNuxtModule({
  configKey: 'example',
  setup(options) {
    addPluginTemplate({
      src: path.resolve(__dirname, 'plugin.ts'),
      mode: 'client',
      options,
    })
  },
})
```
or even `options: { ...options }`. As opposed to **requiring it to be passed like this** `options: { options },` 
<!-- Why is this change required? What problem does it solve? -->

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves nuxt/framework#1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

