### PR TITLE
fix(nuxt3): ignore tests within components directory

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -47,6 +47,7 @@ export default defineNuxtModule<ComponentsOptions>({
           ignore: [
             '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
             '**/*{M,.m,-m}ixin.{js,ts,jsx,tsx}', // ignore mixins
+            '**/*.{spec,test}.{js,ts,jsx,tsx}', // ignore tests
             '**/*.d.ts', // .d.ts files
             // TODO: support nuxt ignore patterns
             ...(dirOptions.ignore || [])


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2343

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds tests to the existing list of exclusions in the components module. Ultimately we are going to want to implement `.nuxtignore` support: https://github.com/nuxt/framework/issues/2163#issuecomment-981612377.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

