### PR TITLE
fix(nuxt3): enable `useAsyncData` and `useFetch` usage within plugins

### DIFF
--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -8,7 +8,7 @@ Nuxt provides `useFetch`, `useLazyFetch`, `useAsyncData` and `useLazyAsyncData` 
 
 ## `useAsyncData`
 
-Within your pages and components you can use `useAsyncData` to get access to data that resolves asynchronously.
+Within your pages, components and plugins you can use `useAsyncData` to get access to data that resolves asynchronously.
 
 ### Usage
 
@@ -57,7 +57,7 @@ This composable behaves identically to `useAsyncData` with the `lazy: true` opti
 
 ## `useFetch`
 
-Within your pages and components you can use `useFetch` to get universally fetch from any URL.
+Within your pages, components and plugins you can use `useFetch` to universally fetch from any URL.
 
 This composable provides a convenient wrapper around `useAsyncData` and `$fetch` and automatically generates a key based on url and fetch options and infers API response type.
 

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -61,7 +61,7 @@ export function useAsyncData<
 
   // Setup hook callbacks once per instance
   const instance = getCurrentInstance()
-  if (!instance._nuxtOnBeforeMountCbs) {
+  if (instance && !instance._nuxtOnBeforeMountCbs) {
     const cbs = instance._nuxtOnBeforeMountCbs = []
     if (instance && process.client) {
       onBeforeMount(() => {
@@ -125,15 +125,15 @@ export function useAsyncData<
       asyncData.pending.value = false
     }
     // 2. Initial load (server: false): fetch on mounted
-    if (nuxt.isHydrating && clientOnly) {
+    if (instance && nuxt.isHydrating && clientOnly) {
       // Fetch on mounted (initial load or lazy fetch)
       instance._nuxtOnBeforeMountCbs.push(asyncData.refresh)
     } else if (!nuxt.isHydrating) { // Navigation
-      if (options.lazy) {
+      if (instance && options.lazy) {
         // 3. Navigation (lazy: true): fetch on mounted
         instance._nuxtOnBeforeMountCbs.push(asyncData.refresh)
       } else {
-        // 4. Navigation (lazy: false): await fetch
+        // 4. Navigation (lazy: false) - or plugin usage: await fetch
         asyncData.refresh()
       }
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1931

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds the necessary checks to allow use of `useAsyncData` and `useFetch` within a plugin. Note that `lazy: true` has no effect in this case (and probably also doesn't make sense as the plugin runs on app initialisation rather than on component load)...

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

