### PR TITLE
fix(nitro): respect app.cdnURL when set

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -1,7 +1,7 @@
 import { promises as fsp } from 'fs'
 import fetch from 'node-fetch'
 import { addPluginTemplate, useNuxt } from '@nuxt/kit'
-import { stringifyQuery } from 'ufo'
+import { hasProtocol, isRelative, joinURL, stringifyQuery } from 'ufo'
 import { resolve } from 'pathe'
 import { build, generate, prepare, getNitroContext, NitroContext, createDevServer, wpfs, resolveMiddleware } from '@nuxt/nitro'
 import { AsyncLoadingPlugin } from './async-loading'
@@ -13,6 +13,14 @@ export function setupNitroBridge () {
   // Ensure we're not just building with 'static' target
   if (!nuxt.options.dev && nuxt.options.target === 'static' && !nuxt.options._prepare && !nuxt.options._export && !nuxt.options._legacyGenerate) {
     throw new Error('[nitro] Please use `nuxt generate` for static target')
+  }
+
+  // Default CDN assetsPath to `/_nuxt` for better caching
+  const useCDN = hasProtocol(nuxt.options.build.publicPath, true) && !nuxt.options.dev
+  const isRelativePublicPath = isRelative(nuxt.options.build.publicPath)
+
+  if (nuxt.options.app.basePath === nuxt.options.app.assetsPath) {
+    nuxt.options.app.assetsPath = isRelativePublicPath ? nuxt.options.build.publicPath : useCDN ? '/_nuxt/' : joinURL(nuxt.options.router.base, nuxt.options.build.publicPath)
   }
 
   // Disable loading-screen

--- a/packages/bridge/src/vite/manifest.ts
+++ b/packages/bridge/src/vite/manifest.ts
@@ -46,7 +46,7 @@ export async function prepareManifests (ctx: ViteBuildContext) {
 export async function generateBuildManifest (ctx: ViteBuildContext) {
   const rDist = (...args: string[]): string => resolve(ctx.nuxt.options.buildDir, 'dist', ...args)
 
-  const publicPath = ctx.nuxt.options.app.assetsPath // Default: /nuxt/
+  const publicPath = ctx.nuxt.options._app.cdnURL || ctx.nuxt.options._app.assetsPath // Default: /nuxt/
   const viteClientManifest = await fse.readJSON(rDist('client/manifest.json'))
   const clientEntries = Object.entries(viteClientManifest)
 

--- a/packages/bridge/src/vite/manifest.ts
+++ b/packages/bridge/src/vite/manifest.ts
@@ -46,7 +46,7 @@ export async function prepareManifests (ctx: ViteBuildContext) {
 export async function generateBuildManifest (ctx: ViteBuildContext) {
   const rDist = (...args: string[]): string => resolve(ctx.nuxt.options.buildDir, 'dist', ...args)
 
-  const publicPath = ctx.nuxt.options._app.cdnURL || ctx.nuxt.options._app.assetsPath // Default: /nuxt/
+  const publicPath = ctx.nuxt.options.app.cdnURL || ctx.nuxt.options.app.assetsPath // Default: /nuxt/
   const viteClientManifest = await fse.readJSON(rDist('client/manifest.json'))
   const clientEntries = Object.entries(viteClientManifest)
 

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from 'http'
 import { createRenderer } from 'vue-bundle-renderer'
 import devalue from '@nuxt/devalue'
+import { joinURL } from 'ufo'
 import { privateConfig, publicConfig } from './config'
 // @ts-ignore
 import htmlTemplate from '#build/views/document.template.mjs'
@@ -13,7 +14,7 @@ const getClientManifest = cachedImport(() => import('#build/dist/server/client.m
 const getSSRApp = cachedImport(() => import('#build/dist/server/server.mjs'))
 
 const appConfig = publicConfig._app /* Nuxt 2 */ || publicConfig.app /* Nuxt 3 */
-const publicPath = appConfig ? appConfig.cdnURL || appConfig.assetsPath : '/_nuxt'
+const publicPath = appConfig ? joinURL(appConfig.cdnURL, appConfig.assetsPath) : '/_nuxt'
 
 const getSSRRenderer = cachedResult(async () => {
   // Load client manifest

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -12,7 +12,8 @@ const PAYLOAD_JS = '/payload.js'
 const getClientManifest = cachedImport(() => import('#build/dist/server/client.manifest.mjs'))
 const getSSRApp = cachedImport(() => import('#build/dist/server/server.mjs'))
 
-const publicPath = (publicConfig.app && publicConfig.app.assetsPath) || process.env.PUBLIC_PATH || '/_nuxt'
+const appConfig = publicConfig._app /* Nuxt 2 */ || publicConfig.app /* Nuxt 3 */
+const publicPath = appConfig ? appConfig.cdnURL || appConfig.assetsPath : '/_nuxt'
 
 const getSSRRenderer = cachedResult(async () => {
   // Load client manifest

--- a/packages/nitro/src/runtime/server/static.ts
+++ b/packages/nitro/src/runtime/server/static.ts
@@ -27,7 +27,7 @@ export default async function serveStatic (req, res) {
   }
 
   if (!asset) {
-    if (id.startsWith(PUBLIC_PATH) && !id.startsWith(STATIC_ASSETS_BASE)) {
+    if (PUBLIC_PATH !== '/' && id.startsWith(PUBLIC_PATH) && !id.startsWith(STATIC_ASSETS_BASE)) {
       throw createError({
         statusMessage: 'Cannot find static asset ' + id,
         statusCode: 404

--- a/packages/nitro/src/runtime/server/static.ts
+++ b/packages/nitro/src/runtime/server/static.ts
@@ -27,7 +27,7 @@ export default async function serveStatic (req, res) {
   }
 
   if (!asset) {
-    if (PUBLIC_PATH !== '/' && id.startsWith(PUBLIC_PATH) && !id.startsWith(STATIC_ASSETS_BASE)) {
+    if (id.startsWith(PUBLIC_PATH) && !id.startsWith(STATIC_ASSETS_BASE)) {
       throw createError({
         statusMessage: 'Cannot find static asset ' + id,
         statusCode: 404

--- a/packages/schema/src/config/_app.ts
+++ b/packages/schema/src/config/_app.ts
@@ -29,16 +29,26 @@ export default {
   /**
    * Nuxt App configuration.
    * @version 2
+   * @version 3
    */
   app: {
     $resolve: (val, get) => {
-      const useCDN = hasProtocol(get('build.publicPath'), true) && !get('dev')
+      const useCDN = (val?.cdnURL || hasProtocol(get('build.publicPath'), true)) && !get('dev')
       const isRelativePublicPath = isRelative(get('build.publicPath'))
-      return defu(val, {
-        basePath: get('router.base'),
-        assetsPath: isRelativePublicPath ? get('build.publicPath') : useCDN ? '/' : joinURL(get('router.base'), get('build.publicPath')),
-        cdnURL: useCDN ? get('build.publicPath') : null
-      })
+
+      const basePath = val?.basePath ?? get('router.base')
+      const assetsPath = val?.assetsPath ?? (isRelativePublicPath ? get('build.publicPath') : useCDN ? '/_nuxt/' : joinURL(get('router.base'), get('build.publicPath')))
+      const cdnURL = val?.cdnURL ?? (useCDN ? get('build.publicPath') : null)
+
+      if (basePath === assetsPath) {
+        throw new Error('[schema] basePath and assetsPath cannot be the same')
+      }
+
+      return {
+        basePath,
+        assetsPath,
+        cdnURL
+      }
     }
   },
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1467
resolves #2242

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`cdnURL` wasn't being taken into account by bundle-renderer. In addition, when serving static files from `/` we were never allowing a fallback to rendering the vue app. I don't think it's safe simply to disable `serveStatic` when a CDN is in use, but I would certainly suggest to users that they disable serving static files when using a CDN that does not rely on 'pulling' files from their site:

```js
import { defineNuxtConfig } from 'nuxt3'

export default defineNuxtConfig({
  nitro: {
    serveStatic: false
  }
})
```

**Note**: We didn't reserve `.app` namespace in Nuxt 2 (see https://github.com/nuxt/nuxt.js/pull/9075) in case it's in use so we need to check `._app` existence first.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

