### PR TITLE
docs: add examples of multi filed components

### DIFF
--- a/docs/content/3.docs/2.directory-structure/4.components.md
+++ b/docs/content/3.docs/2.directory-structure/4.components.md
@@ -140,8 +140,8 @@ Imagine a directory structure like this:
 Then in `awesome-ui/nuxt.js` you can use the `components:dirs` hook:
 
 ```js
-import { join } from 'pathe'
-import { defineNuxtModule } from '@nuxt/kit'
+import { defineNuxtModule } from ‘@nuxt/kit-edge’
+import { join } from ‘pathe’
 
 export default defineNuxtModule({
   hooks: {
@@ -176,3 +176,45 @@ export default {
 ```
 
 It will automatically import the components only if used and also support HMR when updating your components in `node_modules/awesome-ui/components/`.
+
+If you have library components that are stored in their own folders you can define and loop over an array to add them to the export:
+
+```js
+import { defineNuxtModule } from ‘@nuxt/kit-edge’
+import { join } from ‘pathe’
+
+const componentDirs = [
+  'avatar',
+  'button',
+  'modal',
+]
+
+export default defineNuxtModule({
+  hooks: {
+    'components:dirs'(dirs) {
+      componentDirs.forEach (componentDir => {
+        dirs.push({
+        path: join(__dirname, ‘components’),
+        prefix: ‘awesome’
+      })
+    }
+  }
+})
+```
+
+If you'd rather leave out the prefix you can do that as well:
+
+```js
+export default defineNuxtModule({
+  hooks: {
+    'components:dirs'(dirs) {
+      // Add ./components dir to the list
+      dirs.push({
+        path: join(__dirname, 'components'),
+        prefix: '',
+        pathPrefix: false
+      })
+    }
+  }
+})
+```


### PR DESCRIPTION
For our design system we use a folder for every component (which sometimes contains other component parts). To get this to work in our nuxt.js export we had to create an array of directories and loop over it to add them all to the export. I thought maybe others would be helped with it :) We also didn't want to use a prefix so I added an example for that as well. I also changed the import order, I got an error if I didn't import pathe after defineNuxtModule so I switched them around. I used @nuxt/kit-edge in this example, as I got an error when I used @nuxt/kit.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

I wanted to add the issue myself but I don't really know how to reproduce a minimal reproduction using our private design system.. I don't know how to include a private NPM package in a CodeSanbox. I hope that's okay.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a couple of things. Pathe is need before defineNuxtModule is imported, so I switched those two around. Next is that I get errors when using @nuxt/kit, @nuxt/kit-edge does work however. The biggest thing I wanted to add is how you can define your library components if they are put in their on separate folders. You need to create and array and loop over each item to add the components from those folders. I also added an example for when you don't want the prefix, we don't use that for example. This is a use case of how we are currently importing our design system components into a Nuxt 3 application.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

