### PR TITLE
feat(nitro): pass Rollup options from Nuxt config (#2091)

### DIFF
--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -72,3 +72,31 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
   req.someValue = true
 }
 ```
+
+## Server Options
+
+You may include Rollup's [big list of options](https://rollupjs.org/guide/en/#big-list-of-options) in the Nuxt config as:
+
+```js
+export default defineNuxtConfig({
+  build: {
+    rollup: {
+      // ...
+    }
+  }
+})
+```
+
+if you need support for file watch polling for the server directory, for example:
+
+```js
+export default defineNuxtConfig({
+  build: {
+    rollup: {
+      chokidar: {
+        usePolling: true
+      }
+    }
+  }
+})
+```

--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -99,7 +99,7 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
     entry: undefined,
     node: undefined,
     preset: undefined,
-    rollupConfig: undefined,
+    rollupConfig: nuxtOptions.build.rollup,
     experiments: {},
     moduleSideEffects: ['unenv/runtime/polyfill/'],
     renderer: undefined,

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -79,6 +79,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
   const runtimeAppDir = join(nitroContext._internal.runtimeDir, 'app')
 
   const rollupConfig: RollupConfig = {
+    ...nitroContext.rollupConfig,
     input: resolvePath(nitroContext, nitroContext.entry),
     output: {
       dir: nitroContext.output.serverDir,

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -28,6 +28,14 @@ export default {
   analyze: false,
 
   /**
+   * Pass through Rollup options. Useful, for example, if polling for rebuild is required for some environments.
+   *
+   * @see [Rollup Options](https://rollupjs.org/guide/en/#big-list-of-options)
+   * @type {RollupOptions}
+   */
+  rollup: {},
+
+  /**
    * Enable the profiler in webpackbar.
    *
    * It is normally enabled by CLI argument `--profile`.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#2091 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Specifically, WSL 1 users still require polling on the Nitro server to trigger rebuilds on file changes. Other build components support this option, but seems to have been missed for Nitro.

`RollupOptions` have been added as `NuxtConfig.build.rollup`, such that `chokidar.usePolling` may be used for Nitro for example.

Resolves #2091 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

