### PR TITLE
fix(nuxt3): correct compoennts hooks parameters types

### DIFF
--- a/packages/nuxt3/src/components/types.ts
+++ b/packages/nuxt3/src/components/types.ts
@@ -39,13 +39,13 @@ export interface ComponentsDir extends ScanDir {
   transpile?: 'auto' | boolean
 }
 
-type componentsDirHook = (dirs: ComponentsDir[]) => void | Promise<void>
-type componentsExtendHook = (components: (ComponentsDir | ScanDir)[]) => void | Promise<void>
-
 export interface Options {
   dirs: (string | ComponentsDir)[]
   loader: Boolean
 }
+
+type componentsDirHook = (dirs: Options['dirs']) => void | Promise<void>
+type componentsExtendHook = (components: (Component | ComponentsDir | ScanDir)[]) => void | Promise<void>
 
 declare module '@nuxt/kit' {
   interface NuxtOptions {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

`'components:dirs'` and 'components:extend'` can also accept `stirng[]` and `Component[]`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

