### PR TITLE
fix(kit): remove invalid portion of version from semver

### DIFF
--- a/packages/kit/src/module/utils.ts
+++ b/packages/kit/src/module/utils.ts
@@ -356,7 +356,8 @@ export function checkNuxtCompatibilityIssues (constraints: NuxtCompatibilityCons
   const issues: NuxtCompatibilityIssues = []
   if (constraints.nuxt) {
     const nuxtVersion = getNuxtVersion(nuxt)
-    if (!semver.satisfies(nuxtVersion, constraints.nuxt)) {
+    const nuxtSemanticVersion = nuxtVersion.split('-').shift()
+    if (!semver.satisfies(nuxtSemanticVersion, constraints.nuxt)) {
       issues.push({
         name: 'nuxt',
         message: `Nuxt version \`${constraints.nuxt}\` is required but currently using \`${nuxtVersion}\``


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

closes nuxt/nuxt.js#12854

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`nuxt-edge` produces a version string like `2.16.0-27256336.293dc11a` which isn't parseable by `semver`, so this PR removes the extraneous bit at the end.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

