### PR TITLE
fix(vite): remove aliases from inline list

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -25,19 +25,10 @@ function isExternal (opts: TransformOptions, id: string) {
   // Externals
   const ssrConfig = (opts.viteServer.config as any).ssr
 
-  // Vite's alias have two possible formats
-  // https://vitejs.dev/config/#resolve-alias
-  const alias = opts.viteServer.config.resolve.alias || {}
-  const aliasKeys = Array.isArray(alias)
-    ? alias.map(i => i.find).filter(Boolean)
-    : Object.keys(alias)
-
   const externalOpts: ExternalsOptions = {
     inline: [
       /virtual:/,
       /\.ts$/,
-      // Things like '~', '@', etc.
-      ...aliasKeys,
       ...ExternalsDefaults.inline,
       ...ssrConfig.noExternal
     ],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves nuxt/nuxt.js#12663
nuxt/nuxt.js#12632

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems we don't need to inline Vite aliases as they are resolved first. 🤔 Certainly the issue was caused by inlining Vue CJS dependencies which we had aliased.

Am I missing something @antfu?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

