### PR TITLE
fix(bridge): ensure `vue` ts alias points to original vue

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -127,9 +127,16 @@ If you are using TypeScript, you can edit your `tsconfig.json` to benefit from a
 + "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
     ...
-  }
+  },
++ "vueCompilerOptions": {
++   "experimentalCompatMode": 2,
++ }
 }
 ```
+
+::alert
+You may also need to add `@vue/runtime-dom` as a devDependency if you are struggling to get template type inference working with [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar).
+::
 
 ## Migrate Composition API
 

--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -50,6 +50,12 @@ export function setupAppBridge (_options: any) {
     nuxt.options.alias[alias] = nuxt.options.alias['vue2-bridge']
   }
 
+  // Ensure TS still recognises vue imports
+  nuxt.hook('prepare:types', ({ tsConfig }) => {
+    tsConfig.compilerOptions.paths.vue2 = ['vue']
+    delete tsConfig.compilerOptions.paths.vue
+  })
+
   // Deprecate various Nuxt options
   if (nuxt.options.globalName !== 'nuxt') {
     throw new Error('Custom global name is not supported by @nuxt/bridge.')

--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -54,6 +54,11 @@ export function setupAppBridge (_options: any) {
   nuxt.hook('prepare:types', ({ tsConfig }) => {
     tsConfig.compilerOptions.paths.vue2 = ['vue']
     delete tsConfig.compilerOptions.paths.vue
+
+    // @ts-ignore
+    tsConfig.vueCompilerOptions = {
+      experimentalCompatMode: 2
+    }
   })
 
   // Deprecate various Nuxt options


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/1831, resolves #1130

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: https://github.com/nuxt/framework/pull/1861. This PR removes any rewriting of `vue` import (which would otherwise be circular).

Together with adding the following to `~~/tsconfig.json`, type inference is working for me with Volar:

```json
{
    "extends": "./.nuxt/tsconfig.json",
    "vueCompilerOptions": {
        "experimentalCompatMode": 2,
    }
}
```

Note that Volar doesn't seem to pick this up if it's added to `.nuxt/tsconfig.json`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] Add note to docs
- [ ] I have updated the documentation accordingly.

