### PR TITLE
fix(bridge): can't install vue plugin

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -15,7 +15,7 @@ export default (ctx, inject) => {
       provide: inject,
       unmount: () => { },
       use (vuePlugin) {
-        vuePlugin.install(this)
+        vuePlugin.install(Vue)
       },
       version: Vue.version
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
not applicable in issues.
but, I have a reproduction link
https://github.com/kazupon/nuxt-i18n-next/tree/repro-vue-plugin-install

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
As described in the vue official docs, the vue plugin is a function whose first argument is a Vue constructor.
https://vuejs.org/v2/guide/plugins.html#Writing-a-Plugin

The nuxt bridge implements `vueApp` that is compatible with the Vue constructor.
However, the first argument of `install`, which is executed in `use`, is not passed a Vue constructor.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

