### PR TITLE
fix(nuxt3): add missing `build:before` hook

### DIFF
--- a/packages/nuxt3/src/core/builder.ts
+++ b/packages/nuxt3/src/core/builder.ts
@@ -23,6 +23,7 @@ export async function build (nuxt: Nuxt) {
     nuxt.hook('builder:generateApp', () => generateApp(nuxt, app))
   }
 
+  await nuxt.callHook('build:before', { nuxt })
   await bundle(nuxt)
   await nuxt.callHook('build:done', { nuxt })
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems `build:before` is never called in Nuxt 3.
This adds the corresponding `nuxt.callHook` in builder.ts

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
