### PR TITLE
docs(bridge): advice to stop server before upgrade

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -17,7 +17,7 @@ Using Nuxt Bridge, you can make sure your project is (almost) ready for Nuxt 3 a
 
 ## Upgrade Nuxt 2
 
-Remove any package lock files (`package-lock.json` and `yarn.lock`) and use the latest `nuxt-edge`:
+Remove any package lock files (`package-lock.json` and `yarn.lock`), remove also the folder `.nuxt` on the root of your project, and install the latest `nuxt-edge`:
 
 ```diff [package.json]
 - "nuxt": "^2.15.0"

--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -17,7 +17,7 @@ Using Nuxt Bridge, you can make sure your project is (almost) ready for Nuxt 3 a
 
 ## Upgrade Nuxt 2
 
-Remove any package lock files (`package-lock.json` and `yarn.lock`), remove also the folder `.nuxt` on the root of your project, and install the latest `nuxt-edge`:
+Make sure your dev server (`nuxt dev`) isn't running, remove any package lock files (`package-lock.json` and `yarn.lock`), and install the latest `nuxt-edge`:
 
 ```diff [package.json]
 - "nuxt": "^2.15.0"


### PR DESCRIPTION
By not removing a previous `.nuxt` folder, the `yarn dev` socket might be broken and throw an error on the console.
I added said step in this PR.