### PR TITLE
fix(nuxt3): enable legacy access to $config and static flags

### DIFF
--- a/packages/nuxt3/src/app/legacy.ts
+++ b/packages/nuxt3/src/app/legacy.ts
@@ -120,7 +120,7 @@ const staticFlags = {
   isClient: process.client,
   isServer: process.server,
   isDev: process.dev,
-  isStatic: false,
+  isStatic: undefined,
   target: 'server',
   modern: false
 }

--- a/packages/nuxt3/src/app/legacy.ts
+++ b/packages/nuxt3/src/app/legacy.ts
@@ -122,7 +122,7 @@ const staticFlags = {
   isDev: process.dev,
   isStatic: false,
   target: 'server',
-  modern: true
+  modern: false
 }
 
 export const legacyPlugin = (nuxtApp: NuxtApp) => {

--- a/packages/nuxt3/src/app/legacy.ts
+++ b/packages/nuxt3/src/app/legacy.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import type { App } from 'vue'
 import type { Component } from '@vue/runtime-core'
 import mockContext from 'unenv/runtime/mock/proxy'
-import type { NuxtApp } from './nuxt'
+import { NuxtApp, useRuntimeConfig } from './nuxt'
 
 type Route = any
 type Store = any
@@ -92,19 +92,12 @@ function mock (warning: string) {
 }
 
 const unsupported = new Set<keyof LegacyContext | keyof LegacyContext['ssrContext']>([
-  'isClient',
-  'isServer',
-  'isStatic',
   'store',
-  'target',
   'spa',
-  'env',
-  'modern',
   'fetchCounters'
 ])
 
 const todo = new Set<keyof LegacyContext | keyof LegacyContext['ssrContext']>([
-  'isDev',
   'isHMR',
   // Routing handlers - needs implementation or deprecation
   'base',
@@ -122,6 +115,15 @@ const todo = new Set<keyof LegacyContext | keyof LegacyContext['ssrContext']>([
 ])
 
 const routerKeys: Array<keyof LegacyContext | keyof LegacyContext['ssrContext']> = ['route', 'params', 'query']
+
+const staticFlags = {
+  isClient: process.client,
+  isServer: process.server,
+  isDev: process.dev,
+  isStatic: false,
+  target: 'server',
+  modern: true
+}
 
 export const legacyPlugin = (nuxtApp: NuxtApp) => {
   nuxtApp._legacyContext = new Proxy(nuxtApp, {
@@ -149,9 +151,12 @@ export const legacyPlugin = (nuxtApp: NuxtApp) => {
         }
       }
 
-      if (p === '$config') {
-        // TODO: needs implementation
-        return mock('Accessing runtime config is not yet supported in Nuxt 3.')
+      if (p === '$config' || p === 'env') {
+        return useRuntimeConfig()
+      }
+
+      if (p in staticFlags) {
+        return staticFlags[p]
       }
 
       if (p === 'ssrContext') {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1587

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR aims to provide compatible APIs for legacy modules that rely on certain flags from [the Nuxt context](https://nuxtjs.org/docs/2.x/internals-glossary/context).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

