### PR TITLE
fix(bridge): Recognize {... as default } construction in vite plugin

### DIFF
--- a/packages/bridge/src/vite/plugins/default-export.ts
+++ b/packages/bridge/src/vite/plugins/default-export.ts
@@ -6,7 +6,7 @@ const PREFIX = 'defaultexport:'
 const hasPrefix = (id: string = '') => id.startsWith(PREFIX)
 const removePrefix = (id: string = '') => hasPrefix(id) ? id.substr(PREFIX.length) : id
 
-const hasDefaultExport = (code: string = '') => code.includes('export default')
+const hasDefaultExport = (code: string = '') => code.match(/export (default|.* as default)/g)
 const addDefaultExport = (code: string = '') => code + '\n\n' + 'export default () => {}'
 
 export function defaultExportPlugin () {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the construction `export { xyz as default }` is not recognized as a valid default export by the default-export vite plugin. Thus, a second default export is added, which leads to an error.
An example is 
https://github.com/posva/pinia/blob/a76e34387419e86154a63985ad038eefeb2bc9fd/packages/nuxt/src/templates/plugin.ts#L50
which is transpiled as `export { PiniaNuxtPlugin as default };` in the distributed build. (cc @posva)

This is fixed by adding a regex-based check.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

