### PR TITLE
fix(vite): expose underlying import errors

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -71,7 +71,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
 
   if (await isExternal(opts, id)) {
     return {
-      code: `(global, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) => import('${(pathToFileURL(id))}').then(r => { exports.default = r.default; ssrExportAll(r) }).catch(e => { console.error(e); throw new Error('Error loading external "${id}".') })`,
+      code: `(global, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) => import('${(pathToFileURL(id))}').then(r => { exports.default = r.default; ssrExportAll(r) }).catch(e => { console.error(e); throw new Error('[vite dev] Error loading external "${id}".') })`,
       deps: [],
       dynamicDeps: []
     }

--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -71,7 +71,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
 
   if (await isExternal(opts, id)) {
     return {
-      code: `(global, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) => import('${(pathToFileURL(id))}').then(r => { exports.default = r.default; ssrExportAll(r) })`,
+      code: `(global, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) => import('${(pathToFileURL(id))}').then(r => { exports.default = r.default; ssrExportAll(r) }).catch(e => { console.error(e); throw new Error('Error loading external "${id}".') })`,
       deps: [],
       dynamicDeps: []
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

See https://github.com/nuxt/framework/issues/940#issuecomment-960937200

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current error message when loading externals is:
```
(node:31884) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
Unexpected token 'export'
  at wrapSafe (internal/modules/cjs/loader.js:1001:16)  
  at Module._compile (internal/modules/cjs/loader.js:1049:27)  
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)  
  at Module.load (internal/modules/cjs/loader.js:950:32)  
  at Function.Module._load (internal/modules/cjs/loader.js:790:14)  
  at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)  
  at ModuleJob.run (internal/modules/esm/module_job.js:169:25)  
  at async Loader.import (internal/modules/esm/loader.js:177:24)  
  at async __instantiateModule__ (file://./playground/.nuxt/dist/server/server.mjs:7515:3)
```

This doesn't reveal anything about the underlying cause or package, and can be very confusing.

This PR changes the logging to the following:
```
(node:33676) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/v-tooltip/node_modules/@popperjs/core/lib/enums.js:1
export var top = 'top';
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
    at ModuleJob.run (internal/modules/esm/module_job.js:169:25)
    at async Loader.import (internal/modules/esm/loader.js:177:24)
    at async __instantiateModule__ (file:///Users/daniel/code/nuxt/framework/playground/.nuxt/dist/server/server.mjs:7515:3)

Error loading external "/v-tooltip/node_modules/@popperjs/core/lib/enums.js".
  at file://./playground/.nuxt/dist/server/server.mjs:3704:283  
  at async __instantiateModule__ (file://./playground/.nuxt/dist/server/server.mjs:7515:3)
```

And the message displayed in the browser is, which is more relevant:

```
Error loading external "/v-tooltip/node_modules/@popperjs/core/lib/enums.js".
  at file://./playground/.nuxt/dist/server/server.mjs:3704:283  
  at async __instantiateModule__ (file://./playground/.nuxt/dist/server/server.mjs:7515:3)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

