### PR TITLE
fix(nuxt3): enable app-level `<suspense>` with pages module

### DIFF
--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -29,8 +29,6 @@ export default defineNuxtModule({
     })
 
     nuxt.hook('app:resolve', (app) => {
-      // Remove default root with Suspense
-      app.rootComponent = resolve(runtimeDir, 'root.vue')
       // Add default layout for pages
       if (app.mainComponent.includes('nuxt-welcome')) {
         app.mainComponent = resolve(runtimeDir, 'app.vue')

--- a/packages/nuxt3/src/pages/runtime/root.vue
+++ b/packages/nuxt3/src/pages/runtime/root.vue
@@ -1,3 +1,0 @@
-<template>
-  <App />
-</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1893
resolves #1344

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context is #750. Even with pages module enabled (which handles suspensible lIt seems we need a top-level `<Suspense>` barrier outside to cover await within `app` and layouts.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

