### PR TITLE
docs: clarify composable default name inference

### DIFF
--- a/docs/content/3.docs/2.directory-structure/5.composables.md
+++ b/docs/content/3.docs/2.directory-structure/5.composables.md
@@ -24,7 +24,7 @@ Example: (using default export)
 ```js [composables/use-foo.ts or composables/useFoo.ts]
 import { useState } from '#app'
 
-// It will be available as useFoo() based on the file name
+// It will be available as useFoo() (pascalCase of file name without extension)
 export default function () {
   return 'bar'
 }


### PR DESCRIPTION
Changed the second example to more closely resemble the first example for easy comparison. Also added that the name of the composition is based on the file name.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

None

### ❓ Type of change


- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Changed the return value of the second example to more closely resemble the first example for easy comparison. 
- Added that the name of the composition in the second example is base on the file name.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

