### PR TITLE
fix(nuxi): default to skipping lib check

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -12,6 +12,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
       target: 'ESNext',
       module: 'ESNext',
       moduleResolution: 'Node',
+      skipLibCheck: true,
       strict: true,
       allowJs: true,
       noEmit: true,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

see #1822

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

some issues will be thrown up by `vue-tsc` that are somewhat outside our control, such as:
```
nitro/dist/index.d.ts:14:21 - error TS7016: Could not find a declaration file for module 'fs-extra'. '/node_modules/fs-extra/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/fs-extra` if it exists or add a new declaration (.d.ts) file containing `declare module 'fs-extra';`

import fsExtra from 'fs-extra';
                    ~~~~~~~~~~

listhen/dist/index.d.ts:3:35 - error TS7016: Could not find a declaration file for module 'selfsigned'. '/node_modules/selfsigned/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/selfsigned` if it exists or add a new declaration (.d.ts) file containing `declare module 'selfsigned';`

import { SelfsignedOptions } from 'selfsigned';
                                  ~~~~~~~~~~~~

listhen/dist/index.d.ts:6:16 - error TS2665: Invalid module name in augmentation. Module 'selfsigned' resolves to an untyped module at '/node_modules/selfsigned/index.js', which cannot be augmented.
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

