### PR TITLE
feat(kit): add `registerComponentDirectory` helper

### DIFF
--- a/packages/kit/src/module/utils.ts
+++ b/packages/kit/src/module/utils.ts
@@ -295,11 +295,11 @@ export async function compileTemplate (template: NuxtTemplate, ctx: any) {
  *
  * Requires Nuxt 2.13+
  */
-export function addComponentsDirectory (directory: ComponentsDir) {
+export function addComponentsDir (dir: ComponentsDir) {
   const nuxt = useNuxt()
   ensureNuxtCompatibility({ nuxt: '>=2.13' }, nuxt)
   nuxt.options.components = nuxt.options.components || []
-  nuxt.hook('components:dirs', (dirs) => { dirs.push(directory) })
+  nuxt.hook('components:dirs', (dirs) => { dirs.push(dir) })
 }
 
 const serialize = (data: any) => JSON.stringify(data, null, 2).replace(/"{(.+)}"/g, '$1')


### PR DESCRIPTION

### 🔗 Linked issue

* resolves nuxt/nuxt.js#10950

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a utility to register a components directory. If Nuxt 2, it will also enable `@nuxt/components` (though only for the registered directory, and any directories added by other modules, rather than globally).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

