### PR TITLE
fix(nuxt3): add missing `key` property to meta components

### DIFF
--- a/packages/nuxt3/src/meta/runtime/components.ts
+++ b/packages/nuxt3/src/meta/runtime/components.ts
@@ -153,6 +153,7 @@ export const Meta = defineComponent({
     charset: String,
     content: String,
     httpEquiv: String,
+    key: String,
     name: String
   },
   setup: setupForUseMeta(meta => ({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#2029

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

If we have multiple meta tags with the same name (e.g. `<meta name="keywords" content="foo"> and <meta name="keywords" content="bar">`) then @vueuse/head will just keep the last meta tag. To avoid that we can add a property key to the meta tag and @vueuse/head will keep both meta tags.
This works fine with the composable useMeta but in the Meta component we need to add the key property to pass it then to useMeta.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

