### PR TITLE
fix(nuxt3): added missing `dev` to `process` shims

### DIFF
--- a/packages/nuxt3/src/app/types/shims.d.ts
+++ b/packages/nuxt3/src/app/types/shims.d.ts
@@ -6,6 +6,7 @@ declare global {
     interface Process {
       browser: boolean
       client: boolean
+      dev: boolean
       mode: 'spa' | 'universal'
       server: boolean
       static: boolean


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Such small change, wasn't sure if it needs one.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added missing property to the process shim file to typehint the the existence of `dev` key.

However when running dev and `console.log(process)` I only get `client`, `dev` and `server` properties. Does that mean the rest should be marked as optional?
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

