### PR TITLE
fix(vite): set root to `srcDir`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -26,7 +26,7 @@ export async function bundle (nuxt: Nuxt) {
     config: vite.mergeConfig(
       nuxt.options.vite as any || {},
       {
-        root: nuxt.options.rootDir,
+        root: nuxt.options.srcDir,
         mode: nuxt.options.dev ? 'development' : 'production',
         logLevel: 'warn',
         define: {


### PR DESCRIPTION
### 🔗 Linked issue

* resolves nuxt/nuxt.js#12001
* resolves nuxt/nuxt.js#12011

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite `publicDir` is set by default to `<root>/public` which fails with custom `srcDir`. This PR changes that root directory (though another valid fix would be to set `publicDir` directly if for some reason we want the root not to be at the same place as `srcDir`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

