### PR TITLE
fix(autoImports): dirs option should be of type `string[]`

### DIFF
--- a/packages/schema/src/types/imports.ts
+++ b/packages/schema/src/types/imports.ts
@@ -51,5 +51,5 @@ export interface AutoImportsOptions {
    *
    * By default <rootDir>/composables is added
    */
-   dirs?: []
+   dirs?: string[]
 }


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Simply fixes an issue where the `autoImports.dirs` type was set to `[]` instead of `string[]`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

