### PR TITLE
docs: fix usage/cookies url and table of contents

### DIFF
--- a/docs/content/3.docs/1.usage/6.cookies.md
+++ b/docs/content/3.docs/1.usage/6.cookies.md
@@ -71,7 +71,7 @@ so if both are set, they should point to the same date and time!
 If neither of `expires` and `maxAge` is set, the cookie will be session-only and removed when the user closes their browser.
 ::
 
-#### `httpOnly`
+### `httpOnly`
 
 Specifies the `boolean` value for the [`HttpOnly` `Set-Cookie` attribute](https://tools.ietf.org/html/rfc6265#section-5.2.6). When truthy,
 the `HttpOnly` attribute is set; otherwise it is not. By default, the `HttpOnly` attribute is not set.
@@ -81,7 +81,7 @@ the `HttpOnly` attribute is set; otherwise it is not. By default, the `HttpOnly`
 JavaScript to see the cookie in `document.cookie`.
 ::
 
-#### `secure`
+### `secure`
 
 Specifies the `boolean` value for the [`Secure` `Set-Cookie` attribute](https://tools.ietf.org/html/rfc6265#section-5.2.5). When truthy,
 the `Secure` attribute is set; otherwise it is not. By default, the `Secure` attribute is not set.
@@ -91,17 +91,17 @@ the `Secure` attribute is set; otherwise it is not. By default, the `Secure` att
 the server in the future if the browser does not have an HTTPS connection. This can lead to hydration errors.
 ::
 
-#### `domain`
+### `domain`
 
 Specifies the value for the [`Domain` `Set-Cookie` attribute](https://tools.ietf.org/html/rfc6265#section-5.2.3). By default, no
 domain is set, and most clients will consider to apply the cookie only to the current domain.
 
-#### `path`
+### `path`
 
 Specifies the value for the [`Path` `Set-Cookie` attribute](https://tools.ietf.org/html/rfc6265#section-5.2.4). By default, the path
 is considered the ["default path"](https://tools.ietf.org/html/rfc6265#section-5.1.4).
 
-#### `sameSite`
+### `sameSite`
 
 Specifies the `boolean` or `string` value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).
 
@@ -113,7 +113,7 @@ Specifies the `boolean` or `string` value for the [`SameSite` `Set-Cookie` attri
 
 More information about the different enforcement levels can be found in [the specification](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).
 
-#### `encode`
+### `encode`
 
 Specifies a function that will be used to encode a cookie's value. Since the value of a cookie
 has a limited character set (and must be a simple string), this function can be used to encode
@@ -121,7 +121,7 @@ a value into a string suited for a cookie's value.
 
 The default encoder is the `JSON.stringify` + `encodeURIComponent`.
 
-#### `decode`
+### `decode`
 
 Specifies a function that will be used to decode a cookie's value. Since the value of a cookie
 has a limited character set (and must be a simple string), this function can be used to decode


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR makes the _cookies_ page available at `docs/usage/cookies` and fixes its table of contents (some section headers were nested one level too deep and weren't included).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

