### PR TITLE
fix(vite): dev-bundler externality

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -25,6 +25,8 @@ function isExternal (opts: TransformOptions, id: string) {
   // Externals
   const ssrConfig = (opts.viteServer.config as any).ssr
 
+  // Vite's alias have two possible formats
+  // https://vitejs.dev/config/#resolve-alias
   const alias = opts.viteServer.config.resolve.alias || {}
   const aliasKeys = Array.isArray(alias)
     ? alias.map(i => i.find).filter(Boolean)


### PR DESCRIPTION
On some conditions, the alias will be normalized to an array of `{find: string, replacement: string}[]` instead of an object. Causing the vue-entry external and `vue2` alias not resolving.