### PR TITLE
fix(nuxi): ignore static check with `prepare` command

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -11,7 +11,7 @@ export function setupNitroBridge () {
   const nuxt = useNuxt()
 
   // Ensure we're not just building with 'static' target
-  if (!nuxt.options.dev && nuxt.options.target === 'static' && !nuxt.options._export && !nuxt.options._legacyGenerate) {
+  if (!nuxt.options.dev && nuxt.options.target === 'static' && !nuxt.options._prepare && !nuxt.options._export && !nuxt.options._legacyGenerate) {
     throw new Error('[nitro] Please use `nuxt generate` for static target')
   }
 

--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -11,7 +11,7 @@ export function setupNitroBridge () {
   const nuxt = useNuxt()
 
   // Ensure we're not just building with 'static' target
-  if (!nuxt.options.dev && nuxt.options.target === 'static' && !nuxt.options._prepare && !nuxt.options._export && !nuxt.options._legacyGenerate) {
+  if (!nuxt.options.dev && nuxt.options.target === 'static' && !nuxt.options._export && !nuxt.options._legacyGenerate) {
     throw new Error('[nitro] Please use `nuxt generate` for static target')
   }
 

--- a/packages/nuxi/src/commands/prepare.ts
+++ b/packages/nuxi/src/commands/prepare.ts
@@ -15,7 +15,7 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt } = await loadKit(rootDir)
-    const nuxt = await loadNuxt({ rootDir })
+    const nuxt = await loadNuxt({ rootDir, config: { _prepare: true } })
     await clearDir(nuxt.options.buildDir)
 
     await writeTypes(nuxt)

--- a/packages/nuxi/src/commands/prepare.ts
+++ b/packages/nuxi/src/commands/prepare.ts
@@ -15,7 +15,7 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt } = await loadKit(rootDir)
-    const nuxt = await loadNuxt({ rootDir, config: { _prepare: true } })
+    const nuxt = await loadNuxt({ rootDir, dev: true })
     await clearDir(nuxt.options.buildDir)
 
     await writeTypes(nuxt)

--- a/packages/nuxi/src/commands/prepare.ts
+++ b/packages/nuxi/src/commands/prepare.ts
@@ -15,7 +15,7 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt } = await loadKit(rootDir)
-    const nuxt = await loadNuxt({ rootDir, dev: true })
+    const nuxt = await loadNuxt({ rootDir, config: { _prepare: true } })
     await clearDir(nuxt.options.buildDir)
 
     await writeTypes(nuxt)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1946

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This sets `dev` when running `prepare` to avoid the build-time generate check in the bridge module setup.

I would also consider removing this check entirely.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

