### PR TITLE
fix(nuxt3): handle hydration for `error` and `pending` state

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -64,9 +64,7 @@ export default (ctx, inject) => {
     nuxtApp.vue2App = this
   })
 
-  ctx.app.mounted.push(function () {
-    nuxtApp.isHydrating = false
-  })
+  ctx.app.mounted.push(() => { nuxtApp.isHydrating = false })
 
   const proxiedApp = new Proxy(nuxtApp, {
     get (target, prop) {

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -122,20 +122,15 @@ export function useAsyncData<
   }
 
   // Client side
-  if (process.client) {
-    if (!asyncData.pending.value) {
-      // 1. Hydration (server: true): no fetch
-    } else if (instance && nuxt.isHydrating) {
+  // 1. Hydration (server: true): no fetch
+  if (process.client && asyncData.pending.value) {
+    if (instance && (nuxt.isHydrating || options.lazy)) {
       // 2. Initial load (server: false): fetch on mounted
+      // 3. Navigation (lazy: true): fetch on mounted
       instance._nuxtOnBeforeMountCbs.push(asyncData.refresh)
-    } else if (!nuxt.isHydrating) {
-      if (instance && options.lazy) {
-        // 3. Navigation (lazy: true): fetch on mounted
-        instance._nuxtOnBeforeMountCbs.push(asyncData.refresh)
-      } else {
-        // 4. Navigation (lazy: false) - or plugin usage: await fetch
-        asyncData.refresh()
-      }
+    } else {
+      // 4. Navigation (lazy: false) - or plugin usage: await fetch
+      asyncData.refresh()
     }
   }
 

--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -76,6 +76,7 @@ export function createNuxtApp (options: CreateOptions) {
     payload: reactive({
       data: {},
       state: {},
+      _errors: {},
       ...(process.client ? window.__NUXT__ : { serverRendered: true })
     }),
     isHydrating: process.client,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2122
resolves #2032

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR includes pending/error state within the payload. Otherwise a page that (for example) checked `v-if="error"` would fail to hydrate between client/server. Because we're including pending state as well, we can use that to detect whether we need to refetch data on client side.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

