### PR TITLE
feat(nuxt): add wrapped `useRoute` and `useRouter` composables

### DIFF
--- a/packages/bridge/src/auto-imports.ts
+++ b/packages/bridge/src/auto-imports.ts
@@ -6,8 +6,7 @@ const UnsupportedImports = new Set(['useAsyncData', 'useFetch'])
 const CapiHelpers = new Set(Object.keys(CompositionApi))
 
 const ImportRewrites = {
-  vue: '@vue/composition-api',
-  'vue-router': '#app'
+  vue: '@vue/composition-api'
 }
 
 export async function setupAutoImports () {
@@ -27,6 +26,10 @@ export async function setupAutoImports () {
         autoImport.disabled = true
       }
     }
+
+    // Add auto-imports that are added by ad-hoc modules in nuxt 3
+    autoImports.push({ name: 'useRouter', as: 'useRouter', from: '#app' })
+    autoImports.push({ name: 'useRoute', as: 'useRoute', from: '#app' })
 
     // Add bridge-only auto-imports
     autoImports.push({ name: 'useNuxt2Meta', as: 'useNuxt2Meta', from: '#app' })

--- a/packages/nuxt3/src/auto-imports/imports.ts
+++ b/packages/nuxt3/src/auto-imports/imports.ts
@@ -24,14 +24,6 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
       'useMeta'
     ]
   },
-  // vue-router
-  {
-    from: 'vue-router',
-    names: [
-      'useRoute',
-      'useRouter'
-    ]
-  },
   // vue-demi (mocked)
   {
     from: 'vue-demi',

--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -35,6 +35,12 @@ export default defineNuxtModule({
       }
     })
 
+    nuxt.hook('autoImports:extend', (autoImports) => {
+      const composablesFile = resolve(runtimeDir, 'composables')
+      autoImports.push({ name: 'useRouter', as: 'useRouter', from: composablesFile })
+      autoImports.push({ name: 'useRoute', as: 'useRoute', from: composablesFile })
+    })
+
     // Add router plugin
     addPlugin(resolve(runtimeDir, 'router'))
 

--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -1,0 +1,23 @@
+import { computed, reactive } from 'vue'
+import type { Router, RouteLocationNormalizedLoaded } from 'vue-router'
+import { useNuxtApp } from '#app'
+
+export const useRouter = () => {
+  return useNuxtApp().$router as Router
+}
+
+export const useRoute = (): RouteLocationNormalizedLoaded => {
+  const nuxtApp = useNuxtApp()
+  if (nuxtApp._route) {
+    return nuxtApp._route
+  }
+
+  const currentRoute = (nuxtApp.$router as Router).currentRoute
+
+  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
+  nuxtApp._route = reactive(Object.fromEntries(
+    Object.keys(currentRoute.value).map(key => [key, computed(() => currentRoute.value[key])])
+  ) as any)
+
+  return nuxtApp._route
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2402, resolves #1750

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows using `useRoute` and `useRouter` within Nuxt plugins in Nuxt 3 (this already works in Bridge). They need to be imported from `#imports` or used via auto-imports. (I've moved them to the `pages` ad-hoc module as it probably doesn't make sense for them to be available unless it's enabled, but if we want them to have the `#app` alias I can move them into the app composables...)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

