### PR TITLE
fix(bridge): install bridge module at the end

### DIFF
--- a/packages/bridge/module.cjs
+++ b/packages/bridge/module.cjs
@@ -13,6 +13,7 @@ module.exports.defineNuxtConfig = (config = {}) => {
       config.buildModules = []
     }
     if (!config.buildModules.find(m => m === '@nuxt/bridge' || m === '@nuxt/bridge-edge')) {
+      // Ensure other modules register their hooks before
       config.buildModules.push('@nuxt/bridge')
     }
   }

--- a/packages/bridge/module.cjs
+++ b/packages/bridge/module.cjs
@@ -13,7 +13,7 @@ module.exports.defineNuxtConfig = (config = {}) => {
       config.buildModules = []
     }
     if (!config.buildModules.find(m => m === '@nuxt/bridge' || m === '@nuxt/bridge-edge')) {
-      config.buildModules.unshift('@nuxt/bridge')
+      config.buildModules.push('@nuxt/bridge')
     }
   }
   return config


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

Fix #2501

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I am not very sure if there is a reason for the initial decision to append the module at the beginning, but having that at the beginning caused the other modules relying on the hooks provided by the bridge fail to work.

e.g. in @vueuse/nuxt

We have
```ts
// @vueuse/nuxt
{
  setup() {
    nuxt.hook('autoImports:sources', () => { /* register the auto imports */ })
  }
}
```

Where if the bridge module has been installed before, the hook has already been called, causing the auto-import registration in VueUse never called.

As a temporary workaround, explicitly set the bridge module at the end

```ts
// nuxt.config.js
{
  buildModules: [
    '@vueuse/nuxt',
    '@nuxt/bridge'
  ]
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

