### PR TITLE
fix(vite, bridge): avoid vite resolving `tsconfig.json`

### DIFF
--- a/packages/bridge/src/vite/vite.ts
+++ b/packages/bridge/src/vite/vite.ts
@@ -61,7 +61,8 @@ async function bundle (nuxt: Nuxt, builder: any) {
         },
         esbuild: {
           jsxFactory: 'h',
-          jsxFragment: 'Fragment'
+          jsxFragment: 'Fragment',
+          tsconfigRaw: '{}'
         },
         publicDir: resolve(nuxt.options.srcDir, nuxt.options.dir.static),
         clearScreen: false,

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -63,7 +63,8 @@ export async function bundle (nuxt: Nuxt) {
         },
         esbuild: {
           jsxFactory: 'h',
-          jsxFragment: 'Fragment'
+          jsxFragment: 'Fragment',
+          tsconfigRaw: '{}'
         },
         clearScreen: false,
         build: {

--- a/test/fixtures/bridge/tsconfig.json
+++ b/test/fixtures/bridge/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

When we have `tsconfig.json` in the project and run `nuxi generate` in a clean workspace, it will fail to find `.nuxt/tsconfig.json`. This also appends on `nuxi generate` because this is triggered during loading Nuxt and before we write the types.

This PR bring up a failed test, and disabled the vite's tsconfig.json resolving. Currently wait for a bug fix on Vite's side https://github.com/vitejs/vite/pull/5538

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

