### PR TITLE
fix(nuxt3): add `vue-router` types when used

### DIFF
--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -17,7 +17,6 @@ export default defineNuxtModule({
 
     // Add $router types
     nuxt.hook('prepare:types', ({ references }) => {
-      console.log('test')
       references.push({ types: 'vue-router' })
     })
 

--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -15,6 +15,12 @@ export default defineNuxtModule({
       return
     }
 
+    // Add $router types
+    nuxt.hook('prepare:types', ({ references }) => {
+      console.log('test')
+      references.push({ types: 'vue-router' })
+    })
+
     // Regenerate templates when adding or removing pages
     nuxt.hook('builder:watch', async (event, path) => {
       const pathPattern = new RegExp(`^(${nuxt.options.dir.pages}|${nuxt.options.dir.layouts})/`)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1602

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds `vue-router` types when the pages module is being used.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

