### PR TITLE
fix(nitro): enable externals for `azure` and `firebase` presets

### DIFF
--- a/packages/nitro/src/presets/azure.ts
+++ b/packages/nitro/src/presets/azure.ts
@@ -7,6 +7,7 @@ import { NitroPreset, NitroContext } from '../context'
 
 export const azure: NitroPreset = {
   entry: '{{ _internal.runtimeDir }}/entries/azure',
+  externals: true,
   output: {
     serverDir: '{{ output.dir }}/server/functions'
   },

--- a/packages/nitro/src/presets/azure_functions.ts
+++ b/packages/nitro/src/presets/azure_functions.ts
@@ -9,6 +9,7 @@ import { NitroPreset, NitroContext } from '../context'
 export const azure_functions: NitroPreset = {
   serveStatic: true,
   entry: '{{ _internal.runtimeDir }}/entries/azure_functions',
+  externals: true,
   hooks: {
     async 'nitro:compiled' (ctx: NitroContext) {
       await writeRoutes(ctx)

--- a/packages/nitro/src/presets/firebase.ts
+++ b/packages/nitro/src/presets/firebase.ts
@@ -9,6 +9,7 @@ import { NitroPreset, NitroContext } from '../context'
 
 export const firebase: NitroPreset = {
   entry: '{{ _internal.runtimeDir }}/entries/firebase',
+  externals: true,
   hooks: {
     async 'nitro:compiled' (ctx: NitroContext) {
       await writeRoutes(ctx)


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt.js#12039

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When `node-fetch` is inlined, it breaks the polyfilling of `fetch` (just try with `nitro.externals: false`). This will need to be resolved (or identified).

However, we should be supporting externals for these presets in any case, and that solves the immediate issue.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

