### PR TITLE
fix(kit): add missing nuxt hooks types

### DIFF
--- a/packages/kit/src/types/hooks.ts
+++ b/packages/kit/src/types/hooks.ts
@@ -1,5 +1,4 @@
 import type { IncomingMessage, ServerResponse } from 'http'
-import type { HookCallback } from 'hookable'
 import type { Compiler, Configuration, Stats } from 'webpack'
 import type { NuxtConfig, NuxtOptions } from '..'
 import type { ModuleContainer } from '../module/container'
@@ -29,14 +28,12 @@ type RenderResult = {
 // https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
 export type TSReference = { types: string } | { path: string }
 
-export interface NuxtHooks extends Record<string, HookCallback> {
+export interface NuxtHooks {
   // nuxt3
   'app:resolve': (app: NuxtApp) => HookResult
   'app:templates': (app: NuxtApp) => HookResult
   'app:templatesGenerated': (app: NuxtApp) => HookResult
   'builder:generateApp': () => HookResult
-  'components:dirs': (dirs: string[]) => HookResult
-  'components:extend': (components: any[]) => HookResult
 
   // @nuxt/builder
   'build:before':

--- a/packages/nuxt3/src/components/types.ts
+++ b/packages/nuxt3/src/components/types.ts
@@ -51,7 +51,7 @@ declare module '@nuxt/kit' {
   interface NuxtOptions {
     components: boolean | Options | Options['dirs']
   }
-  interface NuxtOptionsHooks {
+  interface NuxtHooks {
     'components:dirs'?: componentsDirHook
     'components:extend'?: componentsExtendHook
     components?: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Remove loose type `Record<string, HookCallback>` on nuxt hooks and add all missing hooks definition.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

