### PR TITLE
chore: use `triage:bug` label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-bridge.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-bridge.yml
@@ -1,6 +1,6 @@
 name: "\U0001F41E Bug report (Nuxt Bridge)"
 description: Create a report to help us improve Nuxt Bridge
-labels: [bug, bridge]
+labels: [triage:bug, bridge]
 body:
   - type: markdown
     attributes:
@@ -19,19 +19,19 @@ body:
     validations:
       required: true
   - type: textarea
-    id: bug-description
-    attributes:
-      label: Describe the bug
-      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
-      placeholder: Bug description
-    validations:
-      required: true
-  - type: textarea
     id: reproduction
     attributes:
       label: Reproduction
       description: Please provide a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://v3.nuxtjs.org/community/reporting-bugs#create-a-minimal-reproduction) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided after we might close it.
       placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report-nuxt3.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-nuxt3.yml
@@ -1,6 +1,6 @@
 name: "\U0001F41E Bug report (Nuxt 3)"
 description: Create a report to help us improve Nuxt 3
-labels: [bug, nuxt3]
+labels: [triage:bug, nuxt3]
 body:
   - type: markdown
     attributes:
@@ -19,19 +19,19 @@ body:
     validations:
       required: true
   - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo that can reproduce the problem you ran into. A [**minimal reproduction**](https://v3.nuxtjs.org/community/reporting-bugs#create-a-minimal-reproduction) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided we might close it.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
     id: bug-description
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
       placeholder: Bug description
-    validations:
-      required: true
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Reproduction
-      description: Please provide a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://v3.nuxtjs.org/community/reporting-bugs#create-a-minimal-reproduction) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided we might close it.
-      placeholder: Reproduction
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Maybe we should even change the existing issue to this label in batch?
