### PR TITLE
docs: remove mention of plugins from data fetching

### DIFF
--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -8,7 +8,7 @@ Nuxt provides `useFetch`, `useLazyFetch`, `useAsyncData` and `useLazyAsyncData` 
 
 ## `useAsyncData`
 
-Within your pages, components and plugins you can use `useAsyncData` to get access to data that resolves asynchronously.
+Within your pages and components you can use `useAsyncData` to get access to data that resolves asynchronously.
 
 ### Usage
 

--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -57,7 +57,7 @@ This composable behaves identically to `useAsyncData` with the `lazy: true` opti
 
 ## `useFetch`
 
-Within your pages, components and plugins you can use `useFetch` to get universally fetch from any URL.
+Within your pages and components you can use `useFetch` to get universally fetch from any URL.
 
 This composable provides a convenient wrapper around `useAsyncData` and `$fetch` and automatically generates a key based on url and fetch options and infers API response type.
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/1915#discussioncomment-1644298

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The [docs for data fetching](https://v3.nuxtjs.org/docs/usage/data-fetching) mention you can use `useAsyncData()` / `useFetch()` in plugins.

Apparently you can't, by design.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

