### PR TITLE
fix(nuxt3): don't mutate options when unsetting cookie

### DIFF
--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -57,7 +57,8 @@ function readRawCookies (opts: CookieOptions = {}): Record<string, string> {
   }
 }
 
-function serializeCookie (name: string, value: any, opts: CookieSerializeOptions = {}) {
+function serializeCookie (name: string, value: any, _opts: CookieSerializeOptions = {}) {
+  const opts = { ..._opts }
   if (value === null || value === undefined) {
     opts.maxAge = -1
   }

--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -57,10 +57,9 @@ function readRawCookies (opts: CookieOptions = {}): Record<string, string> {
   }
 }
 
-function serializeCookie (name: string, value: any, _opts: CookieSerializeOptions = {}) {
-  const opts = { ..._opts }
+function serializeCookie (name: string, value: any, opts: CookieSerializeOptions = {}) {
   if (value === null || value === undefined) {
-    opts.maxAge = -1
+    return serialize(name, value, { ...opts, maxAge: -1 })
   }
   return serialize(name, value, opts)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2480

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When unsetting the cookie, we were mutating the options which mean that any subsequent setting of cookie value would have a `maxAge` of `-1`, which would effectively unset the cookie immediately.

https://github.com/nuxt/framework/blob/6a25d3e245a88d3c838dafa643a5210dba625d73/packages/nuxt3/src/app/composables/cookie.ts#L61-L63

This PR clones the options in the serialize function so we don't mutate the original options object.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

