### PR TITLE
fix(kit): use native import for esm nuxt modules

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,4 +1,4 @@
-import { resolveModule, requireModule } from '../utils/cjs'
+import { resolveModule, requireModule, importModule } from '../utils/cjs'
 import { resolveAlias } from '../utils/resolve'
 import type { LegacyNuxtModule, NuxtModule, ModuleMeta, ModuleInstallOptions, ModuleOptions, ModuleSrc } from '../types/module'
 import type { Nuxt } from '../types/nuxt'
@@ -32,7 +32,9 @@ export async function installModule (nuxt: Nuxt, installOpts: ModuleInstallOptio
   let handler: LegacyNuxtModule
   if (typeof src === 'string') {
     const _src = resolveModule(resolveAlias(src, nuxt.options.alias), { paths: nuxt.options.modulesDir })
-    handler = requireModule(_src)
+    // TODO: also check with type: 'module' in closest `package.json`
+    const isESM = _src.endsWith('.mjs') || meta.isESM
+    handler = isESM ? await importModule(_src) : requireModule(_src)
     if (!meta.name) {
       meta.name = src
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

nuxt/nuxt.js#12269

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows using native ESM modules without depending on `jiti` for nuxt modules with an explicit `.mjs` entry or `{ isESM }` meta for nuxt3


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

