### PR TITLE
feat(nitro, nuxt3, bridge): expose `writeTypes` and call this within `builder:generateApp`

### DIFF
--- a/packages/nitro/src/build.ts
+++ b/packages/nitro/src/build.ts
@@ -64,7 +64,7 @@ export async function build (nitroContext: NitroContext) {
   return nitroContext._nuxt.dev ? _watch(nitroContext) : _build(nitroContext)
 }
 
-async function writeTypes (nitroContext: NitroContext) {
+export async function writeTypes (nitroContext: NitroContext) {
   const routeTypes: Record<string, string[]> = {}
 
   const middleware = [

--- a/packages/nuxt3/src/core/nitro.ts
+++ b/packages/nuxt3/src/core/nitro.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { wpfs, getNitroContext, createDevServer, resolveMiddleware, build, prepare, generate } from '@nuxt/nitro'
+import { wpfs, getNitroContext, createDevServer, resolveMiddleware, build, prepare, generate, writeTypes, scanMiddleware } from '@nuxt/nitro'
 import type { Nuxt } from '@nuxt/schema'
 
 export function initNitro (nuxt: Nuxt) {
@@ -61,6 +61,11 @@ export function initNitro (nuxt: Nuxt) {
       await generate(nitroContext)
       await build(nitroContext)
     }
+  })
+
+  nuxt.hook('builder:generateApp', async () => {
+    nitroDevContext.scannedMiddleware = await scanMiddleware(nitroDevContext._nuxt.serverDir)
+    await writeTypes(nitroDevContext)
   })
 
   // nuxt dev


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#2401

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This exports `writeTypes` from Nitro, allowing types to be written without building a Nitro server. This allows us to call `writeTypes` within bridge & nuxt3 to generate `nitro.d.ts`.

I would suggest entirely moving the _calling_ of `writeTypes` out of `@nuxt/nitro` and into a Nuxt hook, as it seems more like the right place for the job.

I've created this as a separate PR from the other two related .d.ts PRs as we may pend this until `nitropack` lands. And this is purely additive; that is, the other PRs work fine without it, they just don't generate `nitro.d.ts`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

