### PR TITLE
fix(nitro): pass sourcemap option through to rollup plugins

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -109,7 +109,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
       outro: '',
       preferConst: true,
       sanitizeFileName: sanitizeFilePath,
-      sourcemap: nitroContext.sourceMap,
+      sourcemap: !!nitroContext.sourceMap,
       sourcemapExcludeSources: true,
       sourcemapPathTransform (relativePath, sourcemapPath) {
         return resolve(dirname(sourcemapPath), relativePath)
@@ -172,7 +172,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
   // ESBuild
   rollupConfig.plugins.push(esbuild({
     target: 'es2019',
-    sourceMap: true,
+    sourceMap: !!nitroContext.sourceMap,
     ...nitroContext.esbuild?.options
   }))
 

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -298,6 +298,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // https://github.com/rollup/plugins/tree/master/packages/commonjs
   rollupConfig.plugins.push(commonjs({
+    sourceMap: !!nitroContext.sourceMap,
     esmExternals: id => !id.startsWith('unenv/'),
     requireReturnsDefault: 'auto'
   }))

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -149,7 +149,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // https://github.com/rollup/plugins/tree/master/packages/replace
   rollupConfig.plugins.push(replace({
-    // @ts-ignore https://github.com/rollup/plugins/pull/810
+    sourceMap: nitroContext.sourceMap,
     preventAssignment: true,
     values: {
       'process.env.NODE_ENV': nitroContext._nuxt.dev ? '"development"' : '"production"',

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -149,7 +149,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // https://github.com/rollup/plugins/tree/master/packages/replace
   rollupConfig.plugins.push(replace({
-    sourceMap: nitroContext.sourceMap,
+    sourceMap: !!nitroContext.sourceMap,
     preventAssignment: true,
     values: {
       'process.env.NODE_ENV': nitroContext._nuxt.dev ? '"development"' : '"production"',

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -308,6 +308,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
 
   // https://github.com/rollup/plugins/tree/master/packages/inject
   rollupConfig.plugins.push(inject({
+    // TODO: https://github.com/rollup/plugins/pull/1066
     // @ts-ignore
     sourceMap: !!nitroContext.sourceMap,
     ...env.inject

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -306,7 +306,11 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
   rollupConfig.plugins.push(json())
 
   // https://github.com/rollup/plugins/tree/master/packages/inject
-  rollupConfig.plugins.push(inject(env.inject))
+  rollupConfig.plugins.push(inject({
+    // @ts-ignore
+    sourceMap: !!nitroContext.sourceMap,
+    ...env.inject
+  }))
 
   // https://github.com/TrySound/rollup-plugin-terser
   // https://github.com/terser/terser#minify-nitroContext


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2377
see also https://github.com/rollup/plugins/issues/1064

Co-authored-by: Matteo Rigoni <matteo.rigoni@atoms.studio>

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Generating sourcemap is what seems to be causing the memory spike, and this change respects the existing `sourceMap` nitro option.

All credit to some great detective work from @Rigo-m.

On a large project this change shaved off 60% of ram usage and made the build 40% faster.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

