### PR TITLE
fix(nuxt3): type inference for `FetchResult`

### DIFF
--- a/packages/nuxt3/src/app/composables/fetch.ts
+++ b/packages/nuxt3/src/app/composables/fetch.ts
@@ -1,11 +1,11 @@
-import type { FetchOptions } from 'ohmyfetch'
+import type { FetchOptions, FetchRequest } from 'ohmyfetch'
 import type { $Fetch } from '@nuxt/nitro'
 import { murmurHashV3 } from 'murmurhash-es'
 import type { AsyncDataOptions, _Transform, KeyOfRes } from './asyncData'
 import { useAsyncData } from './asyncData'
 
 export type Awaited<T> = T extends Promise<infer U> ? U : T
-export type FetchResult<ReqT extends string> = Awaited<ReturnType<$Fetch<unknown, ReqT>>>
+export type FetchResult<ReqT extends FetchRequest> = Awaited<ReturnType<$Fetch<unknown, ReqT>>>
 
 export type UseFetchOptions<
   DataT,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

closes nuxt/nuxt.js#12196

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Changing ReqT to extend `FetchRequest` rather than just `string` needed this change to be followed through everywhere for inference to work properly

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

