### PR TITLE
fix(nitro): respect fs structure for traced files

### DIFF
--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -87,7 +87,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         const writeFile = async (file) => {
           if (!await isFile(file)) { return }
           const src = resolve(opts.traceOptions.base, file)
-          const dst = resolve(opts.outDir, file.replace(/^.*?node_modules[\\/](.*)$/, '$1'))
+          const dst = resolve(opts.outDir, 'node_modules', file.replace(/^.*?node_modules[\\/](.*)$/, '$1'))
           await fsp.mkdir(dirname(dst), { recursive: true })
           await fsp.copyFile(src, dst)
         }

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -87,7 +87,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         const writeFile = async (file) => {
           if (!await isFile(file)) { return }
           const src = resolve(opts.traceOptions.base, file)
-          const dst = resolve(opts.outDir, 'node_modules', file.split('node_modules/').pop())
+          const dst = resolve(opts.outDir, file.replace(/^.*?node_modules[\\/](.*)$/, '$1'))
           await fsp.mkdir(dirname(dst), { recursive: true })
           await fsp.copyFile(src, dst)
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2083
(likely) resolves #309

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Sometimes we have multiple versions of a library (such as `tslib`) with different major versions required for server dependencies. (See #2083 for example.) Previous tracing implementation flattened this out, for a disk space improvement, but risked resolving multiple versions to last-identified nft file.

Example nft results:
```bash
/node_modules/tslib/tslib.js
/node_modules/@azure/ms-rest-js/node_modules/tslib/package.json
# this ends up overriding the one above
/node_modules/@azure/ms-rest-js/node_modules/tslib/tslib.js 
```

Alternatively, we could check package versions, but I think it's safer to respect package manager's judgement on whether to flatten/nest the dependency.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

