### PR TITLE
chore: explicitly include `std-env` as dep for bridge fixture

### DIFF
--- a/test/fixtures/bridge/package.json
+++ b/test/fixtures/bridge/package.json
@@ -9,6 +9,7 @@
     "@nuxt/bridge": "*",
     "core-js": "^3",
     "nuxt": "^2",
+    "std-env": "^3.0.1",
     "vue": "^2"
   },
   "installConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10342,6 +10342,7 @@ __metadata:
     "@nuxt/bridge": "*"
     core-js: ^3
     nuxt: ^2
+    std-env: ^3.0.1
     vue: ^2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
…ixture

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolve #1848

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I think it's due to the `hoistingLimits` we had in the fixture so the older `std-env` from Nuxt 2 has been hoisted locally. Explicitly adding it solves the problem.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

