### PR TITLE
fix(vite): don't prepend publicPath to public assets

### DIFF
--- a/packages/nitro/src/build.ts
+++ b/packages/nitro/src/build.ts
@@ -49,7 +49,9 @@ export async function generate (nitroContext: NitroContext) {
 
     // Copy nested /_nuxt/_nuxt files across
     // TODO: Workaround vite issue
-    await fse.copy(join(clientDist, nitroContext._nuxt.publicPath), join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath))
+    if (await isDirectory(join(clientDist, nitroContext._nuxt.publicPath))) {
+      await fse.copy(join(clientDist, nitroContext._nuxt.publicPath), join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath))
+    }
   }
 
   consola.success('Generated public ' + prettyPath(nitroContext.output.publicDir))

--- a/packages/nitro/src/build.ts
+++ b/packages/nitro/src/build.ts
@@ -40,17 +40,19 @@ export async function generate (nitroContext: NitroContext) {
 
   const clientDist = resolve(nitroContext._nuxt.buildDir, 'dist/client')
   if (await isDirectory(clientDist)) {
-    const assetsPath = withoutTrailingSlash(join(clientDist, nitroContext._nuxt.publicPath))
-    await fse.copy(clientDist, join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath), {
+    const viteAssetsPath = withoutTrailingSlash(join(clientDist, nitroContext._nuxt.publicPath))
+    const distPublicPath = join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath)
+
+    await fse.copy(clientDist, distPublicPath, {
       // TODO: Workaround vite's issue that duplicates public files
       // https://github.com/nuxt/framework/issues/1192
-      filter: src => !publicFiles.includes(src.replace(clientDist, '')) && !src.includes(assetsPath)
+      filter: src => !publicFiles.includes(src.replace(clientDist, '')) && !src.includes(viteAssetsPath)
     })
 
-    // Copy nested /_nuxt/_nuxt files across
+    // Copy doubly-nested /_nuxt/_nuxt files across
     // TODO: Workaround vite issue
-    if (await isDirectory(join(clientDist, nitroContext._nuxt.publicPath))) {
-      await fse.copy(join(clientDist, nitroContext._nuxt.publicPath), join(nitroContext.output.publicDir, nitroContext._nuxt.publicPath))
+    if (await isDirectory(viteAssetsPath)) {
+      await fse.copy(viteAssetsPath, distPublicPath)
     }
   }
 

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -5,6 +5,7 @@ import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { Connect } from 'vite'
 
+import { withoutLeadingSlash } from 'ufo'
 import { cacheDirPlugin } from './plugins/cache-dir'
 import { analyzePlugin } from './plugins/analyze'
 import { wpfs } from './utils/wpfs'
@@ -31,7 +32,7 @@ export async function buildClient (ctx: ViteBuildContext) {
           entryFileNames: ctx.nuxt.options.dev ? 'entry.mjs' : '[name]-[hash].mjs'
         }
       },
-      assetsDir: '.',
+      assetsDir: withoutLeadingSlash(ctx.nuxt.options.app.assetsPath),
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client')
     },

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -31,6 +31,7 @@ export async function buildClient (ctx: ViteBuildContext) {
           entryFileNames: ctx.nuxt.options.dev ? 'entry.mjs' : '[name]-[hash].mjs'
         }
       },
+      assetsDir: '.',
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client')
     },

