### PR TITLE
fix(bridge): enable vite build by default

### DIFF
--- a/packages/bridge/src/vite/module.ts
+++ b/packages/bridge/src/vite/module.ts
@@ -10,11 +10,6 @@ export default defineNuxtModule<ViteOptions>({
   version,
   configKey: 'vite',
   setup (viteOptions, nuxt) {
-    // Only enable for development or production if `build: true` is set
-    if (!nuxt.options.dev && !viteOptions.build) {
-      return
-    }
-
     nuxt.options.cli.badgeMessages.push(`⚡  Vite Mode Enabled (v${version})`)
     // eslint-disable-next-line no-console
     if (viteOptions.experimentWarning !== false && !nuxt.options.test) {

--- a/test/fixtures/bridge/nuxt.config.ts
+++ b/test/fixtures/bridge/nuxt.config.ts
@@ -21,6 +21,5 @@ export default defineNuxtConfig({
   bridge: {
     meta: true,
     vite: !!process.env.TEST_BRIDGE_VITE
-  },
-  vite: process.env.TEST_BRIDGE_VITE ? { build: {} } : undefined
+  }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Currently, even if we enable `bridge.vite: true`, it still runs webpack on build unless `vite.build: true` is set. Which could be confusing. This PR flips the default by making the vite build opt-out instead of opt-in.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

