### PR TITLE
feat(nitro): Add Cache-Control and Etag  headers to html response for cache server

### DIFF
--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -121,10 +121,10 @@ export async function renderMiddleware (req, res: ServerResponse) {
     res.setHeader('Content-Type', 'text/html;charset=UTF-8')
     
     // Add Cache-Control and Etag headers for cache server
-    if (publicConfig.app.cacheControl) {
+    if (publicConfig.app?.cacheControl) {
       res.setHeader('Cache-Control', publicConfig.app.cacheControl);
     }
-    if (publicConfig.app.etag) {
+    if (publicConfig.app?.etag) {
       const etag = createEtag(data);
       const ifMatch = req.headers['if-none-match'] === etag
       if (ifMatch) {
@@ -138,8 +138,6 @@ export async function renderMiddleware (req, res: ServerResponse) {
 
   const error = ssrContext.nuxt && ssrContext.nuxt.error
   res.statusCode = error ? error.statusCode : 200
-  
-
   res.end(data, 'utf-8')
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

[Add Cache-Control and Etag headers for cache server]#2662

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Describe your changes in detail 
I add etag header and cache-control header to html response in renderMiddleware

Why is this change required? What problem does it solve?
In ssr mode, the html response doesn't has etag header, so the cdn or browser cannot get 304 when the html is same.
This feature will reduce transporting of html file 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

