### PR TITLE
fix(bridge): add `useState` to auto-imports

### DIFF
--- a/packages/bridge/src/auto-imports.ts
+++ b/packages/bridge/src/auto-imports.ts
@@ -15,7 +15,8 @@ const identifiers = {
     'defineNuxtPlugin',
     'useRoute',
     'useRouter',
-    'useRuntimeConfig'
+    'useRuntimeConfig',
+    'useState'
   ],
   '#meta': [
     'useMeta'


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/bridge#236

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds `useState` to the auto-imports list for bridge (to match nuxt3)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

