### PR TITLE
fix(cli): enable `usage` command

### DIFF
--- a/packages/nuxi/src/commands/usage.ts
+++ b/packages/nuxi/src/commands/usage.ts
@@ -1,4 +1,5 @@
 import { cyan } from 'colorette'
+import { showHelp } from '../utils/help'
 import { commands, defineNuxtCommand } from './index'
 
 export default defineNuxtCommand({
@@ -13,5 +14,8 @@ export default defineNuxtCommand({
     sections.push(`Usage: ${cyan(`npx nuxi ${Object.keys(commands).join('|')} [args]`)}`)
 
     console.log(sections.join('\n\n') + '\n')
+
+    // Reuse the same wording as in `-h` commands
+    showHelp({})
   }
 })

--- a/packages/nuxi/src/index.ts
+++ b/packages/nuxi/src/index.ts
@@ -1,5 +1,5 @@
 import mri from 'mri'
-import { red, cyan } from 'colorette'
+import { red } from 'colorette'
 import consola from 'consola'
 import { checkEngines } from './utils/engines'
 import { commands, Command, NuxtCommand } from './commands'

--- a/packages/nuxi/src/index.ts
+++ b/packages/nuxi/src/index.ts
@@ -14,22 +14,19 @@ async function _main () {
     ]
   })
   // @ts-ignore
-  let command = args._.shift() || 'usage'
+  const command = args._.shift() || 'usage'
 
   showBanner(command === 'dev' && args.clear !== false)
 
   if (!(command in commands)) {
     console.log('\n' + red('Invalid command ' + command))
-    command = 'usage'
+
+    await commands.usage().then(r => r.invoke())
+    process.exit(1)
   }
 
   // Check Node.js version in background
   setTimeout(() => { checkEngines() }, 1000)
-
-  if (command === 'usage') {
-    console.log(`\nUsage: ${cyan(`npx nuxi ${Object.keys(commands).join('|')} [args]`)}\n`)
-    process.exit(1)
-  }
 
   try {
     // @ts-ignore default.default is hotfix for #621


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2062

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR aims to remove duplicated code and calls `usage` command directly (unless there's a reason we weren't doing that already?).

Output: 
```
❯ yarn nuxi usage
Nuxt CLI v3.0.0
Usage: npx nuxi dev|build|analyze|generate|prepare|usage|info|init|create|upgrade [args]

Use npx nuxi [command] --help to see help for each command

```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

