### PR TITLE
fix(nux3): use murmurhash for fetchKey

### DIFF
--- a/packages/nuxt3/package.json
+++ b/packages/nuxt3/package.json
@@ -34,6 +34,7 @@
     "hookable": "^5.0.0",
     "ignore": "^5.1.8",
     "mlly": "^0.2.10",
+    "murmurhash-es": "^0.1.1",
     "nuxi": "3.0.0",
     "ohmyfetch": "^0.3.1",
     "pathe": "^0.2.0",

--- a/packages/nuxt3/src/app/composables/fetch.ts
+++ b/packages/nuxt3/src/app/composables/fetch.ts
@@ -1,5 +1,6 @@
 import type { FetchOptions } from 'ohmyfetch'
 import type { $Fetch } from '@nuxt/nitro'
+import { murmurHashV3 } from 'murmurhash-es'
 import type { AsyncDataOptions, _Transform, KeyOfRes } from './asyncData'
 import { useAsyncData } from './asyncData'
 
@@ -35,10 +36,9 @@ export function useFetch<
     opts.key = generateKey(keys)
   }
 
-  return useAsyncData('$f' + opts.key, () => $fetch(url, opts) as Promise<ResT>, opts)
+  return useAsyncData(opts.key, () => $fetch(url, opts) as Promise<ResT>, opts)
 }
 
-// TODO: More predictable universal hash
 function generateKey (keys) {
-  return JSON.stringify(keys).replace(/[{":}=/,]|https?:\/\//g, '_').replace(/_+/g, '_')
+  return '$f' + murmurHashV3(JSON.stringify(keys))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13086,6 +13086,13 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
+"murmurhash-es@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "murmurhash-es@npm:0.1.1"
+  checksum: 3f5aa267161b21ad5b52f4b240ecd40014f21256114fad4b196202a8079ab08af8cdf5e7136caa591846232edc4222ba790ce300b8a6de6085e68e229da26766
+  languageName: node
+  linkType: hard
+
 "mustache@npm:^2.3.0":
   version: 2.3.2
   resolution: "mustache@npm:2.3.2"
@@ -13815,6 +13822,7 @@ fsevents@~2.3.2:
     hookable: ^5.0.0
     ignore: ^5.1.8
     mlly: ^0.2.10
+    murmurhash-es: ^0.1.1
     nuxi: 3.0.0
     ohmyfetch: ^0.3.1
     pathe: ^0.2.0


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves nuxt/nuxt.js#11948

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use a more secure and compact hash for fetch-key (https://github.com/unjs/murmurhash-es)

- Previews payload key: `_u_api_hello_p_foo_bar_`
- New payload key: `$f253430140`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

