### PR TITLE
fix(nuxt3): handle legacy `asyncData` (options api) as `ref`

### DIFF
--- a/packages/nuxt3/src/app/composables/component.ts
+++ b/packages/nuxt3/src/app/composables/component.ts
@@ -1,4 +1,4 @@
-import { defineComponent, getCurrentInstance, toRefs } from 'vue'
+import { defineComponent, getCurrentInstance, reactive, toRefs } from 'vue'
 import type { DefineComponent } from 'vue'
 import { useRoute } from 'vue-router'
 import type { LegacyContext } from '../compat/legacy-app'
@@ -14,7 +14,11 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
   const { fetchKey } = vm.proxy.$options
   const key = typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey || route.fullPath
   const { data } = await useAsyncData(`options:asyncdata:${key}`, () => fn(nuxt._legacyContext))
-  Object.assign(await res, toRefs(data))
+  if (data.value && typeof data.value === 'object') {
+    Object.assign(await res, toRefs(reactive(data.value)))
+  } else if (process.dev) {
+    console.warn('[nuxt] asyncData should return an object', data)
+  }
 }
 
 export const defineNuxtComponent: typeof defineComponent =


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We implemented legacy Options API asyncData support when useAsyncData returned a reactive object. It now returns a ref. This PR updates the legacy support to handle a ref wrapper - but of course will only work if that wrapper contains an object (so will warn in dev mode if it's lacking).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

