### PR TITLE
fix(nuxt3): add missing auto imports

### DIFF
--- a/packages/bridge/src/auto-imports.ts
+++ b/packages/bridge/src/auto-imports.ts
@@ -1,7 +1,9 @@
 import { installModule, useNuxt } from '@nuxt/kit'
+import * as CompositionApi from '@vue/composition-api'
 import autoImports from '../../nuxt3/src/auto-imports/module'
 
 const UnsupportedImports = new Set(['useAsyncData', 'useFetch'])
+const CapiHelpers = new Set(Object.keys(CompositionApi))
 
 const ImportRewrites = {
   vue: '@vue/composition-api',
@@ -19,6 +21,9 @@ export async function setupAutoImports () {
       }
       // Disable unsupported imports
       if (UnsupportedImports.has(autoImport.name)) {
+        autoImport.disabled = true
+      }
+      if (autoImport.from === '@vue/composition-api' && !CapiHelpers.has(autoImport.name)) {
         autoImport.disabled = true
       }
     }

--- a/packages/bridge/test/auto-imports.test.ts
+++ b/packages/bridge/test/auto-imports.test.ts
@@ -1,0 +1,30 @@
+import * as CompositionApi from '@vue/composition-api'
+import { expect } from 'chai'
+
+import { Nuxt3AutoImports } from '../../nuxt3/src/auto-imports/imports'
+
+const excludedVueHelpers = [
+  'EffectScope',
+  'createApp',
+  'createRef',
+  'default',
+  'del',
+  'isRaw',
+  'set',
+  'useCSSModule',
+  'version',
+  'warn',
+  'watchPostEffect',
+  'watchSyncEffect'
+]
+
+describe('auto-imports:vue', () => {
+  for (const name of Object.keys(CompositionApi)) {
+    if (excludedVueHelpers.includes(name)) {
+      continue
+    }
+    it(`should register ${name} globally`, () => {
+      expect(Nuxt3AutoImports.find(a => a.from === 'vue').names).to.include(name)
+    })
+  }
+})

--- a/packages/nuxt3/src/auto-imports/imports.ts
+++ b/packages/nuxt3/src/auto-imports/imports.ts
@@ -33,6 +33,19 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
   {
     from: 'vue',
     names: [
+      // <script setup>
+      'defineEmits',
+      'defineExpose',
+      'defineProps',
+      'withAsyncContext',
+      'withCtx',
+      'withDefaults',
+      'withDirectives',
+      'withKeys',
+      'withMemo',
+      'withModifiers',
+      'withScopeId',
+
       // Lifecycle
       'onActivated',
       'onBeforeMount',
@@ -41,6 +54,8 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
       'onDeactivated',
       'onErrorCaptured',
       'onMounted',
+      'onRenderTracked',
+      'onRenderTriggered',
       'onServerPrefetch',
       'onUnmounted',
       'onUpdated',
@@ -48,15 +63,19 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
       // Reactivity
       'computed',
       'customRef',
+      'isProxy',
+      'isReactive',
       'isReadonly',
       'isRef',
       'markRaw',
+      'proxyRefs',
       'reactive',
       'readonly',
       'ref',
       'shallowReactive',
       'shallowReadonly',
       'shallowRef',
+      'stop',
       'toRaw',
       'toRef',
       'toRefs',
@@ -64,6 +83,12 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
       'unref',
       'watch',
       'watchEffect',
+
+      // effect
+      'effect',
+      'effectScope',
+      'getCurrentScope',
+      'onScopeDispose',
 
       // Component
       'defineComponent',
@@ -73,7 +98,11 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
       'inject',
       'nextTick',
       'provide',
-      'useCssModule'
-    ]
+      'useAttrs',
+      'useCssModule',
+      'useCssVars',
+      'useSlots',
+      'useTransitionState'
+    ] as Array<keyof typeof import('vue')>
   }
 ]

