### PR TITLE
fix(nitro): omit `/index` from generated api urls

### DIFF
--- a/packages/nitro/src/server/middleware.ts
+++ b/packages/nitro/src/server/middleware.ts
@@ -24,7 +24,12 @@ export interface ServerMiddleware {
 
 function filesToMiddleware (files: string[], baseDir: string, basePath: string, overrides?: Partial<ServerMiddleware>): ServerMiddleware[] {
   return files.map((file) => {
-    const route = joinURL(basePath, file.substr(0, file.length - extname(file).length))
+    const route = joinURL(
+      basePath,
+      file
+        .substr(0, file.length - extname(file).length)
+        .replace(/\/index$/, '')
+    )
     const handle = resolve(baseDir, file)
     return {
       route,

--- a/test/fixtures/basic/server/api/hey/index.ts
+++ b/test/fixtures/basic/server/api/hey/index.ts
@@ -1,0 +1,1 @@
+export default () => 'Hey API'

--- a/test/fixtures/bridge/server/api/hey/index.ts
+++ b/test/fixtures/bridge/server/api/hey/index.ts
@@ -1,0 +1,1 @@
+export default () => 'Hey API'

--- a/test/presets/_tests.mjs
+++ b/test/presets/_tests.mjs
@@ -66,7 +66,9 @@ export function testNitroBehavior(_ctx, getHandler) {
   })
 
   it('API Works', async () => {
-    const { data } = await handler({ url: '/api/hello' })
-    expect(destr(data)).to.have.string('Hello API')
+    const { data: helloData } = await handler({ url: '/api/hello' })
+    const { data: heyData } = await handler({ url: '/api/hey' })
+    expect(destr(helloData)).to.have.string('Hello API')
+    expect(destr(heyData)).to.have.string('Hey API')
   })
 }


### PR DESCRIPTION
Signed-off-by: Francisco Buceta <frbuceta@gmail.com>

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves nuxt/nuxt.js#12299" -->

Resolves nuxt/nuxt.js#11934 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

