### PR TITLE
fix(nuxi): generate types with `nuxi generate`

### DIFF
--- a/packages/nuxi/src/commands/generate.ts
+++ b/packages/nuxi/src/commands/generate.ts
@@ -3,6 +3,7 @@ import { resolve } from 'pathe'
 import { isNuxt3 } from '@nuxt/kit'
 
 import { loadKit } from '../utils/kit'
+import { writeTypes } from '../utils/prepare'
 import { defineNuxtCommand } from './index'
 
 export default defineNuxtCommand({
@@ -16,13 +17,16 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt } = await loadKit(rootDir)
-    const nuxt = await loadNuxt({ rootDir })
+    const nuxt = await loadNuxt({ rootDir, config: { _export: true } })
 
     if (isNuxt3(nuxt)) {
       throw new Error('`nuxt generate` is not supported in Nuxt 3. Please follow this RFC: https://git.io/JKfvx')
     } else {
+      // Generate types and close nuxt instance
+      await writeTypes(nuxt)
+      await nuxt.close()
       // Forwards argv to `nuxt generate`
-      await execa('npx nuxt', process.argv.slice(2), { stdio: 'inherit' })
+      await execa('npx', ['nuxt', ...process.argv.slice(2)], { stdio: 'inherit' })
     }
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/1562

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR:
1. updates the `execa` command (it doesn't take arguments in the first part) 
1. writes types and closes out the nuxt instance before passing on the command
1. sets `_export: true` before writing types (as otherwise will fall foul of https://github.com/nuxt/framework/blob/46f858dd82cfe237d66b932423a5c784f9533f2f/packages/bridge/src/nitro.ts#L14-L16

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

