### PR TITLE
fix(nuxt3): only add ref if types were generated

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -79,7 +79,9 @@ export default defineNuxtModule({
     })
 
     nuxt.hook('prepare:types', ({ references }) => {
-      references.push({ path: resolve(nuxt.options.buildDir, 'components.d.ts') })
+      if (components.length) {
+        references.push({ path: resolve(nuxt.options.buildDir, 'components.d.ts') })
+      }
     })
 
     // Watch for changes


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR ensures `components.d.ts` isn't added to `nuxt.d.ts` unless the file has actually been generated. It should just ensure the file remains clean (as there seem to be no negative consequences to adding nonexistent refs other than the squiggly red line).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

