### PR TITLE
fix(nitro): skip non existing externals

### DIFF
--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -87,7 +87,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
 
         const writeFile = async (file) => {
           // Skip symlinks that are included in fileList
-          if (await fse.stat(file).then(i => i.isDirectory())) {
+          if (await fse.stat(file).then((i) => i.isDirectory()).catch(() => true)) {
             return
           }
           const src = resolve(opts.traceOptions.base, file)

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -87,7 +87,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
 
         const writeFile = async (file) => {
           // Skip symlinks that are included in fileList
-          if (await fse.stat(file).then((i) => i.isDirectory()).catch(() => true)) {
+          if (await fse.stat(file).then(i => i.isDirectory()).catch(() => true)) {
             return
           }
           const src = resolve(opts.traceOptions.base, file)

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -1,5 +1,5 @@
+import { promises as fsp } from 'fs'
 import { resolve, dirname } from 'pathe'
-import fse from 'fs-extra'
 import { nodeFileTrace, NodeFileTraceOptions } from '@vercel/nft'
 import type { Plugin } from 'rollup'
 
@@ -86,14 +86,11 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         }
 
         const writeFile = async (file) => {
-          // Skip symlinks that are included in fileList
-          if (await fse.stat(file).then(i => i.isDirectory()).catch(() => true)) {
-            return
-          }
+          if (!await isFile(file)) { return }
           const src = resolve(opts.traceOptions.base, file)
           const dst = resolve(opts.outDir, 'node_modules', file.split('node_modules/').pop())
-          await fse.mkdirp(dirname(dst))
-          await fse.copyFile(src, dst)
+          await fsp.mkdir(dirname(dst), { recursive: true })
+          await fsp.copyFile(src, dst)
         }
         if (process.platform === 'win32') {
           // Workaround for EBUSY on windows (#424)
@@ -105,5 +102,15 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         }
       }
     }
+  }
+}
+
+async function isFile (file: string) {
+  try {
+    const stat = await fsp.stat(file)
+    return stat.isFile()
+  } catch (err) {
+    if (err.code === 'ENOENT') { return false }
+    throw err
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Some packages don't have a `package.json` file in their root. For example, Prisma has the package.json in `.prisma/client/package.json` and not under `.prisma`. This leads to the following problem at the end of `nuxt generate`
```
 Nuxt Fatal Error                                                                                               │
   │                                                                                                                    │
   │   Error: ENOENT: no such file or directory, stat 'D:\Programming\JabRefOnline\node_modules\.prisma\package.json' 
```
This is fixed by silently ignore those packages (for prisma this is not a problem as `.prisma/client` is also imported, and thus the `package.json` file is still copied).

I wasn't sure about the coding style since the file uses an interesting mix of `await/async` and `Promise.then`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

