### PR TITLE
fix(vite): forward default export for external packages

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -64,7 +64,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
 
   if (await isExternal(opts, id)) {
     return {
-      code: `(global, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) => import('${(pathToFileURL(id))}').then(r => { ssrExportAll(r) })`,
+      code: `(global, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) => import('${(pathToFileURL(id))}').then(r => { exports.default = r.default; ssrExportAll(r) })`,
       deps: [],
       dynamicDeps: []
     }


### PR DESCRIPTION
The correct fix for #823 https://github.com/nuxt/framework/pull/823#issuecomment-941314168 and part of #939

The root cause is that, the plugin `runtime/app/nitro.client.mjs` has the following content: 

```js
import { $fetch } from 'ohmyfetch'

if (!globalThis.$fetch) {
  globalThis.$fetch = $fetch
}

export default () => {}
```

While the `plugins/server.mjs` been resolved to:

```js
__vite_ssr_exports__.default = [
  __vite_ssr_import_0__.default,
  __vite_ssr_import_1__.default,
  __vite_ssr_import_2__.default,
  __vite_ssr_import_3__.default // <--
];
```

Which we don't forward the default export and cause the plugin to be undefined.