### PR TITLE
fix(nuxi): write types after nuxt is ready

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -53,7 +53,7 @@ export default defineNuxtCommand({
         await clearDir(newNuxt.options.buildDir)
         currentNuxt = newNuxt
         await currentNuxt.ready()
-        writeTypes(newNuxt).catch(console.error)
+        writeTypes(currentNuxt).catch(console.error)
         await buildNuxt(currentNuxt)
         server.setApp(currentNuxt.server.app)
         if (isRestart && args.clear !== false) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves nuxt/nuxt.js#12840

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we weren't waiting for all modules to be initialised, meaning we could miss possible `prepare:types` hooks that might have been registered.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

