### PR TITLE
fix: fix could not resolve `#vue`

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -10,7 +10,7 @@ export function setupAppBridge (_options: any) {
   nuxt.options.alias['#build'] = nuxt.options.buildDir
 
   // Alias vue to a vue3-compat version of vue2
-  nuxt.options.alias['@@vue'] = nuxt.options.alias.vue || resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
+  nuxt.options.alias._vue = nuxt.options.alias.vue || resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
   for (const alias of [
     // vue 3 helper packages
     '@vue/shared',

--- a/packages/bridge/src/runtime/vue.mjs
+++ b/packages/bridge/src/runtime/vue.mjs
@@ -1,4 +1,4 @@
-import Vue from '@@vue'
+import Vue from '_vue'
 
 export * from '@vue/composition-api'
 


### PR DESCRIPTION
### 🔗 Linked issue
nuxt/bridge#284

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves nuxt/bridge#284 
I tracked down the bug and figured out the `#vue` alias causing the bug (I don't know why but I will share the detail) so I changed the `#vue` alias to something else.

I tried to figure out what is causing it. [Right before building the project](https://github.com/nuxt/vite/blob/main/src/vite.ts#L95), the list of Vite's aliases is:
```js
{
  '~~': '/project-directory',
  '@@': '/project-directory',
  '~': '/project-directory/src',
  '@': '/project-directory/src',
  assets: '/project-directory/src/assets',
  static: '/project-directory/src/static',
  '#app': '/project-directory/node_modules/@nuxt/bridge/dist/runtime/index.mjs',
  '#build': '/project-directory/nuxt-dist',
  '#vue': '/project-directory/node_modules/vue/dist/vue.runtime.esm.js',
  '@vue/shared': 'vue',
  '@vue/reactivity': 'vue',
  'vue/dist/vue.common.dev': 'vue',
  'vue/dist/vue.common.dev.js': 'vue',
  'vue/dist/vue.common': 'vue',
  'vue/dist/vue.common.js': 'vue',
  'vue/dist/vue.common.prod': 'vue',
  'vue/dist/vue.common.prod.js': 'vue',
  'vue/dist/vue.esm.browser': 'vue',
  'vue/dist/vue.esm.browser.js': 'vue',
  'vue/dist/vue.esm.browser.min': 'vue',
  'vue/dist/vue.esm.browser.min.js': 'vue',
  'vue/dist/vue.esm': 'vue',
  'vue/dist/vue.esm.js': 'vue',
  'vue/dist/vue': 'vue',
  'vue/dist/vue.js': 'vue',
  'vue/dist/vue.min': 'vue',
  'vue/dist/vue.min.js': 'vue',
  'vue/dist/vue.runtime.common.dev': 'vue',
  'vue/dist/vue.runtime.common.dev.js': 'vue',
  'vue/dist/vue.runtime.common': 'vue',
  'vue/dist/vue.runtime.common.js': 'vue',
  'vue/dist/vue.runtime.common.prod': 'vue',
  'vue/dist/vue.runtime.common.prod.js': 'vue',
  'vue/dist/vue.runtime.esm': 'vue',
  'vue/dist/vue.runtime.esm.js': 'vue',
  'vue/dist/vue.runtime': 'vue',
  'vue/dist/vue.runtime.js': 'vue',
  'vue/dist/vue.runtime.min': 'vue',
  'vue/dist/vue.runtime.min.js': 'vue',
  vue: '/project-directory/node_modules/@nuxt/bridge/dist/runtime/vue.mjs',
  '~auth/runtime': '/project-directory/node_modules/@nuxtjs/auth-next/dist/runtime',
  '.nuxt': '/project-directory/nuxt-dist',
  _nuxt: '/project-directory/nuxt-dist',
  'web-streams-polyfill/ponyfill/es2018': '/project-directory/node_modules/nuxt-vite/dist/runtime/mock/web-streams-polyfill.mjs',
  'whatwg-url': '/project-directory/node_modules/nuxt-vite/dist/runtime/mock/whatwg-url.mjs',
  'abort-controller': '/project-directory/node_modules/nuxt-vite/dist/runtime/mock/abort-controller.mjs'
}
```
So I can't see any conflict on this! Do you have any idea what's going on?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

