### PR TITLE
docs: Exclude Nuxt build folder from git for migration to nuxt bridge

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -108,6 +108,10 @@ Avoid the usage of `__dirname` and `__filename` as much as possible.
 - Remove `@nuxt/nitro`: Bridge injects same functionality
 - Remove `@nuxtjs/composition-api`: Bridge provides a Nuxt 3 compatible composition-api layer and help to remove dependency
 
+### Exclude Nuxt build folder from git
+
+Add the folder `.output` to the `.gitignore` file.
+
 ### Ensure everything goes well
 
 ✔️ Try with `nuxt dev` and `nuxt build` (or `nuxt generate`) to see if everything goes well.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt now generates an `.output` folder during build, so this should be added to the gitignore file.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

