### PR TITLE
chore(docs): update algolia api key

### DIFF
--- a/docs/docus.config.ts
+++ b/docs/docus.config.ts
@@ -6,9 +6,8 @@ export default {
   template: 'docs',
   twitter: 'nuxt_js',
   algolia: {
-    appId: 'BH4D9OD16A',
-    container: '#docsearch',
-    apiKey: 'ff80fbf046ce827f64f06e16f82f1401',
+    appId: '1V8G7N9GF0',
+    apiKey: '60a01900a4b726d667eab75b6f337592',
     indexName: 'nuxtjs',
     facetFilters: ['tags:v3']
   },


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 👌 Enhancement (improving an existing functionality like performance)
### 📚 Description

Updated Algolia API keys, cannot check locally so far. Running into this error locally:

<img width="903" alt="Screenshot 2021-11-04 at 01 14 35@2x" src="https://user-images.githubusercontent.com/904724/140236279-2c6bedce-e29a-4bbf-b482-adb8b5024280.png">
