### PR TITLE
chore: alias types for `@nuxt/kit` src

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
       ],
       "#app/*": [
         "./packages/nuxt3/src/app/*"
+      ],
+      "@nuxt/kit": [
+        "./packages/kit/src/index"
       ]
     }
   },


### PR DESCRIPTION
Not really sure why, but my VS Code can't find declarations for `@nuxt/kit`, probably because #820? But either way I guess it makes sense to alias the local package for typing in developement.