--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -27,21 +27,23 @@ export async function writeManifest (ctx: ViteBuildContext, extraEntries: string
     ? devClientManifest
     : await fse.readJSON(resolve(clientDist, 'manifest.json'))
 
-  const assetsDir = withoutTrailingSlash(withoutLeadingSlash(ctx.nuxt.options.app.assetsPath))
-  const publicPathRE = new RegExp(`^${assetsDir}/`)
+  if (!ctx.nuxt.options.dev) {
+    const assetsDir = withoutTrailingSlash(withoutLeadingSlash(ctx.nuxt.options.app.assetsPath))
+    const publicPathRE = new RegExp(`^${assetsDir}/`)
 
-  // Remove assetsDir prefix (`_nuxt`) inserted by vite
-  clientManifest = Object.fromEntries(Object.entries(clientManifest).map(([key, value]) => {
-    const entry: Record<string, any> = value
-    for (const key of ['css', 'assets']) {
-      if (key in entry) {
-        entry[key] = entry[key].map(item => item.replace(publicPathRE, ''))
+    // Remove assetsDir prefix (`_nuxt`) inserted by vite
+    clientManifest = Object.fromEntries(Object.entries(clientManifest).map(([key, value]) => {
+      const entry: Record<string, any> = value
+      for (const key of ['css', 'assets']) {
+        if (key in entry) {
+          entry[key] = entry[key].map(item => item.replace(publicPathRE, ''))
+        }
       }
-    }
-    return [key, entry]
-  }))
+      return [key, entry]
+    }))
 
-  await fse.writeFile(resolve(clientDist, 'manifest.json'), JSON.stringify(clientManifest, null, 2), 'utf8')
+    await fse.writeFile(resolve(clientDist, 'manifest.json'), JSON.stringify(clientManifest, null, 2), 'utf8')
+  }
 
   await fse.mkdirp(serverDist)
   await fse.writeFile(resolve(serverDist, 'client.manifest.json'), JSON.stringify(clientManifest, null, 2), 'utf8')

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -6,6 +6,7 @@ import fse from 'fs-extra'
 import pDebounce from 'p-debounce'
 import consola from 'consola'
 import { resolveModule } from '@nuxt/kit'
+import { withoutLeadingSlash } from 'ufo'
 import { ViteBuildContext, ViteOptions } from './vite'
 import { wpfs } from './utils/wpfs'
 import { cacheDirPlugin } from './plugins/cache-dir'
@@ -54,6 +55,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     },
     build: {
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
+      assetsDir: withoutLeadingSlash(ctx.nuxt.options.app.assetsPath),
       ssr: true,
       rollupOptions: {
         output: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -48,7 +48,7 @@ export async function bundle (nuxt: Nuxt) {
             'abort-controller': 'unenv/runtime/mock/empty'
           }
         },
-        base: nuxt.options.app.cdnURL || '/',
+        base: nuxt.options.dev ? nuxt.options.build.publicPath : nuxt.options.app.cdnURL || '/',
         publicDir: resolve(nuxt.options.srcDir, nuxt.options.dir.public),
         // TODO: move to kit schema when it exists
         vue: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -48,7 +48,7 @@ export async function bundle (nuxt: Nuxt) {
             'abort-controller': 'unenv/runtime/mock/empty'
           }
         },
-        base: nuxt.options.build.publicPath,
+        base: nuxt.options.app.cdnURL || '/',
         publicDir: resolve(nuxt.options.srcDir, nuxt.options.dir.public),
         // TODO: move to kit schema when it exists
         vue: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -48,7 +48,7 @@ export async function bundle (nuxt: Nuxt) {
             'abort-controller': 'unenv/runtime/mock/empty'
           }
         },
-        base: nuxt.options.dev ? nuxt.options.build.publicPath : nuxt.options.app.cdnURL || '/',
+        base: nuxt.options.dev ? nuxt.options.build.publicPath : '/',
         publicDir: resolve(nuxt.options.srcDir, nuxt.options.dir.public),
         // TODO: move to kit schema when it exists
         vue: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2261

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR sets base to be `/` or cdnURL, if set (previously `_nuxt`), and set `assetsDir` instead to `_nuxt`. This means we have the desired rewriting in the HTML for our assets: static assets aren't rewritten, but generated assets are. The only hack is that we then have to rewrite the client manifest to remove this `assetsDir` prefix (because the bundle renderer will handle re-inserting it for us).

Ideally we would have support in vite directly for this.

It produces a file structure like:
```
.output/public/_nuxt/entry-74f24f8b.mjs
.output/public/_nuxt/entry.bb100772.css
.output/public/_nuxt/logo-2.148d9522.svg
.output/public/_nuxt/manifest.json
.output/public/_nuxt/vendor-1887291f.mjs
.output/public/robots.txt
.output/public/logo.svg
```

and in the HTML:

```html
<!DOCTYPE html>
<html data-head-attrs="">

<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <meta name="head:count" content="2">
  <link rel="modulepreload" href="/_nuxt/entry-74f24f8b.mjs" as="script">
  <link rel="preload" href="/_nuxt/entry.bb100772.css" as="style">
  <link rel="modulepreload" href="/_nuxt/vendor-1887291f.mjs" as="script">
  <link rel="prefetch" href="/_nuxt/logo-2.148d9522.svg">
  <link rel="stylesheet" href="/_nuxt/entry.bb100772.css">
</head>

<body data-head-attrs="">
  <div id="__nuxt">
    <div class="app" data-v-12ae6901><img src="/logo.svg" height="40" data-v-12ae6901><img
        src="/_nuxt/logo-2.148d9522.svg" height="40" data-v-12ae6901>
      <h1 class="greeting" data-v-12ae6901>Hello, <br data-v-12ae6901>Nuxt 3! </h1>
    </div>
  </div>
  <script>window.__NUXT__ = { data: {}, state: { hello: "Hello" }, _errors: {}, serverRendered: true, config: { app: { basePath: "\u002F", assetsPath: "\u002F_nuxt\u002F", cdnURL: null } } }</script>
  <script type="module" src="/_nuxt/entry-74f24f8b.mjs" defer></script>
</body>

</html>
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] ~~update bridge vite configuration too~~
- [ ] I have updated the documentation accordingly.

