### PR TITLE
docs(TypeScript): Required dependency for TypeScript users

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -51,6 +51,18 @@ npm install -D @nuxt/bridge@npm:@nuxt/bridge-edge
 ```
 ::
 
+### _Optional: Update TypeScript Support_
+For TypeScript users you will need to update your types dependencies based on the documentation available at https://typescript.nuxtjs.org/guide/setup
+
+::code-group
+```bash [Yarn]
+yarn add --dev @nuxt/types@npm:@nuxt/types-edge
+```
+```bash [NPM]
+npm install --save-dev @nuxt/types@npm:@nuxt/types-edge
+```
+::
+
 ### Update your scripts
 
 You will also need to update your scripts within your `package.json` to reflect the fact that Nuxt will now produce a Nitro server as build output.


### PR DESCRIPTION
This updates the documentation to reflect a required dependency for TypeScript update.

### 🔗 Linked issue
Resolves nuxt/bridge#300

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds documentation cross-referencing an updated Types version requirement from Nuxt TypeScript documentation (at https://typescript.nuxtjs.org/guide/setup). This action is required for TypeScript users to properly support production deployments, especially when bridge: false is set.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

