### PR TITLE
fix(nitro): disable automatic spa fallback

### DIFF
--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -42,10 +42,7 @@ const getSPARenderer = cachedResult(async () => {
 
 function renderToString (ssrContext) {
   const getRenderer = (NUXT_NO_SSR || ssrContext.noSSR) ? getSPARenderer : getSSRRenderer
-  return getRenderer().then(renderToString => renderToString(ssrContext)).catch((err) => {
-    console.warn('Server Side Rendering Error:', err)
-    return getSPARenderer().then(renderToString => renderToString(ssrContext))
-  })
+  return getRenderer().then(renderToString => renderToString(ssrContext))
 }
 
 export async function renderMiddleware (req, res: ServerResponse) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

At the moment if there is any server-side rendering error, nitro reverts to a SPA fallback meaning there is no indication on client-side of any issue.

This PR means that Nitro will serve instead the SSR error page.

More to come: https://github.com/nuxt/framework/discussions/559