### PR TITLE
docs: modify the comment description of `buildModules`

### DIFF
--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -232,21 +232,21 @@ export default {
   modules: [],
 
   /**
-   * Modules that are only required during development and build time.
+   * BuildModules that are only required during development and build time.
    *
-   * Modules are Nuxt extensions which can extend its core functionality and add endless integrations
+   * BuildModules are Nuxt extensions which can extend its core functionality and add endless integrations
    *
-   * Each module is either a string (which can refer to a package, or be a path to a file), a
+   * Each buildModule is either a string (which can refer to a package, or be a path to a file), a
    * tuple with the module as first string and the options as a second object, or an inline module function.
    *
-   * Nuxt tries to resolve each item in the modules array using node require path
+   * Nuxt tries to resolve each item in the buildModules array using node require path
    * (in `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used.
    *
    * @note Modules are executed sequentially so the order is important.
    *
    * @example
    * ```js
-   * modules: [
+   * buildModules: [
    *   // Using package name
    *   '@nuxtjs/axios',
    *   // Relative to your project srcDir


### PR DESCRIPTION
### 🔗 Linked docs to [buildModules](https://v3.nuxtjs.org/docs/directory-structure/nuxt.config#buildmodules)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

From the file `packages/schema/src/config/_common.ts`, it can be seen that there are many places where `modules` is used to describe the content of `buildmodules`. This is consistent with the comment content of `modules` described above

Many of the `buildmodules` in the document are described as `modules`, and **`modules` are also used in the configuration examples of `buildmodules`** . This is particularly confusing!

