### PR TITLE
fix(vite): don't copy `publicDir` files to `_nuxt`

### DIFF
--- a/packages/nitro/src/build.ts
+++ b/packages/nitro/src/build.ts
@@ -4,7 +4,7 @@ import * as rollup from 'rollup'
 import fse from 'fs-extra'
 import { printFSTree } from './utils/tree'
 import { getRollupConfig } from './rollup/config'
-import { hl, prettyPath, serializeTemplate, writeFile, isDirectory } from './utils'
+import { hl, prettyPath, serializeTemplate, writeFile, isDirectory, readDirRecursively } from './utils'
 import { NitroContext } from './context'
 import { scanMiddleware } from './server/middleware'
 
@@ -30,14 +30,18 @@ async function cleanupDir (dir: string) {
 export async function generate (nitroContext: NitroContext) {
   consola.start('Generating public...')
 
-  const clientDist = resolve(nitroContext._nuxt.buildDir, 'dist/client')
-  if (await isDirectory(clientDist)) {
-    await fse.copy(clientDist, join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath))
+  const publicDir = nitroContext._nuxt.publicDir
+  let publicFiles: string[] = []
+  if (await isDirectory(publicDir)) {
+    publicFiles = readDirRecursively(publicDir).map(r => r.replace(publicDir, ''))
+    await fse.copy(publicDir, nitroContext.output.publicDir)
   }
 
-  const publicDir = nitroContext._nuxt.publicDir
-  if (await isDirectory(publicDir)) {
-    await fse.copy(publicDir, nitroContext.output.publicDir)
+  const clientDist = resolve(nitroContext._nuxt.buildDir, 'dist/client')
+  if (await isDirectory(clientDist)) {
+    await fse.copy(clientDist, join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath), {
+      filter: src => !publicFiles.includes(src.replace(clientDist, ''))
+    })
   }
 
   consola.success('Generated public ' + prettyPath(nitroContext.output.publicDir))

--- a/packages/nitro/src/build.ts
+++ b/packages/nitro/src/build.ts
@@ -40,6 +40,8 @@ export async function generate (nitroContext: NitroContext) {
   const clientDist = resolve(nitroContext._nuxt.buildDir, 'dist/client')
   if (await isDirectory(clientDist)) {
     await fse.copy(clientDist, join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath), {
+      // TODO: Workaround vite's issue that duplicates public files
+      // https://github.com/nuxt/framework/issues/1192
       filter: src => !publicFiles.includes(src.replace(clientDist, ''))
     })
   }

--- a/packages/nitro/src/utils/index.ts
+++ b/packages/nitro/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'module'
-import { relative, dirname, resolve } from 'pathe'
+import { relative, dirname, join, resolve } from 'pathe'
 import fse from 'fs-extra'
 import jiti from 'jiti'
 import defu from 'defu'
@@ -147,4 +147,12 @@ export function readPackageJson (
     }
     throw error
   }
+}
+
+export function readDirRecursively (dir: string) {
+  return fse.readdirSync(dir).reduce((files, file) => {
+    const name = join(dir, file)
+    const isDirectory = fse.statSync(name).isDirectory()
+    return isDirectory ? [...files, ...readDirRecursively(name)] : [...files, name]
+  }, [])
 }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,4 +1,3 @@
-import { promises as fsp } from 'fs'
 import * as vite from 'vite'
 import { resolve } from 'pathe'
 import consola from 'consola'

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,3 +1,4 @@
+import { promises as fsp } from 'fs'
 import * as vite from 'vite'
 import { resolve } from 'pathe'
 import consola from 'consola'
@@ -49,6 +50,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         },
         base: nuxt.options.build.publicPath,
+        publicDir: resolve(nuxt.options.srcDir, nuxt.options.dir.public),
         // TODO: move to kit schema when it exists
         vue: {
           isProduction: !nuxt.options.dev,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1192

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When building, vite copies `publicDir` contents and places them alongside assets in the `_nuxt` folder. This is an unwanted duplication of assets. (They will never be served from this path.) We can 'fix' this behaviour by simply not copying these files across to `.output/public`.

Ideally we would fix this with a PR to vite itself to allow us to allow js files to be included with `assetsDir` as well, rather than setting vite's `base: '_nuxt'`, which seems like a workaround for our desired nuxt behaviour. (cc: @antfu)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

