### PR TITLE
fix(nuxi): set `allowSyntheticDefaultImports`

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -17,6 +17,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
       allowJs: true,
       noEmit: true,
       resolveJsonModule: true,
+      allowSyntheticDefaultImports: true,
       types: ['node'],
       baseUrl: relative(nuxt.options.buildDir, nuxt.options.rootDir),
       paths: {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

should probably have been included in https://github.com/nuxt/framework/pull/1824 🤦 
see #1822

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR covers the following errors that would be thrown up by a TS lib-check:

```
node_modules/pathe/dist/index.d.ts:1:8 - error TS1259: Module '"path"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import path from 'path';
         ~~~~

  node_modules/@types/node/path.d.ts:167:5
    167     export = path;
            ~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.

node_modules/rollup-plugin-visualizer/dist/plugin/index.d.ts:2:8 - error TS1259: Module '"/node_modules/open/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

2 import opn from "open";
         ~~~

  node_modules/open/index.d.ts:88:1
    88 export = open;
       ~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

