### PR TITLE
fix: Nuxi cjs importModule with jiti

### DIFF
--- a/packages/nuxi/src/utils/cjs.ts
+++ b/packages/nuxi/src/utils/cjs.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'module'
-import { pathToFileURL } from 'url'
 import { normalize, dirname } from 'pathe'
+import jiti from 'jiti'
 
 export function getModulePaths (paths?: string | string[]): string[] {
   return [].concat(
@@ -31,7 +31,7 @@ export function requireModule (id: string, paths?: string | string[]) {
 
 export function importModule (id: string, paths?: string | string[]) {
   const resolvedPath = resolveModule(id, paths)
-  return import(pathToFileURL(resolvedPath).href)
+  return jiti(resolvedPath, { interopDefault: true })(resolvedPath)
 }
 
 export function getNearestPackage (id: string, paths?: string | string[]) {


### PR DESCRIPTION
### 🔗 Linked issue

#1795

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Solves #1795
We couldn't loadNuxt in CJS because import would return a default key.
By using Jiti we ensure that both in CJS and ESM we get { loadNuxt: Function[] } when calling loadKit.
And we can then destructure const { loadNuxt } = loadKit()

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

