### PR TITLE
fix(nuxi): validate template argument

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -13,6 +13,19 @@ const knownTemplates = {
   bridge: 'nuxt/starter#bridge'
 }
 
+const resolveTemplate = (template) => {
+  if (template in knownTemplates) {
+    return knownTemplates[template]
+  }
+
+  if (typeof template === 'string' && template.includes('/')) {
+    return template
+  }
+
+  consola.error(`Invalid template name: \`${template}\``)
+  process.exit(1)
+}
+
 export default defineNuxtCommand({
   meta: {
     name: 'init',
@@ -21,8 +34,7 @@ export default defineNuxtCommand({
   },
   async invoke (args) {
     // Clone template
-    const t = args.template || args.t
-    const src = knownTemplates[t] || t || 'nuxt/starter#v3'
+    const src = resolveTemplate(args.template || args.t)
     const dstDir = resolve(process.cwd(), args._[0] || 'nuxt-app')
     const tiged = createTiged(src, { cache: false /* TODO: buggy */, verbose: (args.verbose || args.v) })
     if (existsSync(dstDir) && readdirSync(dstDir).length) {


### PR DESCRIPTION
### 🔗 Linked issue
nuxt/nuxt.js#12608 

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves nuxt/nuxt.js#12608

This PR adds a helper to arrive at the starter template based on the user choice.

`nuxi init -t default`

<img width="397" alt="Screenshot 2021-10-24 at 4 54 36 PM" src="https://user-images.githubusercontent.com/25279263/138592034-a1cbb687-f2a3-4b98-9170-57733539cb2b.png">

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.