### PR TITLE
fix(nuxt3): add `imports.d.ts` to `nuxt.d.ts`

### DIFF
--- a/packages/nuxt3/src/auto-imports/module.ts
+++ b/packages/nuxt3/src/auto-imports/module.ts
@@ -87,6 +87,7 @@ export default defineNuxtModule<AutoImportsOptions>({
     // Add generated types to `nuxt.d.ts`
     nuxt.hook('prepare:types', ({ references }) => {
       references.push({ path: resolve(nuxt.options.buildDir, 'auto-imports.d.ts') })
+      references.push({ path: resolve(nuxt.options.buildDir, 'imports.d.ts') })
     })
 
     // Watch composables/ directory


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ensures that `imports.d.ts` is included in ts scope (otherwise you'll see red underlines for the nuxt-specific aliases like `vue-demi` and `#meta` if you open the file up). With this change, they are recognised and clickable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

