### PR TITLE
fix(kit): improve `ScanDir` type

### DIFF
--- a/packages/kit/src/types/components.ts
+++ b/packages/kit/src/types/components.ts
@@ -67,11 +67,18 @@ export interface ScanDir {
 }
 
 export interface ComponentsDir extends ScanDir {
+  /**
+   * Watch specified path for changes, including file additions and file deletions.
+   */
   watch?: boolean
   /**
    * Extensions supported by Nuxt builder.
    */
   extensions?: string[]
+  /**
+   * Transpile specified path using build.transpile.
+   * By default ('auto') it will set transpile: true if node_modules/ is in path.
+   */
   transpile?: 'auto' | boolean
 }
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

ScanDir type was missing `isAsync` property.

I also added comments on this ScanDir type from @nuxt/components docs so we get them from autocomplete in `nuxt.config`.