### PR TITLE
fix(nitro): correct `#assets` type declaration

### DIFF
--- a/packages/nitro/types/shims.d.ts
+++ b/packages/nitro/types/shims.d.ts
@@ -5,9 +5,12 @@ declare module '#storage' {
 
 declare module '#assets' {
   export interface AssetMeta { type?: string, etag?: string, mtime?: string }
-  export function readAsset<T = any> (id: string): Promise<T>
-  export function statAsset (id: string): Promise<AssetMeta>
-  export function getKeys() : Promise<string[]>
+
+  export const assets: {
+    readAsset<T = any> (id: string): Promise<T>
+    statAsset (id: string): Promise<AssetMeta>
+    getKeys() : Promise<string[]>
+  }
 }
 
 declare module '#config' {

--- a/packages/nitro/types/shims.d.ts
+++ b/packages/nitro/types/shims.d.ts
@@ -7,9 +7,10 @@ declare module '#assets' {
   export interface AssetMeta { type?: string, etag?: string, mtime?: string }
 
   export const assets: {
-    readAsset<T = any> (id: string): Promise<T>
-    statAsset (id: string): Promise<AssetMeta>
-    getKeys() : Promise<string[]>
+    getKeys(): Promise<string[]>
+    hasItem(id: string): Promise<boolean>
+    getItem<T = any> (id: string): Promise<T>
+    getMeta(id: string): Promise<AssetMeta>
   }
 }
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix to update the typing for `#assets`. Here's the implementation:
https://github.com/nuxt/framework/blob/a08b435f51a2e054a708eb5dae283f74b8874450/packages/nitro/src/rollup/plugins/assets.ts#L82-L108