### PR TITLE
fix(nuxt3): import computed from `vue` to preserve reactivity

### DIFF
--- a/packages/nuxt3/src/app/composables/component.ts
+++ b/packages/nuxt3/src/app/composables/component.ts
@@ -1,5 +1,4 @@
-import { toRefs } from '@vue/reactivity'
-import { defineComponent, getCurrentInstance } from 'vue'
+import { defineComponent, getCurrentInstance, toRefs } from 'vue'
 import type { DefineComponent } from 'vue'
 import { useRoute } from 'vue-router'
 import type { LegacyContext } from '../compat/legacy-app'

--- a/packages/nuxt3/src/meta/runtime/composables.ts
+++ b/packages/nuxt3/src/meta/runtime/composables.ts
@@ -1,5 +1,5 @@
 import { isFunction } from '@vue/shared'
-import { computed } from '@vue/reactivity'
+import { computed } from 'vue'
 import type { ComputedGetter } from '@vue/reactivity'
 import type { MetaObject } from '@nuxt/schema'
 import { useNuxtApp } from '#app'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2344

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The issue in #2344 is caused by importing `computed` from `@vue/reactivity` rather than `vue` - and only reproducible in vite.

The reason is that vite is optimizing imports from `vue`. It's not processing `nuxt3/dist/meta/runtime` which means it's unaware of an import from `@vue/reactivity`. (To see this in action, just add an import of `computed` from `@vue/reactivity` into the repro app; it'll start working.) **Note**: adding this path to `optimizeDeps` fails due to the import from `#app`, or I'd have taken this approach.

The consequence is that `/_nuxt/node_modules/.vite/vue.js` doesn't share any code with `@vue/reactivity` (`/_nuxt/node_modules/@vue/reactivity/dist/reactivity.esm-bundler.js`), which is what breaks reactivity.

I'd welcome ideas for å more systemic solution (cc: @antfu) but, failing that, this is probably sufficient as it's only framework code affected.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

