### PR TITLE
docs: remove dangling comma from sample `tsconfig.json`

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -129,7 +129,7 @@ If you are using TypeScript, you can edit your `tsconfig.json` to benefit from a
     ...
   },
 + "vueCompilerOptions": {
-+   "experimentalCompatMode": 2,
++   "experimentalCompatMode": 2
 + }
 }
 ```


### PR DESCRIPTION
Dangling comma is not valid JSON.
Given the whole section is added, it does not look like `experimentalCompatMode` is added as one of many properties, but it's the only one and then should not have a comma.

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
