### PR TITLE
feat(nuxt3): add `autoRegisterPlugins` option to config

### DIFF
--- a/docs/content/3.docs/2.directory-structure/10.plugins.md
+++ b/docs/content/3.docs/2.directory-structure/10.plugins.md
@@ -9,7 +9,7 @@ head.title: Plugins directory
 Nuxt will automatically read the files in your `plugins` directory and load them. You can use `.server` or `.client` suffix in the file name to load a plugin only on the server or client side.
 
 ::alert{type=warning}
-All plugins in your `plugins/` directory are auto-registered, so you should not add them to your `nuxt.config` separately.
+All plugins in your `plugins/` directory are auto-registered, so you should not add them to your `nuxt.config` separately unless set `autoRegisterPlugins: false` in your `nuxt.config`.
 ::
 
 ## Creating plugins

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -73,7 +73,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // Resolve plugins
   app.plugins = [
     ...nuxt.options.plugins,
-    ...await resolveFiles(nuxt.options.srcDir, 'plugins/**/*.{js,ts,mjs,cjs}')
+    ...(nuxt.options.autoRegisterPlugins ? await resolveFiles(nuxt.options.srcDir, 'plugins/**/*.{js,ts,mjs,cjs}') : [])
   ].map(plugin => normalizePlugin(plugin))
 
   // Extend app

--- a/packages/schema/src/config/_app.ts
+++ b/packages/schema/src/config/_app.ts
@@ -193,6 +193,13 @@ export default {
   extendPlugins: null,
 
   /**
+   * You may want to disable plugins auto importing.
+   * @type {boolean}
+   * @version 3
+   */
+  autoRegisterPlugins: true,
+
+  /**
    * You can define the CSS files/modules/libraries you want to set globally
    * (included in every page).
    *


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #2163 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I added an option to the `nuxt.config` with `autoRegisterPlugins` name and default value of `true`. So if anyone (like me) doesn't want plugins auto registering, can disable it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

