### PR TITLE
feat(nuxi): add `typecheck` command using `vue-tsc`

### DIFF
--- a/docs/content/1.getting-started/5.commands.md
+++ b/docs/content/1.getting-started/5.commands.md
@@ -73,3 +73,11 @@ To upgrade Nuxt3 version:
 ```bash
 npx nuxi upgrade
 ```
+
+## Checking types
+
+To type-check your application, you can use `nuxi typecheck`. This uses [`vue-tsc`](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-tsc) under the hood. If you have both a locally installed version of `typescript` and `vue-tsc`, nuxi will use these when type-checking.
+
+```bash
+npx nuxi typecheck
+```

--- a/docs/content/2.concepts/3.typescript.md
+++ b/docs/content/2.concepts/3.typescript.md
@@ -4,10 +4,10 @@ Nuxt 3 is fully typed and provides helpful shortcuts to ensure you have access t
 
 ## Type-checking
 
-By default, Nuxt doesn't check types when you run `nuxi dev` or `nuxi build`, for performance reasons. However, you can manually check your types using [`vue-tsc`](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-tsc).
+By default, Nuxt doesn't check types when you run `nuxi dev` or `nuxi build`, for performance reasons. However, you can [manually check your types with nuxi](/getting-started/commands).
 
 ```bash
-npx vue-tsc --noEmit
+yarn nuxi typecheck
 ```
 
 ## Auto-generated types

--- a/packages/nuxi/src/commands/index.ts
+++ b/packages/nuxi/src/commands/index.ts
@@ -8,6 +8,7 @@ export const commands = {
   analyze: () => import('./analyze').then(_rDefault),
   generate: () => import('./generate').then(_rDefault),
   prepare: () => import('./prepare').then(_rDefault),
+  typecheck: () => import('./typecheck').then(_rDefault),
   usage: () => import('./usage').then(_rDefault),
   info: () => import('./info').then(_rDefault),
   init: () => import('./init').then(_rDefault),

--- a/packages/nuxi/src/commands/typecheck.ts
+++ b/packages/nuxi/src/commands/typecheck.ts
@@ -1,0 +1,32 @@
+import { execa } from 'execa'
+import { resolve } from 'pathe'
+import { tryResolveModule } from '../utils/cjs'
+
+import { loadKit } from '../utils/kit'
+import { writeTypes } from '../utils/prepare'
+import { defineNuxtCommand } from './index'
+
+export default defineNuxtCommand({
+  meta: {
+    name: 'typecheck',
+    usage: 'npx nuxi typecheck [rootDir]',
+    description: 'Runs `vue-tsc` to check types throughout your app.'
+  },
+  async invoke (args) {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+    const rootDir = resolve(args._[0] || '.')
+
+    const { loadNuxt } = await loadKit(rootDir)
+    const nuxt = await loadNuxt({ rootDir, config: { _prepare: true } })
+
+    // Generate types and close nuxt instance
+    await writeTypes(nuxt)
+    await nuxt.close()
+
+    // Prefer local install if possible
+    const hasLocalInstall = tryResolveModule('typescript') && tryResolveModule('vue-tsc/package.json')
+    const npxArgs = hasLocalInstall ? '' : '-p vue-tsc -p typescript '
+
+    await execa('npx', `${npxArgs}vue-tsc --noEmit`.split(' '), { stdio: 'inherit' })
+  }
+})

--- a/packages/nuxi/src/commands/typecheck.ts
+++ b/packages/nuxi/src/commands/typecheck.ts
@@ -24,9 +24,11 @@ export default defineNuxtCommand({
     await nuxt.close()
 
     // Prefer local install if possible
-    const hasLocalInstall = tryResolveModule('typescript') && tryResolveModule('vue-tsc/package.json')
-    const npxArgs = hasLocalInstall ? '' : '-p vue-tsc -p typescript '
-
-    await execa('npx', `${npxArgs}vue-tsc --noEmit`.split(' '), { stdio: 'inherit' })
+    const hasLocalInstall = tryResolveModule('typescript', rootDir) && tryResolveModule('vue-tsc/package.json', rootDir)
+    if (hasLocalInstall) {
+      await execa('vue-tsc', ['--noEmit'], { preferLocal: true, stdio: 'inherit', cwd: rootDir })
+    } else {
+      await execa('npx', '-p vue-tsc -p typescript vue-tsc --noEmit'.split(' '), { stdio: 'inherit', cwd: rootDir })
+    }
   }
 })

--- a/packages/schema/src/config/_internal.ts
+++ b/packages/schema/src/config/_internal.ts
@@ -10,6 +10,8 @@ export default {
   /** @private */
   _generate: false,
   /** @private */
+  _prepare: false,
+  /** @private */
   _cli: false,
   /** @private */
   _requiredModules: {},


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1825

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for using `vue-tsc` in any nuxt project. It will first generate the types and then run `vue-tsc` on the project.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

