### PR TITLE
fix(bridge): add vuex alias

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -9,6 +9,9 @@ export function setupAppBridge (_options: any) {
   nuxt.options.alias['#app'] = resolve(distDir, 'runtime/index.mjs')
   nuxt.options.alias['#build'] = nuxt.options.buildDir
 
+  // Alias vuex to its esm version, as vuex.mjs currently exports cjs: https://github.com/vuejs/vuex/pull/2073
+  nuxt.options.alias.vuex = 'vuex/dist/vuex.esm.js'
+
   // Alias vue to a vue3-compat version of vue2
   nuxt.options.alias['#vue'] = nuxt.options.alias.vue || resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
   for (const alias of [


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/bridge#242

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**This is a hotfix.**

With our new enhanced resolve for bridge, we're now resolving the `.mjs` build for vuex, which is exporting the vuex `.cjs` build. (Upstream PR: https://github.com/vuejs/vuex/pull/2073).

This then triggers what seems to be a Babel issue (**note**: not an issue with our typescript plugin). I'm tracking down the root cause but putting up this PR in the mean time. (Feel free to mark pending until I confirm root issue.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

