### PR TITLE
fix(nuxt3): use nuxt extensions for component discovery

### DIFF
--- a/packages/kit/src/config/schema/_common.ts
+++ b/packages/kit/src/config/schema/_common.ts
@@ -457,7 +457,7 @@ export default {
    * @version 3
    */
   extensions: {
-    $resolve: val => ['.js', '.mjs', '.ts', '.tsx', '.vue'].concat(val).filter(Boolean)
+    $resolve: val => ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.vue'].concat(val).filter(Boolean)
   },
 
   /**

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -26,7 +26,7 @@ export default defineNuxtModule({
         const dirOptions: ComponentsDir = typeof dir === 'object' ? dir : { path: dir }
         const dirPath = resolveAlias(dirOptions.path, nuxt.options.alias)
         const transpile = typeof dirOptions.transpile === 'boolean' ? dirOptions.transpile : 'auto'
-        const extensions = dirOptions.extensions || ['vue'] // TODO: nuxt extensions and strip leading dot
+        const extensions = dirOptions.extensions || nuxt.options.extensions.map(e => e.slice(1))
 
         dirOptions.level = Number(dirOptions.level || 0)
 

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -26,7 +26,7 @@ export default defineNuxtModule({
         const dirOptions: ComponentsDir = typeof dir === 'object' ? dir : { path: dir }
         const dirPath = resolveAlias(dirOptions.path, nuxt.options.alias)
         const transpile = typeof dirOptions.transpile === 'boolean' ? dirOptions.transpile : 'auto'
-        const extensions = dirOptions.extensions || nuxt.options.extensions.map(e => e.slice(1))
+        const extensions = (dirOptions.extensions || nuxt.options.extensions).map(e => e.replace(/^\./g, ''))
 
         dirOptions.level = Number(dirOptions.level || 0)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Context: #243

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves a todo item by resolving more than just `.vue` files in components directory, as well as adding `.jsx` to valid extensions. There may be a reason this wasn't implemented yet however? - cc: @pi0.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

