### PR TITLE
fix(nuxi): explicitly set listen options only when they are provided

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -3,6 +3,7 @@ import chokidar from 'chokidar'
 import debounce from 'p-debounce'
 import type { Nuxt } from '@nuxt/kit'
 import consola from 'consola'
+import { ListenOptions } from 'listhen'
 import { createServer, createLoadingHandler } from '../utils/server'
 import { showBanner } from '../utils/banner'
 import { writeTypes } from '../utils/prepare'
@@ -17,21 +18,25 @@ export default defineNuxtCommand({
   },
   async invoke (args) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development'
-    const https = !!(args['ssl-cert'] && args['ssl-key'])
     const server = createServer()
-    const listener = await server.listen({
+    const listenOptions: Partial<ListenOptions> = {
       clipboard: args.clipboard,
-      open: args.open || args.o,
-      port: args.port || args.p,
-      hostname: args.host || args.h,
-      ...(https && {
-        https,
-        certificate: {
-          cert: args['ssl-cert'],
-          key: args['ssl-key']
-        }
-      })
-    })
+      open: args.open || args.o
+    }
+    if (args.port || args.p) {
+      listenOptions.port = args.port || args.p
+    }
+    if (args.host || args.h) {
+      listenOptions.hostname = args.host || args.h
+    }
+    if (args['ssl-cert'] && args['ssl-key']) {
+      listenOptions.https = true
+      listenOptions.certificate = {
+        cert: args['ssl-cert'],
+        key: args['ssl-key']
+      }
+    }
+    const listener = await server.listen(listenOptions)
 
     const rootDir = resolve(args._[0] || '.')
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt.js#11977

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This avoids setting undefined properties by checking first. Alternatively, we could filter object.entries.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

