### PR TITLE
fix(docs): fix broken links in server section

### DIFF
--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -73,4 +73,4 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 }
 ```
 
-More information about custom middleware can be found in the documentation for [nuxt.config.js](../nuxt.config#servermiddleware)
+More information about custom middleware can be found in the documentation for [nuxt.config.js](/docs/directory-structure/nuxt.config#servermiddleware)

--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -21,7 +21,7 @@ Each file should export a default function that handles API requests. It can ret
 #### Hello world
 
 ```js [server/api/hello.ts]
-export default (req, res) => "Hello World";
+export default (req, res) => 'Hello World'
 ```
 
 See the result on <http://localhost:3000/api/hello>.
@@ -30,23 +30,23 @@ See the result on <http://localhost:3000/api/hello>.
 
 ```js [server/api/async.ts]
 export default async (req, res) => {
-  await someAsyncFunction();
+  await someAsyncFunction()
 
   return {
-    someData: true,
-  };
-};
+    someData: true
+  }
+}
 ```
 
 **Example:** Using Node.js style
 
 ```ts [server/api/node.ts]
-import type { IncomingMessage, ServerResponse } from "http";
+import type { IncomingMessage, ServerResponse } from 'http'
 
 export default async (req: IncomingMessage, res: ServerResponse) => {
-  res.statusCode = 200;
-  res.end("Works!");
-};
+  res.statusCode = 200
+  res.end('Works!')
+}
 ```
 
 ## Server Middleware
@@ -59,18 +59,18 @@ Each file should export a default function that will handle a request.
 
 ```js
 export default async (req, res) => {
-  req.someValue = true;
-};
+  req.someValue = true
+}
 ```
 
 There is nothing different about the `req`/`res` objects, so typing them is straightforward.
 
 ```ts
-import type { IncomingMessage, ServerResponse } from "http";
+import type { IncomingMessage, ServerResponse } from 'http'
 
 export default async (req: IncomingMessage, res: ServerResponse) => {
-  req.someValue = true;
-};
+  req.someValue = true
+}
 ```
 
 More information about custom middleware can be found in the documentation for [nuxt.config.js](../nuxt.config#servermiddleware)

--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -21,7 +21,7 @@ Each file should export a default function that handles API requests. It can ret
 #### Hello world
 
 ```js [server/api/hello.ts]
-export default (req, res) => 'Hello World'
+export default (req, res) => "Hello World";
 ```
 
 See the result on <http://localhost:3000/api/hello>.
@@ -30,47 +30,47 @@ See the result on <http://localhost:3000/api/hello>.
 
 ```js [server/api/async.ts]
 export default async (req, res) => {
-  await someAsyncFunction()
+  await someAsyncFunction();
 
   return {
-    someData: true
-  }
-}
+    someData: true,
+  };
+};
 ```
 
 **Example:** Using Node.js style
 
 ```ts [server/api/node.ts]
-import type { IncomingMessage, ServerResponse } from 'http'
+import type { IncomingMessage, ServerResponse } from "http";
 
 export default async (req: IncomingMessage, res: ServerResponse) => {
-  res.statusCode = 200
-  res.end('Works!')
-}
+  res.statusCode = 200;
+  res.end("Works!");
+};
 ```
 
 ## Server Middleware
 
 Nuxt will automatically read in any files in the `~/server/middleware` to create server middleware for your project.
 
-These files will be run on every request, unlike [API routes](./api) that are mapped to their own routes. This is typically so you can add a common header to all responses, log responses or modify the incoming request object for later use in the request chain.
+These files will be run on every request, unlike [API routes](#api-routes) that are mapped to their own routes. This is typically so you can add a common header to all responses, log responses or modify the incoming request object for later use in the request chain.
 
 Each file should export a default function that will handle a request.
 
 ```js
 export default async (req, res) => {
-  req.someValue = true
-}
+  req.someValue = true;
+};
 ```
 
 There is nothing different about the `req`/`res` objects, so typing them is straightforward.
 
 ```ts
-import type { IncomingMessage, ServerResponse } from 'http'
+import type { IncomingMessage, ServerResponse } from "http";
 
 export default async (req: IncomingMessage, res: ServerResponse) => {
-  req.someValue = true
-}
+  req.someValue = true;
+};
 ```
 
-More information about custom middleware can be found in the documentation for [nuxt.config.js](./nuxt.config#servermiddleware)
+More information about custom middleware can be found in the documentation for [nuxt.config.js](../nuxt.config#servermiddleware)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Issue #2503

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This change fixes the paths of the .md links in the server docs, namely `API Routes` and `nuxt.config.js`. They were erroneously linked.
<!-- Why is this change required? What problem does it solve? -->
To avoid having the links go to 404.
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

