### PR TITLE
perf(bridge): allow skipping legacy composition api support

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -251,6 +251,11 @@ export default defineNuxtConfig({
     // Disable composition API support
     // capi: false,
 
+    // ... or just disable legacy composition API support
+    // capi: {
+    //   legacy: false
+    // },
+
     // Do not transpile modules
     // transpile: false,
 

--- a/packages/bridge/src/capi.ts
+++ b/packages/bridge/src/capi.ts
@@ -4,7 +4,7 @@ import { resolve } from 'pathe'
 import { distDir } from './dirs'
 import { KeyPlugin } from './capi-legacy-key-plugin'
 
-export function setupCAPIBridge (_options: any) {
+export function setupCAPIBridge (options: { legacy?: boolean }) {
   const nuxt = useNuxt()
 
   // Error if `@nuxtjs/composition-api` is added
@@ -35,6 +35,11 @@ export function setupCAPIBridge (_options: any) {
     // @ts-ignore
     configs.forEach(config => config.entry.app.unshift(capiPluginPath))
   })
+
+  if (options.legacy === false) {
+    // Skip adding `@nuxtjs/composition-api` handlers if legacy support is disabled
+    return
+  }
 
   // Handle legacy `@nuxtjs/composition-api`
   nuxt.options.alias['@nuxtjs/composition-api'] = resolve(distDir, 'runtime/capi.legacy.mjs')

--- a/packages/bridge/src/capi.ts
+++ b/packages/bridge/src/capi.ts
@@ -1,10 +1,11 @@
 import { createRequire } from 'module'
 import { useNuxt, addPlugin, addPluginTemplate, addVitePlugin, addWebpackPlugin } from '@nuxt/kit'
 import { resolve } from 'pathe'
+import { BridgeConfig } from '../types'
 import { distDir } from './dirs'
 import { KeyPlugin } from './capi-legacy-key-plugin'
 
-export function setupCAPIBridge (options: { legacy?: boolean }) {
+export function setupCAPIBridge (options: Exclude<BridgeConfig['capi'], boolean>) {
   const nuxt = useNuxt()
 
   // Error if `@nuxtjs/composition-api` is added

--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -42,7 +42,7 @@ export default defineNuxtModule({
       if (!opts.app) {
         throw new Error('[bridge] Cannot enable composition-api with app disabled!')
       }
-      await setupCAPIBridge(opts.capi)
+      await setupCAPIBridge(opts.capi === true ? {} : opts.capi)
     }
     if (opts.scriptSetup) {
       await setupScriptSetup(opts.scriptSetup as ScriptSetupOptions)

--- a/packages/bridge/types.d.ts
+++ b/packages/bridge/types.d.ts
@@ -9,7 +9,9 @@ export interface BridgeConfig {
   nitro: boolean
   vite: boolean
   app: boolean | {}
-  capi: boolean | {}
+  capi: boolean | {
+    legacy?: boolean
+  }
   scriptSetup: boolean | ScriptSetupOptions
   autoImports: boolean
   transpile: boolean


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously, even if users had fully migrated to new Composition API, we are still loading in support for keying `ssrRef`, etc. There's a small performance win users can realise by disabling legacy support.

```js
export default defineNuxtConfig({
  bridge: {
    capi: {
      legacy: false 
    }
  }
})
```
