### PR TITLE
docs: disable gem dragging

### DIFF
--- a/docs/components/atoms/Gem.vue
+++ b/docs/components/atoms/Gem.vue
@@ -79,6 +79,7 @@ export default {
     controls.enableZoom = false
     controls.target.set(0, 0.75, 0)
     controls.enableDamping = true
+    controls.enablePan = false
     // Lock Y Axis
     controls.minPolarAngle = Math.PI / 2
     controls.maxPolarAngle = Math.PI / 2


### PR DESCRIPTION
Fixes issue [#1852](https://github.com/nuxt/nuxtjs.org/issues/1852) of nuxtjs.org repository

### 🔗 Linked issue

[#1852](https://github.com/nuxt/nuxtjs.org/issues/1852)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The homepage of the docs of v3 contains a gem, which can be dragged out of view by moving the mouse while pressing right click (or using two fingers on mobile). This PR disables dragging.

Resolves [#1852](https://github.com/nuxt/nuxtjs.org/issues/1852)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.