### PR TITLE
docs(examples): add example for runtime route extend

### DIFF
--- a/examples/extend-routes/README.md
+++ b/examples/extend-routes/README.md
@@ -1,6 +1,6 @@
 # Adding routes dynamically
 
-This example showcase how to add routes at runtime using [`router.addRoute()`](https://next.router.vuejs.org/guide/advanced/dynamic-routing.html#adding-routes) method from [vue-router](https://next.router.vuejs.org).
+This example showcases how to add routes at runtime using [`router.addRoute()`](https://next.router.vuejs.org/guide/advanced/dynamic-routing.html#adding-routes) method from [vue-router](https://next.router.vuejs.org).
 
 Play online on [StackBliz](https://stackblitz.com/github/nuxt/framework/tree/main/examples/extend-routes)
 

--- a/examples/extend-routes/README.md
+++ b/examples/extend-routes/README.md
@@ -1,0 +1,11 @@
+# Adding routes dynamically
+
+This example showcase how to add routes at runtime using [`router.addRoute()`](https://next.router.vuejs.org/guide/advanced/dynamic-routing.html#adding-routes) method from [vue-router](https://next.router.vuejs.org).
+
+Play online on [StackBliz](https://stackblitz.com/github/nuxt/framework/tree/main/examples/extend-routes)
+
+## Setup
+
+```bash
+npx nuxi init nuxt3-app -t nuxt/framework/examples/extend-routes
+```

--- a/examples/extend-routes/README.md
+++ b/examples/extend-routes/README.md
@@ -2,7 +2,7 @@
 
 This example showcases how to add routes at runtime using [`router.addRoute()`](https://next.router.vuejs.org/guide/advanced/dynamic-routing.html#adding-routes) method from [vue-router](https://next.router.vuejs.org).
 
-Play online on [StackBliz](https://stackblitz.com/github/nuxt/framework/tree/main/examples/extend-routes)
+Play online on [StackBlitz](https://stackblitz.com/github/nuxt/framework/tree/main/examples/extend-routes).
 
 ## Setup
 

--- a/examples/extend-routes/app.vue
+++ b/examples/extend-routes/app.vue
@@ -1,0 +1,16 @@
+<script setup>
+const routes = useRouter().getRoutes()
+</script>
+
+<template>
+  <div>
+    <ul>
+      <li v-for="route of routes" :key="route.path">
+        <NuxtLink :to="route">
+          {{ route.path }}
+        </NuxtLink>
+      </li>
+    </ul>
+    <NuxtPage />
+  </div>
+</template>

--- a/examples/extend-routes/areas/about/pages/about.vue
+++ b/examples/extend-routes/areas/about/pages/about.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>About page</h1>
+</template>

--- a/examples/extend-routes/package.json
+++ b/examples/extend-routes/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example-extend-routes",
+  "private": true,
+  "devDependencies": {
+    "nuxt3": "latest"
+  },
+  "scripts": {
+    "dev": "nuxi dev",
+    "build": "nuxi build",
+    "start": "node .output/server/index.mjs"
+  }
+}

--- a/examples/extend-routes/pages/index.vue
+++ b/examples/extend-routes/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Index page</h1>
+</template>

--- a/examples/extend-routes/plugins/extend-routes.ts
+++ b/examples/extend-routes/plugins/extend-routes.ts
@@ -1,0 +1,6 @@
+export default defineNuxtPlugin(({ $router }) => {
+  $router.addRoute({
+    path: '/about',
+    component: () => import('~/areas/about/pages/about.vue')
+  })
+})

--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -3,6 +3,7 @@ import { getCurrentInstance, reactive } from 'vue'
 import type { App, VNode } from 'vue'
 import { createHooks, Hookable } from 'hookable'
 import type { RuntimeConfig } from '@nuxt/kit'
+import { Router } from 'vue-router'
 import { legacyPlugin, LegacyContext } from './compat/legacy-app'
 
 type NuxtMeta = {
@@ -22,6 +23,7 @@ export interface RuntimeNuxtHooks {
   'app:rendered': () => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
+  'router:created': (router: Router) => HookResult
   'meta:register': (metaRenderers: Array<(nuxt: NuxtApp) => NuxtMeta | Promise<NuxtMeta>>) => HookResult
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10249,6 +10249,14 @@ __metadata:
   languageName: node
   linkType: hard
 
+"example-extend-routes@workspace:examples/extend-routes":
+  version: 0.0.0-use.local
+  resolution: "example-extend-routes@workspace:examples/extend-routes"
+  dependencies:
+    nuxt3: latest
+  languageName: unknown
+  linkType: soft
+
 "example-hello-world@workspace:examples/hello-world":
   version: 0.0.0-use.local
   resolution: "example-hello-world@workspace:examples/hello-world"


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

Since vue-router 4 has the `addRoute` method, I believe adding routes at runtime is quite interesting.
We can discuss about merging this example with https://github.com/nuxt/framework/tree/main/examples/module-extend-pages to showcase the two possibilities.

Once done, and adding the examples section (#1960), we will be able to improve the documentation about routing 😊 

### 📝 Checklist

- [ ] There is an hydration error happening when hitting the dynamically added route coming from SSR. Any help on this would be much appreciated @posva 

https://user-images.githubusercontent.com/904724/142760337-b35ee82b-901d-459b-a43f-3f25bd460a41.mp4

To run the example locally (read https://github.com/nuxt/framework#-development first):
```bash
yarn example extend-routes
```

