### PR TITLE
fix(nuxi): add `nuxt3` to dev deps in upgrade command

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -44,7 +44,7 @@ export default defineNuxtCommand({
       execSync(`${packageManager} install`, { stdio: 'inherit' })
     } else {
       consola.info('Upgrading nuxt...')
-      execSync(`${packageManager} ${packageManager === 'yarn' ? 'add' : 'install'} nuxt3@latest`, { stdio: 'inherit' })
+      execSync(`${packageManager} ${packageManager === 'yarn' ? 'add' : 'install'} -D nuxt3@latest`, { stdio: 'inherit' })
     }
 
     const upgradedVersion = await getNuxtVersion(rootDir)


### PR DESCRIPTION


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add nuxt3 to dev dependencies. Otherwise users on default `nuxt/starter` get something like the following message:

```
Nuxt CLI v3.0.0-27293794.c3b72a6
ℹ Package Manager: yarn 1.22.17
ℹ Current nuxt version: 3.0.0-27293794.c3b72a6
ℹ Upgrading nuxt...
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
warning "nuxt3" is already in "devDependencies". Please remove existing entry first before adding it to "dependencies".
success Saved 12 new dependencies.
```
