### PR TITLE
perf(nuxt3): don't include null errors in payload

### DIFF
--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -104,7 +104,9 @@ export function useAsyncData<
       .finally(() => {
         asyncData.pending.value = false
         nuxt.payload.data[key] = asyncData.data.value
-        nuxt.payload._errors[key] = !!asyncData.error.value
+        if (asyncData.error.value) {
+          nuxt.payload._errors[key] = !!asyncData.error.value
+        }
         delete nuxt._asyncDataPromises[key]
       })
     return nuxt._asyncDataPromises[key]

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -105,7 +105,7 @@ export function useAsyncData<
         asyncData.pending.value = false
         nuxt.payload.data[key] = asyncData.data.value
         if (asyncData.error.value) {
-          nuxt.payload._errors[key] = !!asyncData.error.value
+          nuxt.payload._errors[key] = true
         }
         delete nuxt._asyncDataPromises[key]
       })


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

By setting explicitly to null when there's no error we also add asyncData _key_ to payload which can't be deduplicated as the null value can. This PR avoids that cost by only setting errors if they exist.