### PR TITLE
refactor(nuxt3): export NuxtConfig for convenience (resolves #1038)

### DIFF
--- a/packages/nuxt3/src/core/nuxt.ts
+++ b/packages/nuxt3/src/core/nuxt.ts
@@ -84,3 +84,6 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 export function defineNuxtConfig (config: NuxtConfig): NuxtConfig {
   return config
 }
+
+// For a convenience import together with `defineNuxtConfig`
+export type { NuxtConfig }


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/nuxt.js#12005

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Additionally export the `NuxtConfig` type in `nuxt3` package, to allow imports (like in @nuxt/bridge) in `nuxt.config.ts` like these:
```ts
// possible
import { defineNuxtConfig, NuxtConfig } from '@nuxt/bridge'
// not possible now
import { defineNuxtConfig, NuxtConfig } from 'nuxt3'

const config: NuxtConfig = {
  // ...
}

// some conditional stuff that modifies `config`

export default defineNuxtConfig(config)
```

Resolves nuxt/nuxt.js#12005

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