--- a/packages/nuxt3/test/auto-imports.test.ts
+++ b/packages/nuxt3/test/auto-imports.test.ts
@@ -1,7 +1,9 @@
 import type { AutoImport } from '@nuxt/kit'
 import { expect } from 'chai'
+import * as VueFunctions from 'vue'
 import { AutoImportContext, updateAutoImportContext } from '../src/auto-imports/context'
 import { TransformPlugin } from '../src/auto-imports/transform'
+import { Nuxt3AutoImports } from '../src/auto-imports/imports'
 
 describe('auto-imports:transform', () => {
   const autoImports: AutoImport[] = [
@@ -33,4 +35,103 @@ describe('auto-imports:transform', () => {
     const result = await transform('// import { computed } from "foo"\n;const a = computed(0)')
     expect(result).to.equal('import { computed } from \'bar\';// import { computed } from "foo"\n;const a = computed(0)')
   })
+})
+
+const excludedVueHelpers = [
+  'EffectScope',
+  'ReactiveEffect',
+  'stop',
+  'camelize',
+  'capitalize',
+  'normalizeClass',
+  'normalizeProps',
+  'normalizeStyle',
+  'toDisplayString',
+  'toHandlerKey',
+  'BaseTransition',
+  'Comment',
+  'Fragment',
+  'KeepAlive',
+  'Static',
+  'Suspense',
+  'Teleport',
+  'Text',
+  'callWithAsyncErrorHandling',
+  'callWithErrorHandling',
+  'cloneVNode',
+  'compatUtils',
+  'createBlock',
+  'createCommentVNode',
+  'createElementBlock',
+  'createElementVNode',
+  'createHydrationRenderer',
+  'createPropsRestProxy',
+  'createRenderer',
+  'createSlots',
+  'createStaticVNode',
+  'createTextVNode',
+  'createVNode',
+  'getTransitionRawChildren',
+  'guardReactiveProps',
+  'handleError',
+  'initCustomFormatter',
+  'isMemoSame',
+  'isRuntimeOnly',
+  'isVNode',
+  'mergeDefaults',
+  'mergeProps',
+  'openBlock',
+  'popScopeId',
+  'pushScopeId',
+  'queuePostFlushCb',
+  'registerRuntimeCompiler',
+  'renderList',
+  'renderSlot',
+  'resolveComponent',
+  'resolveDirective',
+  'resolveDynamicComponent',
+  'resolveFilter',
+  'resolveTransitionHooks',
+  'setBlockTracking',
+  'setDevtoolsHook',
+  'setTransitionHooks',
+  'ssrContextKey',
+  'ssrUtils',
+  'toHandlers',
+  'transformVNodeArgs',
+  'useSSRContext',
+  'version',
+  'warn',
+  'watchPostEffect',
+  'watchSyncEffect',
+  'withAsyncContext',
+  'Transition',
+  'TransitionGroup',
+  'VueElement',
+  'createApp',
+  'createSSRApp',
+  'defineCustomElement',
+  'defineSSRCustomElement',
+  'hydrate',
+  'initDirectivesForSSR',
+  'render',
+  'useCssVars',
+  'vModelCheckbox',
+  'vModelDynamic',
+  'vModelRadio',
+  'vModelSelect',
+  'vModelText',
+  'vShow',
+  'compile'
+]
+
+describe('auto-imports:vue', () => {
+  for (const name of Object.keys(VueFunctions)) {
+    if (excludedVueHelpers.includes(name)) {
+      continue
+    }
+    it(`should register ${name} globally`, () => {
+      expect(Nuxt3AutoImports.find(a => a.from === 'vue').names).to.include(name)
+    })
+  }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1706

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds some missing auto-imports in Nuxt 3. (We may want to tweak this list further - please suggest away - as a lot of the more technical ones probably don't need to be auto-imported.) It also disables auto imports in Nuxt Bridge that aren't supported by the Vue 2 Composition API. And it adds tests so we will know in future if there is a new composable introduced that we should add to the list.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

