### PR TITLE
fix(nitro): improve regex for tracedFiles scanning

### DIFF
--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -75,7 +75,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         const pkgs = new Set<string>()
         for (const file of tracedFiles) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const [_, baseDir, pkgName, _importPath] = /(.+\/node_modules\/)([^@/]+|@[^/]+\/[^/]+)\/(.*)/.exec(file)
+          const [_, baseDir, pkgName, _importPath] = /^(.+\/node_modules\/)([^@/]+|@[^/]+\/[^/]+)(\/?.*?)?$/.exec(file)
           pkgs.add(resolve(baseDir, pkgName, 'package.json'))
         }
 


### PR DESCRIPTION
Improved regex that covered the case of the imports without importPath (see regex playground). Improved pnpm compatibility #939

Regex101: https://regex101.com/r/JZE7G2/1