### PR TITLE
Fix(vite) use querySelectorAll instead of querySelector for dev-ssr-css

### DIFF
--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -18,7 +18,7 @@ export function devStyleSSRPlugin (rootDir: string): Plugin {
 
       // When dev `<style>` is injected, remove the `<link>` styles from manifest
       // TODO: Use `app.assetsPath` or unique hash
-      return code + `\ndocument.querySelector(\`link[href="/_nuxt${moduleId}"]\`).forEach(i=>i.remove())`
+      return code + `\ndocument.querySelectorAll(\`link[href="/_nuxt${moduleId}"]\`).forEach(i=>i.remove())`
     }
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue
#1731 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Potentially fixes an bug introduced here:
https://github.com/nuxt/framework/pull/1712/files#diff-3849e94b5e97edc9444890d8800209cb730a3ac9c0e7004ee9d85d2c2dad12d5R21

Where `document.querySelector(...).forEach(...)` should be `document.querySelectorAll(...).forEach(...)`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

