### PR TITLE
fix(bridge): add `builder:generateApp` hook implementation

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -96,10 +96,10 @@ export function setupAppBridge (_options: any) {
   })
 
   nuxt.hook('builder:generateApp', async () => {
-    const { Builder } = await import('@nuxt/builder')
+    const { getBuilder } = await import('nuxt')
     ;(nuxt.options.build as any).createRoutes = () => []
 
-    const builder = new Builder(nuxt)
+    const builder = getBuilder(nuxt)
     await nuxt.callHook('builder:prepared', builder, nuxt.options.build)
     await builder.generateRoutesAndFiles()
   })

--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -94,4 +94,13 @@ export function setupAppBridge (_options: any) {
       })
     }
   })
+
+  nuxt.hook('builder:generateApp', async () => {
+    const { Builder } = await import('@nuxt/builder')
+    ;(nuxt.options.build as any).createRoutes = () => []
+
+    const builder = new Builder(nuxt)
+    await nuxt.callHook('builder:prepared', builder, nuxt.options.build)
+    await builder.generateRoutesAndFiles()
+  })
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#2401 (for bridge)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a `builder:generateApp` compatible hook that will generate a `.nuxt` directory (for use in `nuxi prepare`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

