### PR TITLE
fix(pkg): remove vue 3 from peerDependencies

### DIFF
--- a/packages/nitro/build.config.ts
+++ b/packages/nitro/build.config.ts
@@ -17,7 +17,6 @@ export default defineBuildConfig({
     'ohmyfetch',
     'ora',
     'vue-bundle-renderer',
-    'vue-server-renderer',
-    'vue'
+    'vue-server-renderer'
   ]
 })

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -78,14 +78,6 @@
     "unbuild": "latest",
     "vue": "3.2.20"
   },
-  "peerDependencies": {
-    "vue": "3.2.20"
-  },
-  "peerDependenciesMeta": {
-    "vue": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": "^14.16.0 || ^16.11.0"
   }

--- a/packages/nuxt3/package.json
+++ b/packages/nuxt3/package.json
@@ -23,8 +23,8 @@
     "@nuxt/nitro": "3.0.0",
     "@nuxt/vite-builder": "3.0.0",
     "@nuxt/webpack-builder": "3.0.0",
-    "@vue/reactivity": "3.2.20",
-    "@vue/shared": "3.2.20",
+    "@vue/reactivity": "^3.2.20",
+    "@vue/shared": "^3.2.20",
     "@vueuse/head": "^0.6.0",
     "chokidar": "^3.5.2",
     "consola": "^2.15.3",
@@ -48,11 +48,6 @@
     "@types/hash-sum": "^1.0.0",
     "unbuild": "latest",
     "vue-meta": "next"
-  },
-  "peerDependencies": {
-    "@vue/reactivity": "3.2.20",
-    "@vue/shared": "3.2.20",
-    "vue": "3.2.20"
   },
   "engines": {
     "node": "^14.16.0 || ^16.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,11 +2686,6 @@ __metadata:
     vue: 3.2.20
     vue-bundle-renderer: ^0.3.2
     vue-server-renderer: ^2.6.14
-  peerDependencies:
-    vue: 3.2.20
-  peerDependenciesMeta:
-    vue:
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4133,7 +4128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.2.20":
+"@vue/reactivity@npm:3.2.20, @vue/reactivity@npm:^3.2.20":
   version: 3.2.20
   resolution: "@vue/reactivity@npm:3.2.20"
   dependencies:
@@ -4188,7 +4183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.2.20, @vue/shared@npm:^3.2.11":
+"@vue/shared@npm:3.2.20, @vue/shared@npm:^3.2.11, @vue/shared@npm:^3.2.20":
   version: 3.2.20
   resolution: "@vue/shared@npm:3.2.20"
   checksum: da6e59a40622b5be5300c51d83e0a9d8ae1f67315dbec86cfc809b89f8620c09a3c6222cae5d80df0fb986f92afc1b6345db4e7a9b1a079f5783d27a839fea7d
@@ -13837,8 +13832,8 @@ fsevents@~2.3.2:
     "@nuxt/vite-builder": 3.0.0
     "@nuxt/webpack-builder": 3.0.0
     "@types/hash-sum": ^1.0.0
-    "@vue/reactivity": 3.2.20
-    "@vue/shared": 3.2.20
+    "@vue/reactivity": ^3.2.20
+    "@vue/shared": ^3.2.20
     "@vueuse/head": ^0.6.0
     chokidar: ^3.5.2
     consola: ^2.15.3
@@ -13859,10 +13854,6 @@ fsevents@~2.3.2:
     vue: ^3.2.20
     vue-meta: next
     vue-router: ^4.0.12
-  peerDependencies:
-    "@vue/reactivity": 3.2.20
-    "@vue/shared": 3.2.20
-    vue: 3.2.20
   bin:
     nuxt: ./bin/nuxt.mjs
   languageName: unknown


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

nuxt/bridge#292 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

npm >= 7 install peerDependencies unlike older versions of node and yarn. This causes issues for bridge users as they install nitro as a sub dependency.

Also moving vue from peerDepenencies to dependencies of nuxt3 as we don't ask users to install it anyway


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

