### PR TITLE
fix(bridge): disable legacy fetch polyfills

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -13,6 +13,10 @@ export function setupAppBridge (_options: any) {
   nuxt.options.alias.vue2 = resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
   nuxt.options.build.transpile.push('vue')
 
+  // Disable legacy fetch polyfills
+  nuxt.options.fetch.server = false
+  nuxt.options.fetch.client = false
+
   // Alias vue to have identical vue3 exports
   nuxt.options.alias['vue2-bridge'] = resolve(distDir, 'runtime/vue2-bridge.mjs')
   for (const alias of [

--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -21,9 +21,6 @@ export function setupNitroBridge () {
   // @ts-ignore
   nuxt.options.build.indicator = false
 
-  // Disable fetch polyfill (nitro provides it)
-  nuxt.options.fetch.server = false
-
   // Create contexts
   const nitroOptions = (nuxt.options as any).nitro || {}
   const nitroContext = getNitroContext(nuxt.options, nitroOptions)

--- a/test/fixtures/bridge/package.json
+++ b/test/fixtures/bridge/package.json
@@ -7,9 +7,7 @@
   },
   "devDependencies": {
     "@nuxt/bridge": "*",
-    "core-js": "^3",
-    "nuxt": "^2",
-    "std-env": "^3.0.1",
+    "nuxt-edge": "latest",
     "vue": "^2"
   },
   "installConfig": {

--- a/test/presets/_tests.mjs
+++ b/test/presets/_tests.mjs
@@ -27,7 +27,7 @@ export function setupTest (preset) {
   before('nitro build', async function () {
     this.timeout(60000)
     const nuxtCLI = isBridge
-      ? resolve(ctx.rootDir, 'node_modules/nuxt/bin/nuxt.js')
+      ? resolve(ctx.rootDir, 'node_modules/nuxt-edge/bin/nuxt.js')
       : resolveWorkspace('packages/nuxi/bin/nuxi.mjs')
 
     await execa('node', [nuxtCLI, 'build', ctx.rootDir], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,7 +414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-decorators@npm:^7.13.15, @babel/plugin-proposal-decorators@npm:^7.15.8":
+"@babel/plugin-proposal-decorators@npm:^7.13.15, @babel/plugin-proposal-decorators@npm:^7.15.8, @babel/plugin-proposal-decorators@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/plugin-proposal-decorators@npm:7.16.0"
   dependencies:
@@ -1072,7 +1072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.13.15":
+"@babel/plugin-transform-runtime@npm:^7.13.15, @babel/plugin-transform-runtime@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/plugin-transform-runtime@npm:7.16.0"
   dependencies:
@@ -1180,7 +1180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.14.1":
+"@babel/preset-env@npm:^7.14.1, @babel/preset-env@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/preset-env@npm:7.16.0"
   dependencies:
@@ -1285,6 +1285,15 @@ __metadata:
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: bfbca3ec52c94de262a3932473bceeead1a088b50194108fa1ff6eda447333f0f7d43fa4e9c5937c6e5d45bf838da8480905d0a227589b257c51f954ea060bac
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.16.0":
+  version: 7.16.3
+  resolution: "@babel/runtime@npm:7.16.3"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: ab8ac887096d76185ddbf291d28fb976cd32473696dc497ad4905b784acbd5aa462533ad83a5c5104e10ead28c2e0e119840ee28ed8eff90dcdde9d57f916eda
   languageName: node
   linkType: hard
 
@@ -2362,6 +2371,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxt/babel-preset-app-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/babel-preset-app-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@babel/compat-data": ^7.16.0
+    "@babel/core": ^7.16.0
+    "@babel/helper-compilation-targets": ^7.16.0
+    "@babel/helper-module-imports": ^7.16.0
+    "@babel/plugin-proposal-class-properties": ^7.16.0
+    "@babel/plugin-proposal-decorators": ^7.16.0
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.16.0
+    "@babel/plugin-proposal-optional-chaining": ^7.16.0
+    "@babel/plugin-proposal-private-methods": ^7.16.0
+    "@babel/plugin-transform-runtime": ^7.16.0
+    "@babel/preset-env": ^7.16.0
+    "@babel/runtime": ^7.16.0
+    "@vue/babel-preset-jsx": ^1.2.4
+    core-js: ^3.19.0
+    core-js-compat: ^3.19.1
+    regenerator-runtime: ^0.13.9
+  checksum: 8489e59b7d2a620e235bd64b4049a98793c4e06a4bc063245d25867751265f824fdf49a0c496c7325d5af0aec1609472262e8c1e6c112ff3a7fa85cc1db8c2a8
+  languageName: node
+  linkType: hard
+
 "@nuxt/babel-preset-app@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/babel-preset-app@npm:2.15.8"
@@ -2438,6 +2471,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@nuxt/builder-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/builder-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/devalue": ^2.0.0
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/vue-app-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/webpack-edge": 2.16.0-27276495.ab1c6cb4
+    chalk: ^4.1.2
+    chokidar: ^3.5.2
+    consola: ^2.15.3
+    fs-extra: ^10.0.0
+    glob: ^7.2.0
+    hash-sum: ^2.0.0
+    ignore: ^5.1.9
+    lodash: ^4.17.21
+    pify: ^5.0.0
+    serialize-javascript: ^6.0.0
+    upath: ^2.0.1
+  checksum: 4bb25992f195e7e03b6851740a0503c9d8a0467d731728af91a5cb826a370b6f35647d2ef7c3a539a67ebf6650d94d03d29842dd1e076a7181131e8ed41e5101
+  languageName: node
+  linkType: hard
+
 "@nuxt/builder@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/builder@npm:2.15.8"
@@ -2458,6 +2514,40 @@ __metadata:
     serialize-javascript: ^5.0.1
     upath: ^2.0.1
   checksum: 05ad41b077bb8c5174f9b8dd2e7f4208b92c36608280abb65ca095632004c2aae1d00e07d05de6034a812beb52ffb3dbb0835bf1d8d68979bac8e981935a4f54
+  languageName: node
+  linkType: hard
+
+"@nuxt/cli-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/cli-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/config-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    boxen: ^5.1.2
+    chalk: ^4.1.2
+    compression: ^1.7.4
+    connect: ^3.7.0
+    consola: ^2.15.3
+    crc: ^3.8.0
+    defu: ^5.0.0
+    destr: ^1.1.0
+    execa: ^5.1.1
+    exit: ^0.1.2
+    fs-extra: ^10.0.0
+    globby: ^11.0.4
+    hable: ^3.0.0
+    lodash: ^4.17.21
+    minimist: ^1.2.5
+    opener: 1.5.2
+    pretty-bytes: ^5.6.0
+    semver: ^7.3.5
+    serve-static: ^1.14.1
+    std-env: ^3.0.1
+    upath: ^2.0.1
+    wrap-ansi: ^7.0.0
+  bin:
+    nuxt-cli: bin/nuxt-cli.js
+  checksum: 6848b83bc70a51a64f69e229978a15fad95830145e7674f52718e20461f44b091affdeabc7c53d061c7af0d1d95531e481e6e132ab241e84ab3a84f1cd4946dd
   languageName: node
   linkType: hard
 
@@ -2495,7 +2585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/components@npm:^2.1.8":
+"@nuxt/components@npm:^2.1.8, @nuxt/components@npm:^2.2.1":
   version: 2.2.1
   resolution: "@nuxt/components@npm:2.2.1"
   dependencies:
@@ -2513,6 +2603,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxt/config-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/config-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    consola: ^2.15.3
+    defu: ^5.0.0
+    destr: ^1.1.0
+    dotenv: ^10.0.0
+    lodash: ^4.17.21
+    rc9: ^1.2.0
+    std-env: ^3.0.1
+    ufo: ^0.7.9
+  checksum: c0cd3995d3c208e02133dfd41aef2772312b063bd8368866e7010806dbcde57f1b5e13127a6557eadaba6b0fa224ba7d114654f24a48f68d3a8d8569cb1fdacb
+  languageName: node
+  linkType: hard
+
 "@nuxt/config@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/config@npm:2.15.8"
@@ -2527,6 +2634,22 @@ __metadata:
     std-env: ^2.3.0
     ufo: ^0.7.4
   checksum: a7368c718e40238590907ecf03d46b169abbf5c6d4f05259242630b256ab1eb78ea745cf88121100246022bc3a84e26d5042dd0f9f3a870555ce3fdabe4c0f87
+  languageName: node
+  linkType: hard
+
+"@nuxt/core-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/core-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/config-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/server-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    consola: ^2.15.3
+    fs-extra: ^10.0.0
+    hable: ^3.0.0
+    hash-sum: ^2.0.0
+    lodash: ^4.17.21
+  checksum: fb6b52c423dee3597724988989ed2b19b212a0707f1c6f6ae3e282c20e9fcd848f56d6a9ed40af87cfde77c8854560856e7af08fde7ef582bc20091e370be6d6
   languageName: node
   linkType: hard
 
@@ -2583,6 +2706,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxt/generator-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/generator-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    chalk: ^4.1.2
+    consola: ^2.15.3
+    defu: ^5.0.0
+    devalue: ^2.0.1
+    fs-extra: ^10.0.0
+    html-minifier: ^4.0.0
+    node-html-parser: ^5.1.0
+    ufo: ^0.7.9
+  checksum: c8bc8253272c62892d2067e353dc85bfb948a1444909f91ea417dd9b3a465e2dd44fa142305d56d0f8a548bb1b2c3ed03db5089745eb272bd4560373737b9b59
+  languageName: node
+  linkType: hard
+
 "@nuxt/generator@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/generator@npm:2.15.8"
@@ -2629,7 +2769,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nuxt/loading-screen@npm:^2.0.3":
+"@nuxt/loading-screen@npm:^2.0.3, @nuxt/loading-screen@npm:^2.0.4":
   version: 2.0.4
   resolution: "@nuxt/loading-screen@npm:2.0.4"
   dependencies:
@@ -2741,6 +2881,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxt/server-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/server-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/vue-renderer-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxtjs/youch": ^4.2.3
+    compression: ^1.7.4
+    connect: ^3.7.0
+    consola: ^2.15.3
+    etag: ^1.8.1
+    fresh: ^0.5.2
+    fs-extra: ^10.0.0
+    ip: ^1.1.5
+    launch-editor-middleware: ^2.2.1
+    on-headers: ^1.0.2
+    pify: ^5.0.0
+    serve-placeholder: ^1.2.4
+    serve-static: ^1.14.1
+    server-destroy: ^1.0.1
+    ufo: ^0.7.9
+  checksum: 007e79ca1535041be0de9d7d5ff2c849e89223f2beb4ecde122bb43557b0c4223b9437416a9d03aeef5e07f2911cd188d614f00103c035258dffc036ad7eadde
+  languageName: node
+  linkType: hard
+
 "@nuxt/server@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/server@npm:2.15.8"
@@ -2766,7 +2931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/telemetry@npm:^1.3.3":
+"@nuxt/telemetry@npm:^1.3.3, @nuxt/telemetry@npm:^1.3.6":
   version: 1.3.6
   resolution: "@nuxt/telemetry@npm:1.3.6"
   dependencies:
@@ -2821,6 +2986,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxt/utils-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/utils-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    consola: ^2.15.3
+    create-require: ^1.1.1
+    fs-extra: ^10.0.0
+    hash-sum: ^2.0.0
+    jiti: ^1.12.9
+    lodash: ^4.17.21
+    proper-lockfile: ^4.1.2
+    semver: ^7.3.5
+    serialize-javascript: ^6.0.0
+    signal-exit: ^3.0.5
+    ua-parser-js: ^1.0.2
+    ufo: ^0.7.9
+  checksum: f767cf069f0e50c3bea60ff8ca26de63d59e3f32d82f9da5cd27dc17211ed52f5188fabcf33092312c465511a6727a35ba937b7b64c7211d8650f1f7fc1b6b21
+  languageName: node
+  linkType: hard
+
 "@nuxt/utils@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/utils@npm:2.15.8"
@@ -2872,6 +3057,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@nuxt/vue-app-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/vue-app-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    node-fetch: ^2.6.6
+    ufo: ^0.7.9
+    unfetch: ^4.2.0
+    vue: ^2.6.14
+    vue-client-only: ^2.1.0
+    vue-meta: ^2.4.0
+    vue-no-ssr: ^1.1.1
+    vue-router: ^3.5.3
+    vue-template-compiler: ^2.6.14
+    vuex: ^3.6.2
+  checksum: f886b0540026f6c0f7df6230a4eaaf4108fce67bd58732f399eff1fe2c551ffffc731b116495988b1539452a6ef739e367ed3da62cb2ffb1fe2ffed16d425088
+  languageName: node
+  linkType: hard
+
 "@nuxt/vue-app@npm:2.15.8":
   version: 2.15.8
   resolution: "@nuxt/vue-app@npm:2.15.8"
@@ -2887,6 +3090,25 @@ __metadata:
     vue-template-compiler: ^2.6.12
     vuex: ^3.6.2
   checksum: ed83f865cb00fc7cec0eea51a0fcb70d7d80ae632335dc45d031116254fa66a0ea9e2d47536f9e5484b0955ea458f59db1c4b68d0006d911f3cdd5bf504c5f7c
+  languageName: node
+  linkType: hard
+
+"@nuxt/vue-renderer-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/vue-renderer-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/devalue": ^2.0.0
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    consola: ^2.15.3
+    defu: ^5.0.0
+    fs-extra: ^10.0.0
+    lodash: ^4.17.21
+    lru-cache: ^5.1.1
+    ufo: ^0.7.9
+    vue: ^2.6.14
+    vue-meta: ^2.4.0
+    vue-server-renderer: ^2.6.14
+  checksum: 068621a5d1699617f0ad5bdc39b8c03c2fa2d0090aba9c59414fd2ee905db98ec558c2ddf2f4e8fde5156b397ee44d2c34f4b0a4ef8a4719b698ddfe79e2ffb2
   languageName: node
   linkType: hard
 
@@ -2963,6 +3185,60 @@ __metadata:
     vue: 3.2.21
   languageName: unknown
   linkType: soft
+
+"@nuxt/webpack-edge@npm:2.16.0-27276495.ab1c6cb4":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "@nuxt/webpack-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@babel/core": ^7.16.0
+    "@nuxt/babel-preset-app-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/friendly-errors-webpack-plugin": ^2.5.2
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    babel-loader: ^8.2.3
+    cache-loader: ^4.1.0
+    caniuse-lite: ^1.0.30001275
+    consola: ^2.15.3
+    css-loader: ^4.3.0
+    cssnano: ^4.1.11
+    eventsource-polyfill: ^0.9.6
+    extract-css-chunks-webpack-plugin: ^4.9.0
+    file-loader: ^6.2.0
+    glob: ^7.2.0
+    hard-source-webpack-plugin: ^0.13.1
+    hash-sum: ^2.0.0
+    html-webpack-plugin: ^4.5.1
+    lodash: ^4.17.21
+    memory-fs: ^0.5.0
+    optimize-css-assets-webpack-plugin: ^5.0.8
+    pify: ^5.0.0
+    pnp-webpack-plugin: ^1.7.0
+    postcss: ^7.0.32
+    postcss-import: ^12.0.1
+    postcss-import-resolver: ^2.0.0
+    postcss-loader: ^3.0.0
+    postcss-preset-env: ^6.7.0
+    postcss-url: ^8.0.0
+    semver: ^7.3.5
+    std-env: ^3.0.1
+    style-resources-loader: ^1.4.1
+    terser-webpack-plugin: ^4.2.3
+    thread-loader: ^3.0.4
+    time-fix-plugin: ^2.0.7
+    ufo: ^0.7.9
+    url-loader: ^4.1.1
+    vue-loader: ^15.9.8
+    vue-style-loader: ^4.1.3
+    vue-template-compiler: ^2.6.14
+    watchpack: ^2.2.0
+    webpack: ^4.46.0
+    webpack-bundle-analyzer: ^4.5.0
+    webpack-dev-middleware: ^5.2.1
+    webpack-hot-middleware: ^2.25.1
+    webpack-node-externals: ^3.0.0
+    webpackbar: ^5.0.2
+  checksum: c253b0815e2290925696f6801cd895a05242d47374d4227c2299abd3d357d6a8afefedffea96ec48c81d350cb5d49818c1443f86a86ccad38f2f8fcca7fb7274
+  languageName: node
+  linkType: hard
 
 "@nuxt/webpack@npm:2.15.8":
   version: 2.15.8
@@ -6309,7 +6585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boxen@npm:^5.0.1":
+"boxen@npm:^5.0.1, boxen@npm:^5.1.2":
   version: 5.1.2
   resolution: "boxen@npm:5.1.2"
   dependencies:
@@ -6780,6 +7056,13 @@ __metadata:
   version: 1.0.30001278
   resolution: "caniuse-lite@npm:1.0.30001278"
   checksum: 5904289063885be40a98bf124191e816c68117d6a392065f937dd0b4929346bd677ed11ef00cadf65b2485635add46c9c33a85dc52dbf0f7dd6511f3452472bc
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001275":
+  version: 1.0.30001279
+  resolution: "caniuse-lite@npm:1.0.30001279"
+  checksum: c0330577718e4221caae92a1bee8131f546668001840cf66455d5aa6050797f44709865779c5cdcba7cbf32527004a743dc2879497d23f60478f8bbb203cfeeb
   languageName: node
   linkType: hard
 
@@ -7597,7 +7880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.12.1, core-js-compat@npm:^3.18.0, core-js-compat@npm:^3.19.0":
+"core-js-compat@npm:^3.12.1, core-js-compat@npm:^3.18.0, core-js-compat@npm:^3.19.0, core-js-compat@npm:^3.19.1":
   version: 3.19.1
   resolution: "core-js-compat@npm:3.19.1"
   dependencies:
@@ -7614,7 +7897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3, core-js@npm:^3.18.1":
+"core-js@npm:^3.18.1, core-js@npm:^3.19.0":
   version: 3.19.1
   resolution: "core-js@npm:3.19.1"
   checksum: 2f669061788dc6fea823f0433d871deeaaaacc7d68ef2748859509522a34df5c83e648c3c6a1993fed0ab188081b3cf32b957b2a1f46156a2b20bd775961ade4
@@ -10340,9 +10623,7 @@ __metadata:
   resolution: "fixture-basic@workspace:test/fixtures/bridge"
   dependencies:
     "@nuxt/bridge": "*"
-    core-js: ^3
-    nuxt: ^2
-    std-env: ^3.0.1
+    nuxt-edge: latest
     vue: ^2
   languageName: unknown
   linkType: soft
@@ -14059,7 +14340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5, node-fetch@npm:^2.6.6":
   version: 2.6.6
   resolution: "node-fetch@npm:2.6.6"
   dependencies:
@@ -14165,6 +14446,16 @@ __metadata:
     css-select: ^4.1.3
     he: 1.2.0
   checksum: f6cec214bebb42f4a2c7da0f1e5e88584657aca7da103402deb34f00eab01030f9dc738f1b84017b8e5f43047d39eb9f0f41295210206ff6a164435e8a14cd7d
+  languageName: node
+  linkType: hard
+
+"node-html-parser@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "node-html-parser@npm:5.1.0"
+  dependencies:
+    css-select: ^4.1.3
+    he: 1.2.0
+  checksum: 52349d9d5c915ddf9dc0b5078ba3209098569f7a945724a2256018d7970440edd3325b317304ad47f5a66956700165f8628ba3fee637147cd4e5b054779f8526
   languageName: node
   linkType: hard
 
@@ -14576,6 +14867,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"nuxt-edge@npm:latest":
+  version: 2.16.0-27276495.ab1c6cb4
+  resolution: "nuxt-edge@npm:2.16.0-27276495.ab1c6cb4"
+  dependencies:
+    "@nuxt/babel-preset-app-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/builder-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/cli-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/components": ^2.2.1
+    "@nuxt/config-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/core-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/generator-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/loading-screen": ^2.0.4
+    "@nuxt/opencollective": ^0.3.2
+    "@nuxt/server-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/telemetry": ^1.3.6
+    "@nuxt/utils-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/vue-app-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/vue-renderer-edge": 2.16.0-27276495.ab1c6cb4
+    "@nuxt/webpack-edge": 2.16.0-27276495.ab1c6cb4
+  bin:
+    nuxt: bin/nuxt.js
+  checksum: bd58bacc052ee0d968fd33ebbf6fd2ca235a1f7cda61d77e63c4890858f2886d36ef5093495d00ed25bd67d20574ed6f6a480c4e90450cfaabbf17aecec87870
+  languageName: node
+  linkType: hard
+
 "nuxt-framework@workspace:.":
   version: 0.0.0-use.local
   resolution: "nuxt-framework@workspace:."
@@ -14872,7 +15188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optimize-css-assets-webpack-plugin@npm:^5.0.4":
+"optimize-css-assets-webpack-plugin@npm:^5.0.4, optimize-css-assets-webpack-plugin@npm:^5.0.8":
   version: 5.0.8
   resolution: "optimize-css-assets-webpack-plugin@npm:5.0.8"
   dependencies:
@@ -15477,7 +15793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pnp-webpack-plugin@npm:^1.6.4":
+"pnp-webpack-plugin@npm:^1.6.4, pnp-webpack-plugin@npm:^1.7.0":
   version: 1.7.0
   resolution: "pnp-webpack-plugin@npm:1.7.0"
   dependencies:
@@ -18222,7 +18538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.5":
   version: 3.0.5
   resolution: "signal-exit@npm:3.0.5"
   checksum: a1d3d0d63f581bd298b30ed8f6de21b73a0fe5a0c0f123b2e8ed7168bbff8f4c1a45e681de12a1966a89bb725d8eb727816be1c436e136951f31953e4a201587
@@ -19623,6 +19939,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ua-parser-js@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "ua-parser-js@npm:1.0.2"
+  checksum: ff7f6d79a9c1a38aa85a0e751040fc7e17a0b621bda876838d14ebe55aca4e50e68da0350f181e58801c2d8a35e7db4e12473776e558910c4b7cabcec96aa3bf
+  languageName: node
+  linkType: hard
+
 "uc.micro@npm:^1.0.1, uc.micro@npm:^1.0.5":
   version: 1.0.6
   resolution: "uc.micro@npm:1.0.6"
@@ -20250,7 +20573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-client-only@npm:^2.0.0":
+"vue-client-only@npm:^2.0.0, vue-client-only@npm:^2.1.0":
   version: 2.1.0
   resolution: "vue-client-only@npm:2.1.0"
   checksum: 510b6fb51f5ec19b1a416b9ec2eaba7c9fad17889ccdad7f67e902954a13d4b757e5398e398c4b76da71b1864f72001582d2a5785b19f73593e75cbb96abf910
@@ -20281,7 +20604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-loader@npm:^15.9.7":
+"vue-loader@npm:^15.9.7, vue-loader@npm:^15.9.8":
   version: 15.9.8
   resolution: "vue-loader@npm:15.9.8"
   dependencies:
@@ -20341,7 +20664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-router@npm:^3, vue-router@npm:^3.5.1":
+"vue-router@npm:^3, vue-router@npm:^3.5.1, vue-router@npm:^3.5.3":
   version: 3.5.3
   resolution: "vue-router@npm:3.5.3"
   checksum: 7b2cc0d41ff2a8ec3da45761f29e14d0998119f47e4887f54e17eb534f7b4823acb778302891b0aa3a10c62ae8ba999393d7891cc08d36f02ea87aa268e2a36c
@@ -20415,7 +20738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^2, vue@npm:^2.6.12":
+"vue@npm:^2, vue@npm:^2.6.12, vue@npm:^2.6.14":
   version: 2.6.14
   resolution: "vue@npm:2.6.14"
   checksum: 23524a1bdca094d62cb3491a46317eed75184b5d61d28fa846ea5d2b241c1cc7084fc67ee259d47a50a6d0bbc33ecaceb7bb52bff81312fe7da07263f3419942


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#1862

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixing related issue mentioned in #1862. With nuxt 2, we were adding a polyfill for `fetch` (browser and server) but now all browsers (except our friend IE) support it so doesn't make sense to have it. This fixes only usage of `global.` in nuxt 2

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

