### PR TITLE
fix(vite): external modules under`/esm/` pattern

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -42,6 +42,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       noExternal: [
         ...ctx.nuxt.options.build.transpile,
         // TODO: Use externality for production (rollup) build
+        /\/esm\//,
         /\.(es|esm|esm-browser|esm-bundler).js$/,
         '/__vue-jsx',
         '#app',

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -42,7 +42,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       noExternal: [
         ...ctx.nuxt.options.build.transpile,
         // TODO: Use externality for production (rollup) build
-        /\/esm\//,
+        /\/esm\/.*\.js$/,
         /\.(es|esm|esm-browser|esm-bundler).js$/,
         '/__vue-jsx',
         '#app',


### PR DESCRIPTION
Co-authored-by: Ben <bencodezen@users.noreply.github.com>

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Found during pairing with @bencodezen 🙌

To reproduce the bug (Vite):

```html
<script setup lang="ts">
import format from 'date-fns/format'

const date = format(new Date(), 'yyyy/MM/dd')
</script>

<template>
  <div>
    {{ date }}
  </div>
</template>
```

which will cause the error of `export` is not a valid syntax. Searching down, the root cause is that the internal module of `date-fns` been externalized but in a `.js` format of ESM in `server.mjs`

This PR adds the conversion to externalize modules under `/esm/` which I believe is a common pattern (`date-fns` is using is at least).

https://unpkg.com/browse/date-fns@2.25.0/esm/_lib/protectedTokens/index.js

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

