### PR TITLE
fix(vite): swap `<link>` style on dev ssr

### DIFF
--- a/packages/bridge/src/vite/client.ts
+++ b/packages/bridge/src/vite/client.ts
@@ -3,6 +3,7 @@ import * as vite from 'vite'
 import { createVuePlugin } from 'vite-plugin-vue2'
 import PluginLegacy from '@vitejs/plugin-legacy'
 import consola from 'consola'
+import { devStyleSSRPlugin } from '../../../vite/src/plugins/dev-ssr-css'
 import { jsxPlugin } from './plugins/jsx'
 import { ViteBuildContext, ViteOptions } from './types'
 
@@ -38,7 +39,8 @@ export async function buildClient (ctx: ViteBuildContext) {
     plugins: [
       jsxPlugin(),
       createVuePlugin(ctx.config.vue),
-      PluginLegacy()
+      PluginLegacy(),
+      devStyleSSRPlugin(ctx.nuxt.options.rootDir)
     ],
     server: {
       middlewareMode: true

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -11,6 +11,7 @@ import { cacheDirPlugin } from './plugins/cache-dir'
 import { wpfs } from './utils/wpfs'
 import type { ViteBuildContext, ViteOptions } from './vite'
 import { writeManifest } from './manifest'
+import { devStyleSSRPlugin } from './plugins/dev-ssr-css'
 
 export async function buildClient (ctx: ViteBuildContext) {
   const clientConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
@@ -38,7 +39,8 @@ export async function buildClient (ctx: ViteBuildContext) {
     plugins: [
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'client'),
       vuePlugin(ctx.config.vue),
-      viteJsxPlugin()
+      viteJsxPlugin(),
+      devStyleSSRPlugin(ctx.nuxt.options.rootDir)
     ],
     server: {
       middlewareMode: true

--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -1,0 +1,23 @@
+import { Plugin } from 'vite'
+import { isCSS } from '../utils'
+
+export function devStyleSSRPlugin (rootDir: string): Plugin {
+  return {
+    name: 'nuxt:dev-style-ssr',
+    apply: 'serve',
+    enforce: 'post',
+    transform (code, id) {
+      if (!isCSS(id) || !code.includes('import.meta.hot')) {
+        return
+      }
+
+      let moduleId = id
+      if (moduleId.startsWith(rootDir)) {
+        moduleId = moduleId.slice(rootDir.length)
+      }
+
+      // When dev `<style>` is injected, remove the `<link>` styles from manifest
+      return code + `\ndocument.querySelector(\`link[href="/_nuxt${moduleId}"]\`).forEach(i=>i.remove())`
+    }
+  }
+}

--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -17,6 +17,7 @@ export function devStyleSSRPlugin (rootDir: string): Plugin {
       }
 
       // When dev `<style>` is injected, remove the `<link>` styles from manifest
+      // TODO: Use `app.assetsPath` or unique hash
       return code + `\ndocument.querySelector(\`link[href="/_nuxt${moduleId}"]\`).forEach(i=>i.remove())`
     }
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we have the css entries in the manifest and injected as <link ref="stylesheet"> by the renderer. The problem here is that during dev, vite's css are actually a JS module that controls a <style> for HMR. This makes client as duplicated of styles

For example:
![image](https://user-images.githubusercontent.com/11247099/140452193-dee486aa-7edb-4ee1-872a-2c369107813f.png)

Since the style from <link> can't be changed without a full page reload. This makes the old style persist and potentially conflict with the updated ones.

This PR makes the dev css module swap the `<link>` version with the same id to prevent duplication.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

