### PR TITLE
fix(webpack): support jsx syntax in esbuild

### DIFF
--- a/packages/webpack/src/presets/esbuild.ts
+++ b/packages/webpack/src/presets/esbuild.ts
@@ -13,7 +13,7 @@ export function esbuild (ctx: WebpackConfigContext) {
 
   config.module.rules.push(
     {
-      test: /\.m?[jt]s?$/i,
+      test: /\.m?[jt]s$/i,
       loader: 'esbuild-loader',
       exclude: (file) => {
         file = file.split('node_modules', 2)[1]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as nuxt/framework#123 -->

nuxt/bridge#17

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves nuxt/framework#1337" -->

`.jsx` file is built as `ts` loader in esbuild, this pr is moving it to `tsx` for supporting jsx syntax.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

