### PR TITLE
fix(nitro): read firebase package.json

### DIFF
--- a/packages/nitro/src/utils/index.ts
+++ b/packages/nitro/src/utils/index.ts
@@ -134,8 +134,16 @@ export function readPackageJson (
     return _require(`${packageName}/package.json`)
   } catch (error) {
     if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-      const [pkgModulePath] = /^(.*\/node_modules\/).*$/.exec(_require.resolve(packageName))
-      return fse.readJSONSync(resolve(pkgModulePath, packageName, 'package.json'))
+      const pkgModulePaths = /^(.*\/node_modules\/).*$/.exec(_require.resolve(packageName))
+      for (const pkgModulePath of pkgModulePaths) {
+        const path = resolve(pkgModulePath, packageName, 'package.json')
+        if (fse.existsSync(path)) {
+          return fse.readJSONSync(path)
+        }
+        continue
+      }
+
+      throw error
     }
     throw error
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
Fix: nuxt/nuxt.js#12125

<!-- Please ensure there is an open issue and mention its number as nuxt/framework#123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description
There was a bug in the regular expression part of readPackageJson. .exec returns an array. 
The cause of the bug was that there was more than one response to exec. The following is the output result of the error. This resulted in a package not found error.
```js
pkgModulePaths:                                                                                                                                                               09:47:18
[                                                                                                                                                                             09:47:18
  '<your-dir-path>/node_modules/firebase-admin/lib/index.js',
  '<your-dir-path>/node_modules/',
  index: 0,
  input: '<your-dir-path>/node_modules/firebase-admin/lib/index.js',
  groups: undefined
]
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves nuxt/framework#1337" -->