### PR TITLE
docs(meta): add `viewport` example for `useMeta`

### DIFF
--- a/docs/content/3.docs/1.usage/3.meta-tags.md
+++ b/docs/content/3.docs/1.usage/3.meta-tags.md
@@ -11,7 +11,9 @@ For example:
 export default {
   setup () {
     useMeta({
-      meta: [{ name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1' }],
+      meta: [
+        { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1' }
+      ],
       bodyAttrs: {
         class: 'test'
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Not applicable

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Adds one line to show how to add a common meta tag with `useMeta`.

<!-- Why is this change required? What problem does it solve? -->
I couldn't find the source code for `useMeta`.  I eventually figured it out by trial and error.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

