### PR TITLE
feat(nuxt3): add global type definitions for built-in components

### DIFF
--- a/packages/nuxt3/src/meta/runtime/plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/plugin.ts
@@ -5,6 +5,11 @@ import { defineNuxtPlugin } from '#app'
 // @ts-ignore
 import metaConfig from '#build/meta.config.mjs'
 
+type MetaComponents = typeof Components
+declare module 'vue' {
+  export interface GlobalComponents extends MetaComponents {}
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   useMeta(metaConfig.globalMeta)
 

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -12,6 +12,15 @@ import { defineNuxtPlugin } from '#app'
 // @ts-ignore
 import routes from '#build/routes'
 
+declare module 'vue' {
+  export interface GlobalComponents {
+    NuxtChild: typeof NuxtChild
+    NuxtPage: typeof NuxtPage
+    NuxtLayout: typeof NuxtLayout
+    NuxtLink: typeof RouterLink
+  }
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.component('NuxtChild', NuxtChild)
   nuxtApp.vueApp.component('NuxtPage', NuxtPage)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2329

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds type definitions for built-in components from the `meta` and `router` packages to the `GlobalComponents` interface which Volar will pick up. By placing them within the relevant plugin, they will only be picked up if the corresponding ad-hoc module is enabled. (They get drawn in to the TS source through `plugins.d.ts`.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

