### PR TITLE
fix(nitro): fix rendering with `ssr` disabled

### DIFF
--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -10,7 +10,7 @@ const NUXT_NO_SSR = process.env.NUXT_NO_SSR
 const PAYLOAD_JS = '/payload.js'
 
 const getClientManifest = cachedImport(() => import('#build/dist/server/client.manifest.mjs'))
-const getSSRApp = cachedImport(() => import('#build/dist/server/server.mjs'))
+const getSSRApp = !process.env.NUXT_NO_SSR && cachedImport(() => import('#build/dist/server/server.mjs'))
 
 const publicPath = (publicConfig.app && publicConfig.app.assetsPath) || process.env.PUBLIC_PATH || '/_nuxt'
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

fix #886

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When using `ssr: false`, `server.mjs` doesn't exist, but Rollup gets confused because it thinks `server.mjs` might be imported. To fix this, I added a condition so that Rollup knows that `server.mjs` will never be loaded if `NUXT_NO_SSR` is `true`.

I also added code to handle the new Vite manifest format in `getSPARenderer`.

To test my changes, I added `ssr: false` to `playground/nuxt.config.ts`. Then, I ran `npx yarn run nuxi build playground && node playground/.output/server/index.mjs`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

