### PR TITLE
refactor(nuxi): `nuxi info` outputs package manager version

### DIFF
--- a/packages/nuxi/src/utils/fs.ts
+++ b/packages/nuxi/src/utils/fs.ts
@@ -1,6 +1,7 @@
 import { promises as fsp } from 'fs'
 import { promisify } from 'util'
 import rimraf from 'rimraf'
+import { dirname } from 'pathe'
 
 // Check if a file exists
 export async function exists (path: string) {
@@ -15,4 +16,16 @@ export async function exists (path: string) {
 export async function clearDir (path: string) {
   await promisify(rimraf)(path)
   await fsp.mkdir(path, { recursive: true })
+}
+
+export function findup<T> (rootDir: string, fn: (dir: string) => T | undefined): T | null {
+  let dir = rootDir
+  while (dir !== dirname(dir)) {
+    const res = fn(dir)
+    if (res) {
+      return res
+    }
+    dir = dirname(dir)
+  }
+  return null
 }

--- a/packages/nuxi/src/utils/packageManagers.ts
+++ b/packages/nuxi/src/utils/packageManagers.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { resolve } from 'pathe'
+import { findup } from './fs'
+
+export const packageManagerLocks = {
+  yarn: 'yarn.lock',
+  npm: 'package-lock.json',
+  pnpm: 'pnpm-lock.yaml'
+}
+
+export function getPackageManager (rootDir: string) {
+  return findup(rootDir, (dir) => {
+    for (const name in packageManagerLocks) {
+      if (existsSync(resolve(dir, packageManagerLocks[name]))) {
+        return name
+      }
+    }
+  })
+}
+
+export function getPackageManagerVersion (name: string) {
+  return execSync(`${name} --version`).toString('utf8').trim()
+}


### PR DESCRIPTION
- Add support for pnpm (currently prints `unknown`)
- Print out package manager version, for example:

------------------------------
- Operating System: `Darwin`
- Node Version:     `v16.11.1`
- Nuxt Version:     `3.0.0`
- Package Manager:  `yarn@3.1.0`
- Bundler:          `Vite`
- User Config:      `-`
- Runtime Modules:  `-`
- Build Modules:    `-`
------------------------------
