### PR TITLE
fix(bridge): exclude bridge alias types to support Volar

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -39,7 +39,13 @@ export const writeTypes = async (nuxt: Nuxt) => {
     '#assets': '@nuxt/nitro'
   }
 
+  // Do not alias types for Vue 3 packages to support Volar
+  const excludedAlias = [/^vue$/, /^@vue\/.*$/]
+
   for (const alias in aliases) {
+    if (excludedAlias.some(re => re.test(alias))) {
+      continue
+    }
     const relativePath = relative(nuxt.options.rootDir, aliases[alias]).replace(/(?<=\w)\.\w+$/g, '') /* remove extension */ || '.'
     tsConfig.compilerOptions.paths[alias] = [relativePath]
 

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -39,7 +39,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
     '#assets': '@nuxt/nitro'
   }
 
-  // Do not alias types for Vue 3 packages to support Volar
+  // Exclude bridge alias types to support Volar
   const excludedAlias = [/^@vue\/.*$/]
 
   for (const alias in aliases) {

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -40,7 +40,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
   }
 
   // Do not alias types for Vue 3 packages to support Volar
-  const excludedAlias = [/^vue$/, /^@vue\/.*$/]
+  const excludedAlias = [/^@vue\/.*$/]
 
   for (const alias in aliases) {
     if (excludedAlias.some(re => re.test(alias))) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#1920

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the Volar support on Bridge is still broken. I think the root cause is that Volar will use the types from `@vue/runtime-core` to resolve the types but we are forced to alias it. 

![image](https://user-images.githubusercontent.com/11247099/142435093-ca600062-7335-4105-a59d-a5f0b6298c65.png)

I can confirm locally that removing the selected items will make it work.

Repro: 
- https://github.com/antfu/vitesse-nuxt-bridge
- https://github.com/nuxt/modules

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

