### PR TITLE
feat(nitro): specify packages to copy to `.output/server/node_modules`

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -22,7 +22,7 @@ import { resolvePath } from '../utils'
 import { pkgDir } from '../dirs'
 
 import { dynamicRequire } from './plugins/dynamic-require'
-import { externals } from './plugins/externals'
+import { externals, NodeExternalsOptions } from './plugins/externals'
 import { timing } from './plugins/timing'
 // import { autoMock } from './plugins/automock'
 import { staticAssets, dirnames } from './plugins/static'
@@ -249,7 +249,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // Externals Plugin
   if (nitroContext.externals) {
-    rollupConfig.plugins.push(externals(defu(nitroContext.externals as any, {
+    rollupConfig.plugins.push(externals(defu(nitroContext.externals as NodeExternalsOptions, {
       outDir: nitroContext.output.serverDir,
       moduleDirectories,
       external: [
@@ -266,7 +266,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
         nitroContext._nuxt.srcDir,
         nitroContext._nuxt.rootDir,
         nitroContext._nuxt.serverDir,
-        ...nitroContext.middleware.map(m => m.handle),
+        ...nitroContext.middleware.map(m => m.handle).filter(i => typeof i === 'string') as string[],
         ...(nitroContext._nuxt.dev ? [] : ['vue', '@vue/', '@nuxt/'])
       ],
       traceOptions: {

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -71,7 +71,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
       if (opts.trace !== false) {
         for (const pkgName of opts.traceInclude || []) {
           const path = await this.resolve(pkgName)
-          if (path.id) {
+          if (path?.id) {
             trackedExternals.add(path.id)
           }
         }

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -11,7 +11,7 @@ export interface NodeExternalsOptions {
   traceOptions?: NodeFileTraceOptions
   moduleDirectories?: string[]
   /** additional packages to include in `.output/server/node_modules` */
-  include?: string[]
+  traceInclude?: string[]
 }
 
 export function externals (opts: NodeExternalsOptions): Plugin {

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -69,7 +69,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
     },
     async buildEnd () {
       if (opts.trace !== false) {
-        for (const pkgName of opts.include || []) {
+        for (const pkgName of opts.traceInclude || []) {
           const path = await this.resolve(pkgName)
           if (path.id) {
             trackedExternals.add(path.id)

--- a/packages/nitro/src/rollup/plugins/externals.ts
+++ b/packages/nitro/src/rollup/plugins/externals.ts
@@ -10,6 +10,8 @@ export interface NodeExternalsOptions {
   trace?: boolean
   traceOptions?: NodeFileTraceOptions
   moduleDirectories?: string[]
+  /** additional packages to include in `.output/server/node_modules` */
+  include?: string[]
 }
 
 export function externals (opts: NodeExternalsOptions): Plugin {
@@ -67,6 +69,12 @@ export function externals (opts: NodeExternalsOptions): Plugin {
     },
     async buildEnd () {
       if (opts.trace !== false) {
+        for (const pkgName of opts.include || []) {
+          const path = await this.resolve(pkgName)
+          if (path.id) {
+            trackedExternals.add(path.id)
+          }
+        }
         const tracedFiles = await nodeFileTrace(Array.from(trackedExternals), opts.traceOptions)
           .then(r => Array.from(r.fileList).map(f => resolve(opts.traceOptions.base, f)))
           .then(r => r.filter(file => file.includes('node_modules')))


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows manually specifying additional packages that will be traced and copied across to `.output/server/node_modules`, for example if `@vercel/nft` isn't able to detect the requirement.
