### PR TITLE
fix(vite): remove conflicting vite aliases

### DIFF
--- a/packages/bridge/src/vite/vite.ts
+++ b/packages/bridge/src/vite/vite.ts
@@ -36,8 +36,6 @@ async function bundle (nuxt: Nuxt, builder: any) {
             '#build': nuxt.options.buildDir,
             '.nuxt': nuxt.options.buildDir,
             '/.nuxt/entry.mjs': resolve(nuxt.options.buildDir, 'client.js'),
-            '~': nuxt.options.srcDir,
-            '@': nuxt.options.srcDir,
             'web-streams-polyfill/ponyfill/es2018': resolve(distDir, 'runtime/vite/mock/web-streams-polyfill.mjs'),
             'whatwg-url': resolve(distDir, 'runtime/vite/mock/whatwg-url.mjs'),
             // Cannot destructure property 'AbortController' of ..

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -41,11 +41,7 @@ export async function bundle (nuxt: Nuxt) {
             // will be filled in client/server configs
             '#build/plugins': '',
             '#build': nuxt.options.buildDir,
-            '/build': nuxt.options.buildDir,
-            '/app': nuxt.options.appDir,
             '/entry.mjs': resolve(nuxt.options.appDir, 'entry'),
-            '~': nuxt.options.srcDir,
-            '@': nuxt.options.srcDir,
             'web-streams-polyfill/ponyfill/es2018': 'unenv/runtime/mock/empty',
             // Cannot destructure property 'AbortController' of ..
             'abort-controller': 'unenv/runtime/mock/empty'
@@ -98,7 +94,7 @@ export async function bundle (nuxt: Nuxt) {
 
   nuxt.hook('vite:serverCreated', (server: vite.ViteDevServer) => {
     const start = Date.now()
-    warmupViteServer(server, ['/app/entry.mjs']).then(() => {
+    warmupViteServer(server, ['/entry.mjs']).then(() => {
       consola.info(`Vite warmed up in ${Date.now() - start}ms`)
     }).catch(consola.error)
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

partly solves #1622
resolves #966

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes some unused vite aliases which conflict with directory names when present (`/app` and `/build`). I can't find any indication these are used but please correct me if I'm wrong.

I've removed `~` and `@` too as these should be defined in `nuxt.options.alias` but if this was a workaround or I have misunderstood the purpose of this please do let me know (cc @pi0).

It also fixes the warmup command for vite. (Previously this was actually not doing anything as there was no route resolved for it.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

