### PR TITLE
fix(bridge): default export detection

### DIFF
--- a/packages/bridge/src/vite/plugins/default-export.ts
+++ b/packages/bridge/src/vite/plugins/default-export.ts
@@ -1,12 +1,11 @@
 import type { Plugin } from 'vite'
 import fse from 'fs-extra'
+import { findExports } from 'mlly'
 
-// const PREFIX = 'defaultexport:'
 const PREFIX = 'defaultexport:'
 const hasPrefix = (id: string = '') => id.startsWith(PREFIX)
 const removePrefix = (id: string = '') => hasPrefix(id) ? id.substr(PREFIX.length) : id
 
-const hasDefaultExport = (code: string = '') => code.includes('export default')
 const addDefaultExport = (code: string = '') => code + '\n\n' + 'export default () => {}'
 
 export function defaultExportPlugin () {
@@ -26,7 +25,8 @@ export function defaultExportPlugin () {
     async load (id) {
       if (hasPrefix(id)) {
         let code = await fse.readFile(removePrefix(id), 'utf8')
-        if (!hasDefaultExport(code)) {
+        const exports = findExports(code)
+        if (exports.find(i => i.type === 'default' || i.name === 'default')) {
           code = addDefaultExport(code)
         }
         return { map: null, code }

--- a/packages/bridge/src/vite/plugins/default-export.ts
+++ b/packages/bridge/src/vite/plugins/default-export.ts
@@ -26,7 +26,7 @@ export function defaultExportPlugin () {
       if (hasPrefix(id)) {
         let code = await fse.readFile(removePrefix(id), 'utf8')
         const exports = findExports(code)
-        if (exports.find(i => i.type === 'default' || i.name === 'default')) {
+        if (!exports.find(i => i.type === 'default' || i.name === 'default')) {
           code = addDefaultExport(code)
         }
         return { map: null, code }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/posva/pinia/issues/767

In `@pinia/nuxt`, it exports like this:

```ts
export { PiniaNuxtPlugin as default };
```

which causing

![image](https://user-images.githubusercontent.com/11247099/140691730-5504170a-a283-4089-8f56-fde5e36c926e.png)


<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

