### PR TITLE
fix(nuxi): handle missing typescript options in build

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -14,7 +14,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
       module: 'ESNext',
       moduleResolution: 'Node',
       skipLibCheck: true,
-      strict: nuxt.options.typescript.strict,
+      strict: nuxt.options.typescript?.strict ?? false,
       allowJs: true,
       noEmit: true,
       resolveJsonModule: true,


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an issue with bridge (where there are no nuxt typescript options):

```
❯ yarn nuxi prepare test/fixtures/bridge
Nuxt CLI v3.0.0

 ERROR  Cannot read property 'strict' of undefined

  at writeTypes (packages/nuxi/src/utils/prepare.ts:17:39)
  at Object.invoke (packages/nuxi/src/commands/prepare.ts:21:35)
  at async _main (packages/nuxi/src/index.ts:40:7)
```

`<joke>` Ironically this issue would have been avoided if strict were `true` .... `</joke>`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

