### PR TITLE
feat!(bridge): allow accessing injections from `useNuxtApp`

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -14,7 +14,7 @@ export default (ctx, inject) => {
       mount: () => { },
       provide: inject,
       unmount: () => { },
-      use(vuePlugin) {
+      use (vuePlugin) {
         vuePlugin.install(this)
       },
       version: Vue.version
@@ -42,7 +42,16 @@ export default (ctx, inject) => {
     nuxtApp.vue2App = this
   })
 
-  setNuxtAppInstance(nuxtApp)
+  const proxiedApp = new Proxy(nuxtApp, {
+    get (target, prop) {
+      if (prop[0] === '$') {
+        return target.nuxt2Context[prop] || target.vue2App?.[prop]
+      }
+      return Reflect.get(target, prop)
+    }
+  })
 
-  inject('_nuxtApp', nuxtApp)
+  setNuxtAppInstance(proxiedApp)
+
+  inject('_nuxtApp', proxiedApp)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/1589
resolves #967
context: https://github.com/nuxt/framework/discussions/964#discussioncomment-1471713

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR enables accessing injected properties within Bridge directly via `useNuxtApp()` to decrease the difference between Nuxt 2/3.

Example:
```ts
const { $myInjectedProperty } = useNuxtApp()
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

