### PR TITLE
fix(nuxt3): cache `useCookie` ref on nuxtApp instance

### DIFF
--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -22,6 +22,12 @@ const CookieDefaults: CookieOptions<any> = {
 }
 
 export function useCookie <T=string> (name: string, _opts?: CookieOptions<T>): CookieRef<T> {
+  const nuxtApp = useNuxtApp()
+  nuxtApp._cookies = nuxtApp._cookies || {}
+  if (nuxtApp._cookies[name]) {
+    return nuxtApp._cookies[name]
+  }
+
   const opts = { ...CookieDefaults, ..._opts }
   const cookies = readRawCookies(opts)
 
@@ -39,6 +45,8 @@ export function useCookie <T=string> (name: string, _opts?: CookieOptions<T>): C
       }
     })
   }
+
+  nuxtApp._cookies[name] = cookie
 
   return cookie as CookieRef<T>
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2416

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR caches `useCookie` refs so that they will be reactive across invocations of `useCookie`. There's a memory overhead for this as the refs will persist in memory but cookies are normally small and few in number, so I think the benefit outweights the risk.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

