### PR TITLE
fix(nuxt3): don't mock server-only properties on client-side

### DIFF
--- a/packages/nuxt3/src/app/compat/legacy-app.ts
+++ b/packages/nuxt3/src/app/compat/legacy-app.ts
@@ -114,6 +114,12 @@ const todo = new Set<keyof LegacyContext | keyof LegacyContext['ssrContext']>([
   'beforeSerialize'
 ])
 
+const serverProperties = new Set<keyof LegacyContext['ssrContext'] | keyof LegacyContext>([
+  'req',
+  'res',
+  'ssrContext'
+])
+
 const routerKeys: Array<keyof LegacyContext | keyof LegacyContext['ssrContext']> = ['route', 'params', 'query']
 
 const staticFlags = {
@@ -157,6 +163,10 @@ export const legacyPlugin = (nuxtApp: NuxtApp) => {
 
       if (p in staticFlags) {
         return staticFlags[p]
+      }
+
+      if (process.client && serverProperties.has(p)) {
+        return undefined
       }
 
       if (p === 'ssrContext') {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2375

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We shouldn't mock `ctx.req`, `res` or `ssrContext` on client-side, but can early-return with `undefined`, as plugins might legitimately test to see if these exist.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

