### PR TITLE
fix(bridge, kit): don't modify template array whilst traversing it

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -69,13 +69,10 @@ export function defineNuxtModule<OptionsT extends ModuleOptions> (input: NuxtMod
       // Support virtual templates with getContents() by writing them to .nuxt directory
       let virtualTemplates: NuxtTemplate[]
       nuxt.hook('builder:prepared', (_builder, buildOptions) => {
-        virtualTemplates = []
-        buildOptions.templates.forEach((template, index, arr) => {
-          if (!template.getContents) { return }
-          // Remove template from template array to handle it ourselves
-          arr.splice(index, 1)
-          virtualTemplates.push(template)
-        })
+        virtualTemplates = buildOptions.templates.filter(t => t.getContents)
+        for (const template of virtualTemplates) {
+          buildOptions.templates.splice(buildOptions.templates.indexOf(template), 1)
+        }
       })
       nuxt.hook('build:templates', async (templates) => {
         const context = {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2222

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With addition of other virtual templates in Nuxt Bridge (https://github.com/nuxt/framework/pull/2168), a bug in the underlying implementation (https://github.com/nuxt/framework/pull/587) was exposed (splicing array whilst traversing with `forEach` ended up failing to process last item.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

