### PR TITLE
fix(kit): support modern builds with extendWebpackConfig

### DIFF
--- a/packages/kit/src/module/utils.ts
+++ b/packages/kit/src/module/utils.ts
@@ -223,6 +223,7 @@ export function extendWebpackConfig (
         fn(config)
       }
     }
+    // Nuxt 2 backwards compatibility
     if (options.modern !== false) {
       const config = configs.find(i => i.name === 'modern')
       if (config) {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Not exactly sure what the plan for modern builds is with bridge & nuxt 3, but this fix is needed to provide backwards compatibility. 

Had to [revert my code to the hook](https://github.com/windicss/nuxt-windicss-module/pull/121/commits/3d3d024e0a3115b09bf7e3972b96aeb7d374dcdb#diff-a3c63c4762b83e9eba4310e5226b76c3128e5a41d5b51565b6bda1f86a17b351L174) to get around it for the time being if you need some more context.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

