### PR TITLE
docs(concepts): add overwriting disclaimer to tsconfig section

### DIFF
--- a/docs/content/2.concepts/3.typescript.md
+++ b/docs/content/2.concepts/3.typescript.md
@@ -29,6 +29,12 @@ This file contains the recommended basic TypeScript configuration for your proje
 ::alert{icon=👉}
 Nitro also [auto-generates types](/concepts/server-engine#typed-api-routes) for API routes. Plus, Nuxt also generates types for globally available components and [auto-imports from your composables](/docs/directory-structure/composables), plus other core functionality.
 ::
+::alert
+Keep in mind that all options extended from `./.nuxt/tsconfig.json` will be overwritten by the options defined in your `tsconfig.json`.
+Overwriting options such as `"compilerOptions.paths"` with your own configuration will lead Typescript to not factor in the module resolutions from `./.nuxt/tsconfig.json`. This can lead to module resolutions such as `#app` not being recognized.
+
+In case you need to extend options provided by `./.nuxt/tsconfig.json` further, you can use the `alias` property withing your `nuxt.config`. `nuxi` will pick them up and extend `./.nuxt/tsconfig.json` accordingly.
+::
 
 ## Stricter Checks
 


### PR DESCRIPTION
Add a disclaimer highlighting that properties specified in `tsconfig.json` will be overwriting all properties extended from `./.nuxt/tsconfig.json`.

### 🔗 Linked issue

[#586](https://github.com/johnsoncodehk/volar/issues/586#issue-1024254907)

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a disclaimer highlighting that properties specified in `tsconfig.json` will be overwriting all properties extended from `./.nuxt/tsconfig.json`.

It is/was typical to have to define your own `"compilerOptions.paths"` mappings in `tsconfig.json` when using Nuxt 2.
Now that Nuxt 3/nuxi provides `./.nuxt/tsconfig.json` to extend from (recommended in the docs) it would be useful to mention that previously defined properties will be overwriting the extended properties from `./.nuxt/tsconfig.json` entirely.

Extending a config with the following definition...

```json
"compilerOptions.paths": ["@/*": "./*"]
```

**won't lead to this**:

```json
"compilerOptions.paths": ["@/*": "./*", "#app": "node_modules/@nuxt/bridge/dist/runtime/index", ...]
```

but instead to this: 
```json
"compilerOptions.paths": ["@/*": "./*"]
```

This behaviour is unintuitive if you are not familiar with the exact way `"extends"` behaves.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

