### PR TITLE
fix(vite): respect users config

### DIFF
--- a/packages/bridge/src/vite/vite.ts
+++ b/packages/bridge/src/vite/vite.ts
@@ -17,15 +17,16 @@ async function bundle (nuxt: Nuxt, builder: any) {
     p.src = nuxt.resolver.resolvePath(resolve(nuxt.options.buildDir, p.src))
   }
 
+  const userViteConfig = nuxt.options.vite as any || {}
   const ctx: ViteBuildContext = {
     nuxt,
     builder,
     config: vite.mergeConfig(
-      nuxt.options.vite || {},
+      userViteConfig,
       {
         root: nuxt.options.rootDir,
         mode: nuxt.options.dev ? 'development' : 'production',
-        logLevel: 'warn',
+        logLevel: userViteConfig.logLevel || 'warn',
         define: {
           'process.dev': nuxt.options.dev
         },

--- a/packages/bridge/src/vite/vite.ts
+++ b/packages/bridge/src/vite/vite.ts
@@ -17,7 +17,6 @@ async function bundle (nuxt: Nuxt, builder: any) {
     p.src = nuxt.resolver.resolvePath(resolve(nuxt.options.buildDir, p.src))
   }
 
-  const userViteConfig = nuxt.options.vite as any || {}
   const ctx: ViteBuildContext = {
     nuxt,
     builder,
@@ -80,7 +79,7 @@ async function bundle (nuxt: Nuxt, builder: any) {
           defaultExportPlugin()
         ]
       } as ViteOptions,
-      userViteConfig
+      nuxt.options.vite || {}
     )
   }
 

--- a/packages/bridge/src/vite/vite.ts
+++ b/packages/bridge/src/vite/vite.ts
@@ -22,11 +22,10 @@ async function bundle (nuxt: Nuxt, builder: any) {
     nuxt,
     builder,
     config: vite.mergeConfig(
-      userViteConfig,
       {
         root: nuxt.options.rootDir,
         mode: nuxt.options.dev ? 'development' : 'production',
-        logLevel: userViteConfig.logLevel || 'warn',
+        logLevel: 'warn',
         define: {
           'process.dev': nuxt.options.dev
         },
@@ -80,7 +79,8 @@ async function bundle (nuxt: Nuxt, builder: any) {
           jsxPlugin(),
           defaultExportPlugin()
         ]
-      } as ViteOptions
+      } as ViteOptions,
+      userViteConfig
     )
   }
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -22,14 +22,15 @@ export interface ViteBuildContext {
 }
 
 export async function bundle (nuxt: Nuxt) {
+  const userViteConfig = nuxt.options.vite as any || {}
   const ctx: ViteBuildContext = {
     nuxt,
     config: vite.mergeConfig(
-      nuxt.options.vite as any || {},
+      userViteConfig,
       {
         root: nuxt.options.srcDir,
         mode: nuxt.options.dev ? 'development' : 'production',
-        logLevel: 'warn',
+        logLevel: userViteConfig.logLevel || 'warn',
         define: {
           'process.dev': nuxt.options.dev
         },

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -26,11 +26,10 @@ export async function bundle (nuxt: Nuxt) {
   const ctx: ViteBuildContext = {
     nuxt,
     config: vite.mergeConfig(
-      userViteConfig,
       {
         root: nuxt.options.srcDir,
         mode: nuxt.options.dev ? 'development' : 'production',
-        logLevel: userViteConfig.logLevel || 'warn',
+        logLevel: 'warn',
         define: {
           'process.dev': nuxt.options.dev
         },
@@ -94,7 +93,8 @@ export async function bundle (nuxt: Nuxt) {
             ]
           }
         }
-      } as ViteOptions
+      } as ViteOptions,
+      userViteConfig
     )
   }
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -22,7 +22,6 @@ export interface ViteBuildContext {
 }
 
 export async function bundle (nuxt: Nuxt) {
-  const userViteConfig = nuxt.options.vite as any || {}
   const ctx: ViteBuildContext = {
     nuxt,
     config: vite.mergeConfig(
@@ -94,7 +93,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         }
       } as ViteOptions,
-      userViteConfig
+      nuxt.options.vite as any || {}
     )
   }
 


### PR DESCRIPTION
When user-defined

```ts
{
  vite: {
    logLevel: 'info' 
  }
}
```

it won't work, which makes it a bit hard to debug or gather info from vite.