### PR TITLE
docs: add warning that pages need single root element

### DIFF
--- a/docs/content/3.docs/2.directory-structure/9.pages.md
+++ b/docs/content/3.docs/2.directory-structure/9.pages.md
@@ -10,6 +10,10 @@ The `pages/` directory is optional, meaning that if you only use [app.vue](/docs
 
 Nuxt will automatically integrate [Vue Router](https://next.router.vuejs.org/) and map `pages/` directory into the routes of your application.
 
+::alert{type=warning}
+Unlike components, your pages must have a single root element to allow Nuxt to apply route transitions between pages.
+::
+
 ## Dynamic Routes
 
 If you place anything within square brackets, it will be turned into a [dynamic route](https://next.router.vuejs.org/guide/essentials/dynamic-matching.html) parameter. You can mix and match multiple parameters and even non-dynamic text within a file name or directory.


### PR DESCRIPTION
### 🔗 Linked issue

closes nuxt/nuxt.js#12088

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As currently implemented, pages need a single root element or there are issues when navigating backwards/forwards throughout an app (not to mention a warning in the browser dev console).

I prefer the user to have to wrap a page in a single root element because it means they are more in control of the HTML structure of their app, but we could also change this behaviour by automatically wrapping pages in a div (though the element name and attributes will then be out of the user's control).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

