### PR TITLE
perf(ssr): disable vite's pre-trasnfroming to improve perf

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -55,7 +55,7 @@
     "ufo": "^0.7.9",
     "unplugin": "^0.2.21",
     "unplugin-vue2-script-setup": "0.8.3",
-    "vite": "^2.7.6",
+    "vite": "^2.7.10",
     "vite-plugin-vue2": "^1.9.0",
     "vue-template-compiler": "^2.6.14"
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -37,7 +37,7 @@
     "postcss-url": "^10.1.3",
     "rollup-plugin-visualizer": "^5.5.2",
     "ufo": "^0.7.9",
-    "vite": "^2.7.6"
+    "vite": "^2.7.10"
   },
   "peerDependencies": {
     "vue": "3.2.26"

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -69,6 +69,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       }
     },
     server: {
+      // https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027
       preTransformRequests: false
     },
     plugins: [

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -68,6 +68,9 @@ export async function buildServer (ctx: ViteBuildContext) {
         }
       }
     },
+    server: {
+      preTransformRequests: false
+    },
     plugins: [
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'server'),
       vuePlugin(ctx.config.vue),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,7 +2504,7 @@ __metadata:
     unbuild: latest
     unplugin: ^0.2.21
     unplugin-vue2-script-setup: 0.8.3
-    vite: ^2.7.6
+    vite: ^2.7.10
     vite-plugin-vue2: ^1.9.0
     vue: ^2
     vue-router: ^3
@@ -3168,7 +3168,7 @@ __metadata:
     rollup-plugin-visualizer: ^5.5.2
     ufo: ^0.7.9
     unbuild: latest
-    vite: ^2.7.6
+    vite: ^2.7.10
     vue: 3.2.26
   peerDependencies:
     vue: 3.2.26
@@ -21505,9 +21505,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^2.7.6":
-  version: 2.7.6
-  resolution: "vite@npm:2.7.6"
+"vite@npm:^2.7.10":
+  version: 2.7.10
+  resolution: "vite@npm:2.7.10"
   dependencies:
     esbuild: ^0.13.12
     fsevents: ~2.3.2
@@ -21530,7 +21530,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 7aa110a3a5de9f9a29cf8cf461cf5dd2c7000d2a7abacdbe40969a215339492bee93d5eedb51060d13f0b6504511dd0d9e65b1dee4b0cf9ca5c277b046733312
+  checksum: 1757108547ca34bd01a8ee3973cb04b484492c9e5690fc75f54bbcbde5965ab6e0a5b8355c336adf0a9117aa0fdae3053af3aafa9e5eb783282fffa948cfbe11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

In Vite 2.6, it introduced a mechanism to pre-transform the direct imports before the browser requests landed. It could improve the response time of waterflow requests. However, when in SSR, we have our custom logic to handle the externalization, which the pre-transform might start transforming the externalized modules, causing some computation power waste.

Refer to https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

