### PR TITLE
docs: update 3rd party bridge imports to use `#imports`

### DIFF
--- a/docs/content/1.getting-started/4.bridge-composition-api.md
+++ b/docs/content/1.getting-started/4.bridge-composition-api.md
@@ -129,7 +129,7 @@ The only key difference is that `useRoute` no longer returns a computed property
 
 ```diff
 - import { useRouter, useRoute } from '@nuxtjs/composition-api'
-+ import { useRouter, useRoute } from '#app'
++ import { useRouter, useRoute } from '#imports'
 
   const router = useRouter()
   const route = useRoute()

--- a/docs/content/1.getting-started/4.bridge-composition-api.md
+++ b/docs/content/1.getting-started/4.bridge-composition-api.md
@@ -35,11 +35,11 @@ Because some composables have been removed and don't yet have a replacement, thi
     * `useStatic` has been removed. There is no current replacement. Feel free to raise a discussion if you have a use case for this.
     * `reqRef` and `reqSsrRef`, which were deprecated, have now been removed entirely. Follow the instructions below regarding [ssrRef](#ssrref-and-shallowssrref) to replace this.
 
-2. Remove any explicit imports of the basic Vue Composition API composables, or move them to import from `#app` or `vue`.
+2. Remove any explicit imports of the basic Vue Composition API composables, or move them to import from `#imports` or `vue`.
 
    ```diff
    - import { ref, useContext } from '@nuxtjs/composition-api`
-   + import { ref } from '#app'
+   + import { ref } from '#imports'
    ```
 
 3. For each other composable you are using from `@nuxtjs/composition-api`, follow the steps below.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2272

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This aligns the recommendation for importing `useRoute`/`useRouter` (and vue functions like `ref`) so when migrating to nuxt 3 things keep working.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

