### PR TITLE
refactor(nitro): move wasm support behind a flag (`nitro.experiments.wasm`)

### DIFF
--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -35,6 +35,9 @@ export interface NitroContext {
   esbuild?: {
     options?: EsbuildOptions
   }
+  experiments?: {
+    wasm?: boolean
+  }
   moduleSideEffects: string[]
   renderer: string
   serveStatic: boolean
@@ -94,6 +97,7 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
     node: undefined,
     preset: undefined,
     rollupConfig: undefined,
+    experiments: {},
     moduleSideEffects: ['unenv/runtime/polyfill/'],
     renderer: undefined,
     serveStatic: undefined,

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -143,7 +143,9 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
   rollupConfig.plugins.push(raw())
 
   // WASM import support
-  rollupConfig.plugins.push(wasmPlugin())
+  if (nitroContext.experiments.wasm) {
+    rollupConfig.plugins.push(wasmPlugin())
+  }
 
   // https://github.com/rollup/plugins/tree/master/packages/replace
   rollupConfig.plugins.push(replace({


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/692

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Until we stabilize .wasm support in nitro, this PR moves support behind a flag. You can enable .wasm support by enabling `nitro.experiments.wasm` in your `nuxt.config`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

