### PR TITLE
fix(nuxt3): define route in plugin rather than composable

### DIFF
--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -1,4 +1,3 @@
-import { computed, reactive } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded } from 'vue-router'
 import { useNuxtApp } from '#app'
 
@@ -6,18 +5,6 @@ export const useRouter = () => {
   return useNuxtApp().$router as Router
 }
 
-export const useRoute = (): RouteLocationNormalizedLoaded => {
-  const nuxtApp = useNuxtApp()
-  if (nuxtApp._route) {
-    return nuxtApp._route
-  }
-
-  const currentRoute = (nuxtApp.$router as Router).currentRoute
-
-  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
-  nuxtApp._route = reactive(Object.fromEntries(
-    Object.keys(currentRoute.value).map(key => [key, computed(() => currentRoute.value[key])])
-  ) as any)
-
-  return nuxtApp._route
+export const useRoute = () => {
+  return useNuxtApp()._route as RouteLocationNormalizedLoaded
 }

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -1,9 +1,10 @@
-import { shallowRef } from 'vue'
+import { computed, reactive, shallowRef } from 'vue'
 import {
   createRouter,
   createWebHistory,
   createMemoryHistory,
-  RouterLink
+  RouterLink,
+  RouteLocationNormalizedLoaded
 } from 'vue-router'
 import NuxtChild from './child.vue'
 import NuxtPage from './page.vue'
@@ -19,6 +20,18 @@ declare module 'vue' {
     NuxtLayout: typeof NuxtLayout
     NuxtLink: typeof RouterLink
   }
+}
+
+const START_LOCATION_NORMALIZED: RouteLocationNormalizedLoaded = {
+  path: '/',
+  name: undefined,
+  params: {},
+  query: {},
+  hash: '',
+  fullPath: '/',
+  matched: [],
+  meta: {},
+  redirectedFrom: undefined
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
@@ -45,6 +58,14 @@ export default defineNuxtPlugin((nuxtApp) => {
   Object.defineProperty(nuxtApp.vueApp.config.globalProperties, 'previousRoute', {
     get: () => previousRoute.value
   })
+
+  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
+  const route = {}
+  for (const key in START_LOCATION_NORMALIZED) {
+    route[key] = computed(() => router.currentRoute.value[key])
+  }
+
+  nuxtApp._route = reactive(route)
 
   nuxtApp.hook('app:created', async () => {
     if (process.server) {

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -3,8 +3,7 @@ import {
   createRouter,
   createWebHistory,
   createMemoryHistory,
-  RouterLink,
-  RouteLocationNormalizedLoaded
+  RouterLink
 } from 'vue-router'
 import NuxtChild from './child.vue'
 import NuxtPage from './page.vue'
@@ -20,18 +19,6 @@ declare module 'vue' {
     NuxtLayout: typeof NuxtLayout
     NuxtLink: typeof RouterLink
   }
-}
-
-const START_LOCATION_NORMALIZED: RouteLocationNormalizedLoaded = {
-  path: '/',
-  name: undefined,
-  params: {},
-  query: {},
-  hash: '',
-  fullPath: '/',
-  matched: [],
-  meta: {},
-  redirectedFrom: undefined
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
@@ -61,7 +48,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
   const route = {}
-  for (const key in START_LOCATION_NORMALIZED) {
+  for (const key in router.currentRoute.value) {
     route[key] = computed(() => router.currentRoute.value[key])
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2441, closes #2442

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This defines `nuxtApp._route` in the same instance as creating the router itself, rather than on the calling of a composable, which is probably the right location for this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

