### PR TITLE
fix(kit): support chainable `extendRoutes` in container

### DIFF
--- a/packages/kit/src/module/container.ts
+++ b/packages/kit/src/module/container.ts
@@ -107,7 +107,12 @@ export function createModuleContainer (nuxt: Nuxt) {
       if (isNuxt2(nuxt)) {
         nuxt.options.router.extendRoutes = chainFn(nuxt.options.router.extendRoutes, fn)
       } else {
-        nuxt.hook('pages:extend', fn)
+        nuxt.hook('pages:extend', async (pages, ...args) => {
+          const maybeRoutes = await fn(pages, ...args)
+          if (maybeRoutes) {
+            console.warn('[kit] [compat] Using `extendRoutes` in Nuxt 3 needs to directly modify first argument instead of returning updated routes. Skipping extended routes.')
+          }
+        })
       }
     },
 

--- a/packages/kit/src/module/container.ts
+++ b/packages/kit/src/module/container.ts
@@ -108,7 +108,7 @@ export function createModuleContainer (nuxt: Nuxt) {
       if (isNuxt2(nuxt)) {
         nuxt.options.router.extendRoutes = chainFn(nuxt.options.router.extendRoutes, fn)
       } else {
-        extendPages(routes => fn(routes, resolveAlias))
+        nuxt.hook('pages:extend', fn)
       }
     },
 

--- a/packages/kit/src/module/container.ts
+++ b/packages/kit/src/module/container.ts
@@ -1,9 +1,8 @@
 import { parse, relative } from 'pathe'
 import consola from 'consola'
-import { isNuxt2 } from '@nuxt/kit'
 import type { Nuxt, NuxtPluginTemplate, NuxtTemplate } from '../types/nuxt'
 import { chainFn } from '../utils/task'
-import { addTemplate, addPluginTemplate, addServerMiddleware } from './utils'
+import { isNuxt2, addTemplate, addPluginTemplate, addServerMiddleware } from './utils'
 import { installModule } from './install'
 
 /** Legacy ModuleContainer for backwards compatibility with existing Nuxt 2 modules. */

--- a/packages/kit/src/module/container.ts
+++ b/packages/kit/src/module/container.ts
@@ -1,5 +1,6 @@
 import { parse, relative } from 'pathe'
 import consola from 'consola'
+import { isNuxt2 } from '@nuxt/kit'
 import type { Nuxt, NuxtPluginTemplate, NuxtTemplate } from '../types/nuxt'
 import { chainFn } from '../utils/task'
 import { resolveAlias } from '../utils/resolve'
@@ -104,7 +105,11 @@ export function createModuleContainer (nuxt: Nuxt) {
 
     /** Allows extending routes by chaining `options.build.extendRoutes` function. */
     extendRoutes (fn) {
-      extendPages(routes => fn(routes, resolveAlias))
+      if (isNuxt2(nuxt)) {
+        nuxt.options.router.extendRoutes = chainFn(nuxt.options.router.extendRoutes, fn)
+      } else {
+        extendPages(routes => fn(routes, resolveAlias))
+      }
     },
 
     /** `requireModule` is a shortcut for `addModule` */

--- a/packages/kit/src/module/container.ts
+++ b/packages/kit/src/module/container.ts
@@ -3,8 +3,7 @@ import consola from 'consola'
 import { isNuxt2 } from '@nuxt/kit'
 import type { Nuxt, NuxtPluginTemplate, NuxtTemplate } from '../types/nuxt'
 import { chainFn } from '../utils/task'
-import { resolveAlias } from '../utils/resolve'
-import { addTemplate, addPluginTemplate, addServerMiddleware, extendPages } from './utils'
+import { addTemplate, addPluginTemplate, addServerMiddleware } from './utils'
 import { installModule } from './install'
 
 /** Legacy ModuleContainer for backwards compatibility with existing Nuxt 2 modules. */

--- a/packages/kit/src/module/utils.ts
+++ b/packages/kit/src/module/utils.ts
@@ -6,6 +6,7 @@ import { pascalCase, camelCase, kebabCase } from 'scule'
 import type { WebpackPluginInstance, Configuration as WebpackConfig } from 'webpack'
 import type { Plugin as VitePlugin, UserConfig as ViteConfig } from 'vite'
 import satisfies from 'semver/functions/satisfies.js' // npm/node-semver#381
+import { chainFn } from '../utils/task'
 import { NuxtCompatibilityConstraints, NuxtCompatibilityIssues } from '../types/module'
 import { Nuxt } from '../types/nuxt'
 import { useNuxt } from '../nuxt'
@@ -354,7 +355,11 @@ export function addComponent (opts: AddComponentOptions) {
 
 export function extendPages (cb: NuxtHooks['pages:extend']) {
   const nuxt = useNuxt()
-  nuxt.hook('pages:extend', cb)
+  if (isNuxt2(nuxt)) {
+    nuxt.hook('build:extendRoutes', cb)
+  } else {
+    nuxt.hook('pages:extend', cb)
+  }
 }
 
 const serialize = (data: any) => JSON.stringify(data, null, 2).replace(/"{(.+)}"/g, '$1')

--- a/packages/kit/src/module/utils.ts
+++ b/packages/kit/src/module/utils.ts
@@ -6,7 +6,6 @@ import { pascalCase, camelCase, kebabCase } from 'scule'
 import type { WebpackPluginInstance, Configuration as WebpackConfig } from 'webpack'
 import type { Plugin as VitePlugin, UserConfig as ViteConfig } from 'vite'
 import satisfies from 'semver/functions/satisfies.js' // npm/node-semver#381
-import { chainFn } from '../utils/task'
 import { NuxtCompatibilityConstraints, NuxtCompatibilityIssues } from '../types/module'
 import { Nuxt } from '../types/nuxt'
 import { useNuxt } from '../nuxt'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

ref: #1740, #1965

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Allow chaining routes when using kit's legacy ModuleContainer 
- Separate `extendRoutes` and `extendPages` implementations

Caveats: For Nuxt3, chaining is still not supported anymore even when using legacy ModuleContainer (A warning will be emitted to show when skipping)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

