### PR TITLE
feat: add `<Html>` meta component

### DIFF
--- a/docs/content/3.docs/1.usage/3.meta-tags.md
+++ b/docs/content/3.docs/1.usage/3.meta-tags.md
@@ -25,7 +25,7 @@ export default {
 
 ## Meta Components
 
-Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>` and `<Head>` components so that you can interact directly with your metadata within your component template.
+Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>`, `<Html>` and `<Head>` components so that you can interact directly with your metadata within your component template.
 
 Because these component names match native HTML elements, it is very important that they are capitalized in the template.
 

--- a/docs/content/3.docs/1.usage/3.meta-tags.md
+++ b/docs/content/3.docs/1.usage/3.meta-tags.md
@@ -56,11 +56,13 @@ For example:
 <template>
   <div>
     Hello World
-    <Head :lang="dynamic > 50 ? 'en-GB' : 'en-US'">
-      <Title>{{ dynamic }} title</Title>
-      <Meta name="description" :content="`My page's ${dynamic} description`" />
-      <Link rel="preload" href="/test.txt" as="script" />
-    </Head>
+    <Html :lang="dynamic > 50 ? 'en-GB' : 'en-US'">
+      <Head>
+        <Title>{{ dynamic }} title</Title>
+        <Meta name="description" :content="`My page's ${dynamic} description`" />
+        <Link rel="preload" href="/test.txt" as="script" />
+      </Head>
+    </Html>
 
     <button class="blue" @click="dynamic = Math.random() * 100">
       Click me

--- a/docs/content/3.docs/1.usage/3.meta-tags.md
+++ b/docs/content/3.docs/1.usage/3.meta-tags.md
@@ -23,25 +23,6 @@ export default {
 }
 ```
 
-## `head` Component Property
-
-If you would prefer to use the options syntax, you can do exactly the same thing within your component options with an object or function called `head`. For example:
-
-```js
-export default {
-  head: {
-    script: [
-      {
-        async: true,
-        src: 'https://myscript.com/script.js'
-      }
-    ]
-  }
-}
-```
-
-**Note that `head()` does not have access to the component instance.**
-
 ## Meta Components
 
 Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>` and `<Head>` components so that you can interact directly with your metadata within your component template.

--- a/examples/use-meta/app.vue
+++ b/examples/use-meta/app.vue
@@ -2,7 +2,7 @@
   <div>
     Hello World
 
-    <Html :lang="'' + dynamic">
+    <Html :lang="String(dynamic)">
       <Head>
         <Title>{{ dynamic }} title</Title>
         <Meta name="description" :content="`My page's ${dynamic} description`" />

--- a/examples/use-meta/app.vue
+++ b/examples/use-meta/app.vue
@@ -2,11 +2,13 @@
   <div>
     Hello World
 
-    <Head :lang="'' + dynamic">
-      <Title>{{ dynamic }} title</Title>
-      <Meta name="description" :content="`My page's ${dynamic} description`" />
-      <Link rel="preload" href="/test.txt" as="script" />
-    </Head>
+    <Html :lang="'' + dynamic">
+      <Head>
+        <Title>{{ dynamic }} title</Title>
+        <Meta name="description" :content="`My page's ${dynamic} description`" />
+        <Link rel="preload" href="/test.txt" as="script" />
+      </Head>
+    </Html>
 
     <button class="blue" @click="dynamic = Math.random() * 100">
       Clickme

--- a/packages/nuxt3/src/meta/runtime/components.ts
+++ b/packages/nuxt3/src/meta/runtime/components.ts
@@ -212,5 +212,5 @@ export const Html = defineComponent({
 export const Body = defineComponent({
   name: 'Body',
   props: globalProps,
-  setup: setupForUseMeta(bodyAttrs => ({ bodyAttrs }), true)
+  setup: (_props, ctx) => ctx.slots.default
 })

--- a/packages/nuxt3/src/meta/runtime/components.ts
+++ b/packages/nuxt3/src/meta/runtime/components.ts
@@ -193,6 +193,12 @@ export const Style = defineComponent({
 // <head>
 export const Head = defineComponent({
   name: 'Head',
+  setup: setupForUseMeta(() => ({}), true)
+})
+
+// <html>
+export const Html = defineComponent({
+  name: 'Html',
   props: {
     ...globalProps,
     manifest: String,

--- a/packages/nuxt3/src/meta/runtime/components.ts
+++ b/packages/nuxt3/src/meta/runtime/components.ts
@@ -199,7 +199,7 @@ export const Head = defineComponent({
     version: String,
     xmlns: String
   },
-  setup: setupForUseMeta(headAttrs => ({ headAttrs }), true)
+  setup: setupForUseMeta(htmlAttrs => ({ htmlAttrs }), true)
 })
 
 // <body>

--- a/packages/nuxt3/src/meta/runtime/components.ts
+++ b/packages/nuxt3/src/meta/runtime/components.ts
@@ -193,7 +193,7 @@ export const Style = defineComponent({
 // <head>
 export const Head = defineComponent({
   name: 'Head',
-  setup: setupForUseMeta(() => ({}), true)
+  setup: (_props, ctx) => ctx.slots.default
 })
 
 // <html>
@@ -212,5 +212,5 @@ export const Html = defineComponent({
 export const Body = defineComponent({
   name: 'Body',
   props: globalProps,
-  setup: (_props, ctx) => ctx.slots.default
+  setup: setupForUseMeta(bodyAttrs => ({ bodyAttrs }), true)
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1652

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In our docs we give an example of `<Head lang="en-GB" />`, which currently doesn't work as vueuse/head doesn't process headAttrs specifically. This PR fixes this by redirecting any props passed to `<Head>` to `htmlAttrs` instead.

We could alternatively create a `<Html>` element but this would leave `<Head>` without purpose except to visually wrap other meta components. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

