### PR TITLE
fix(bridge): Handle undefined close function on bundle builder

### DIFF
--- a/packages/bridge/src/vite/module.ts
+++ b/packages/bridge/src/vite/module.ts
@@ -43,7 +43,9 @@ export default defineNuxtModule<ViteOptions>({
     addPluginTemplate(middlewareTemplate)
 
     nuxt.hook('builder:prepared', async (builder) => {
-      builder.bundleBuilder.close()
+      if (builder.bundleBuilder.close) {
+        builder.bundleBuilder.close()
+      }
       delete builder.bundleBuilder
       const { ViteBuilder } = await import('./vite')
       builder.bundleBuilder = new ViteBuilder(builder)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the context of building storybook (using https://github.com/nuxt-community/storybook), I got the following error
```
√ Builder initialized                                                                                                                                                                                                        10:27:02

 FATAL  builder.bundleBuilder.close is not a function                                                                                                                                                                        10:27:03  

  at fn (/D:/Programming/JabRefOnline/node_modules/@nuxt/bridge/dist/chunks/module2.mjs:154:29)
  at fn (node_modules\hable\src\hable.js:63:45)
  at name (node_modules\hable\src\utils.js:15:67)
  at async Nuxt.callHook (node_modules\hable\src\hable.js:59:22)
  at async Builder.build (node_modules\@nuxt\builder-edge\dist\builder.js:258:5)
```
And in fact, the `bundleBuilder` only had a `build` function. Thus, I added and if statement to check for the existence of the `close` function. Not sure if that's the way to go or if the close function is always expected to be there and there is a problem in the setup somewhere.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

