### PR TITLE
fix(webpack): detect postcss config and show warning

### DIFF
--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -122,7 +122,7 @@ export class PostcssConfig {
   }
 
   getConfigFile () {
-    const loaderConfig = (this.postcssOptions && this.postcssOptions.config) || {}
+    const loaderConfig = this.postcssOptions && this.postcssOptions.config
     const postcssConfigFile = loaderConfig || this.searchConfigFile()
 
     if (typeof postcssConfigFile === 'string') {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Remove default value on loaderConfig, so that we can fall back to search postcss config file if not postcss config is configured.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

