### PR TITLE
fix(nitro): set content-type header before html 404

### DIFF
--- a/packages/nitro/src/runtime/server/error.ts
+++ b/packages/nitro/src/runtime/server/error.ts
@@ -55,10 +55,9 @@ export function handleError (error, req: IncomingMessage, res: ServerResponse) {
     return res.end(JSON.stringify(errorObject))
   }
 
-  res.setHeader('Content-Type', 'text/html;charset=UTF-8')
-
   // HTML response
   const errorTemplate = is404 ? error404 : (isDev ? errorDev : error500)
   const html = errorTemplate(errorObject)
+  res.setHeader('Content-Type', 'text/html;charset=UTF-8')
   res.end(html)
 }

--- a/packages/nitro/src/runtime/server/error.ts
+++ b/packages/nitro/src/runtime/server/error.ts
@@ -55,6 +55,8 @@ export function handleError (error, req: IncomingMessage, res: ServerResponse) {
     return res.end(JSON.stringify(errorObject))
   }
 
+  res.setHeader('Content-Type', 'text/html;charset=UTF-8')
+
   // HTML response
   const errorTemplate = is404 ? error404 : (isDev ? errorDev : error500)
   const html = errorTemplate(errorObject)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2268

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Set content-type for HTML error response.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

