### PR TITLE
fix(nuxt3): don't immediately trigger update dom

### DIFF
--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -1,5 +1,5 @@
 import { createHead, renderHeadToString } from '@vueuse/head'
-import { ref, watchEffect, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { ref, watch, onBeforeUnmount, getCurrentInstance } from 'vue'
 import type { MetaObject } from '..'
 import { defineNuxtPlugin } from '#app'
 
@@ -14,7 +14,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     if (process.server) { return }
 
-    watchEffect(() => {
+    const stop = watch(() => headObj.value, () => {
       head.updateDOM()
     })
 
@@ -22,6 +22,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (!vm) { return }
 
     onBeforeUnmount(() => {
+      stop()
       head.removeHeadObjs(headObj)
       head.updateDOM()
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#2337 
vueuse/head#45

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
`watchEffect` is an eager watch by immediately executing the DOM update. At the first DOM update after the page has been loaded, vueuse/head library will remove all existing attributes and then set them all to the same old values again, for some attribute like `class`, `style`... this toggle will make the screen flickering. I think `watch` is a proper choice in this case.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.

