### PR TITLE
refactor(nuxt3): rename `<NuxtChild>` to `<NuxtNestedPage>`

### DIFF
--- a/docs/content/3.docs/2.directory-structure/9.pages.md
+++ b/docs/content/3.docs/2.directory-structure/9.pages.md
@@ -93,7 +93,7 @@ If you want to know more about `<RouterLink>`, read the [Vue Router documentati
 
 ## Nested Routes
 
-We provide a semantic alias for `RouterView`, the `<NuxtChild>` component, for displaying the children components of a [nested route](https://next.router.vuejs.org/guide/essentials/nested-routes.html).
+We provide a semantic alias for `RouterView`, the `<NuxtNestedPage>` component, for displaying the children components of a [nested route](https://next.router.vuejs.org/guide/essentials/nested-routes.html).
 
 Example:
 
@@ -123,13 +123,13 @@ This file tree will generate these routes:
 ]
 ```
 
-To display the `child.vue` component, you have to insert the `<NuxtChild>` component inside `pages/parent.vue`:
+To display the `child.vue` component, you have to insert the `<NuxtNestedPage>` component inside `pages/parent.vue`:
 
 ```html{}[pages/parent.vue]
 <template>
   <div>
     <h1>I am the parent view</h1>
-    <NuxtChild :foobar="123" />
+    <NuxtNestedPage :foobar="123" />
   </div>
 </template>
 ```

--- a/examples/with-pages/pages/parent.vue
+++ b/examples/with-pages/pages/parent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
     Parent
-    <NuxtChild />
+    <NuxtNestedPage />
   </div>
 </template>

--- a/packages/nuxt3/src/pages/runtime/nested-page.vue
+++ b/packages/nuxt3/src/pages/runtime/nested-page.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'NuxtChild'
+  name: 'NuxtNestedPage'
 }
 </script>

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -5,7 +5,7 @@ import {
   createMemoryHistory,
   RouterLink
 } from 'vue-router'
-import NuxtChild from './child.vue'
+import NuxtNestedPage from './nested-page.vue'
 import NuxtPage from './page.vue'
 import NuxtLayout from './layout'
 import { defineNuxtPlugin } from '#app'
@@ -14,7 +14,7 @@ import routes from '#build/routes'
 
 declare module 'vue' {
   export interface GlobalComponents {
-    NuxtChild: typeof NuxtChild
+    NuxtNestedPage: typeof NuxtNestedPage
     NuxtPage: typeof NuxtPage
     NuxtLayout: typeof NuxtLayout
     NuxtLink: typeof RouterLink
@@ -22,10 +22,12 @@ declare module 'vue' {
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.component('NuxtChild', NuxtChild)
+  nuxtApp.vueApp.component('NuxtNestedPage', NuxtNestedPage)
   nuxtApp.vueApp.component('NuxtPage', NuxtPage)
   nuxtApp.vueApp.component('NuxtLayout', NuxtLayout)
   nuxtApp.vueApp.component('NuxtLink', RouterLink)
+  // TODO: remove before release - present for backwards compatibility & intentionally undocumented
+  nuxtApp.vueApp.component('NuxtChild', NuxtNestedPage)
 
   const routerHistory = process.client
     ? createWebHistory()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2106

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This renames `<NuxtChild>` to `<NuxtNestedPage>`, keeping `<NuxtChild>` as an undocumented alias.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

