### PR TITLE
fix(vite): normalize full windows paths

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -59,6 +59,10 @@ async function transformRequest (opts: TransformOptions, id: string) {
     // Relative to the root directory
     id = '.' + id
   }
+  // On Windows, this may be `/C:/my/path` at this point, in which case we want to remove the `/`
+  if (id.match(/^\/\w:/)) {
+    id = id.slice(1)
+  }
 
   if (await isExternal(opts, id)) {
     return {

--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -55,13 +55,13 @@ async function transformRequest (opts: TransformOptions, id: string) {
   if (id && id.startsWith('/@fs/')) {
     // Absolute path
     id = id.slice('/@fs'.length)
+    // On Windows, this may be `/C:/my/path` at this point, in which case we want to remove the `/`
+    if (id.match(/^\/\w:/)) {
+      id = id.slice(1)
+    }
   } else if (!id.includes('entry') && id.startsWith('/')) {
     // Relative to the root directory
     id = '.' + id
-  }
-  // On Windows, this may be `/C:/my/path` at this point, in which case we want to remove the `/`
-  if (id.match(/^\/\w:/)) {
-    id = id.slice(1)
   }
 
   if (await isExternal(opts, id)) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1380

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If there is a `srcDir`, vite fully resolves paths outside of it (e.g. to node_modules), which are expressed as `/@fs/C:/my/path` - but we weren't removing the slash before the drive letter. This PR handles it.

related: https://github.com/nuxt/framework/pull/1646

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

