### PR TITLE
fix(schema): handle null/undefined values in `runtimeConfig`

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -14,6 +14,7 @@ import wasmPlugin from '@rollup/plugin-wasm'
 import inject from '@rollup/plugin-inject'
 import { visualizer } from 'rollup-plugin-visualizer'
 import * as unenv from 'unenv'
+import devalue from '@nuxt/devalue'
 
 import type { Preset } from 'unenv'
 import { sanitizeFilePath } from 'mlly'
@@ -164,7 +165,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
       'process.env.NUXT_STATIC_VERSION': JSON.stringify(nitroContext._nuxt.staticAssets.version),
       'process.env.NUXT_FULL_STATIC': nitroContext._nuxt.fullStatic as unknown as string,
       'process.env.NITRO_PRESET': JSON.stringify(nitroContext.preset),
-      'process.env.RUNTIME_CONFIG': JSON.stringify(nitroContext._nuxt.runtimeConfig),
+      'process.env.RUNTIME_CONFIG': devalue(nitroContext._nuxt.runtimeConfig),
       'process.env.DEBUG': JSON.stringify(nitroContext._nuxt.dev)
     }
   }))

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -714,6 +714,6 @@ export default {
    * @version 3
    */
   publicRuntimeConfig: {
-    $resolve: (val = {}, get) => ({ ...val, app: defu(val.app, get('app') })
+    $resolve: (val = {}, get) => ({ ...val, app: defu(val.app, get('app')) })
   },
 }

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -714,6 +714,6 @@ export default {
    * @version 3
    */
   publicRuntimeConfig: {
-    $resolve: (val, get) => defu(val, { app: get('app') })
+    $resolve: (val, get) =>  Object.assign({}, val, defu(val, { app: get('app') }))
   },
 }

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -714,6 +714,6 @@ export default {
    * @version 3
    */
   publicRuntimeConfig: {
-    $resolve: (val, get) =>  Object.assign({}, val, defu(val, { app: get('app') }))
+    $resolve: (val, get) => Object.assign({}, val, defu(val, { app: get('app') }))
   },
 }

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -714,6 +714,6 @@ export default {
    * @version 3
    */
   publicRuntimeConfig: {
-    $resolve: (val, get) => Object.assign({}, val, defu(val, { app: get('app') }))
+    $resolve: (val = {}, get) => ({ ...val, app: defu(val.app, get('app') })
   },
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2423

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

By default `defu` doesn't process values that are null or undefined at the top level:

https://github.com/unjs/defu/blob/main/src/defu.ts#L22-L24

But we likely want to preserve these in `runtimeConfig` as this enables the runtime check for the existence of these environment variables.

I've also switched to using `devalue` for Nitro's runtimeConfig as this enables us to preserve `undefined` values.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

