### PR TITLE
fix(webpack): remove MiniCssExtractPlugin.loader options (#2217)

### DIFF
--- a/packages/webpack/src/presets/style.ts
+++ b/packages/webpack/src/presets/style.ts
@@ -104,8 +104,7 @@ function createCssLoadersRule (ctx: WebpackConfigContext, cssLoaderOptions) {
 
     return [
       {
-        loader: MiniCssExtractPlugin.loader,
-        options: { reloadAll: ctx.isDev, hot: ctx.isDev }
+        loader: MiniCssExtractPlugin.loader
       },
       cssLoader
     ]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolves #2217
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`reloadall` and `hot`  property of `minicssextractplugin.loader` options have been removed. it will cause error when build with webpack If we continue to set them, 
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

