### PR TITLE
fix(bridge): detect existence of `@nuxt/bridge-edge`

### DIFF
--- a/packages/bridge/module.cjs
+++ b/packages/bridge/module.cjs
@@ -8,7 +8,7 @@ module.exports.defineNuxtConfig = (config = {}) => {
     if (!config.buildModules) {
       config.buildModules = []
     }
-    if (!config.buildModules.find(m => m === '@nuxt/bridge')) {
+    if (!config.buildModules.find(m => m === '@nuxt/bridge' || m === '@nuxt/bridge-edge')) {
       config.buildModules.push('@nuxt/bridge')
     }
   }


### PR DESCRIPTION
This makes it possible to use without aliasing.