### PR TITLE
docs(kit): add `css` back to kit v3 schema

### DIFF
--- a/packages/kit/src/config/schema/_app.ts
+++ b/packages/kit/src/config/schema/_app.ts
@@ -182,6 +182,7 @@ export default {
    * ]
    * ```
    * @version 2
+   * @version 3
    */
   css: [],
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since https://github.com/nuxt/framework/pull/418, we support `css` option in Nuxt 3. This PR adds correct version tag back to schema, which will also restore it to the v3 docs.

