### PR TITLE
fix(vite): remove `global` replacement

### DIFF
--- a/packages/bridge/src/vite/client.ts
+++ b/packages/bridge/src/vite/client.ts
@@ -17,7 +17,6 @@ export async function buildClient (ctx: ViteBuildContext) {
 
   const clientConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
     define: {
-      global: 'globalThis',
       'process.client': 'true',
       'process.server': 'false',
       'process.static': 'false',

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -17,8 +17,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     define: {
       'process.server': false,
       'process.client': true,
-      'module.hot': false,
-      global: 'globalThis'
+      'module.hot': false
     },
     resolve: {
       alias: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #1821, Resolves #1713 Resolves #1006

Related https://github.com/vitejs/vite/issues/5616

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Remove `global` to `globalThis` replacements from vite. 

Alternatives to bring the backward compatibility back:

- Polyfill `process` and `global` in `globalThis`
- Use replacement with better regex

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

