### PR TITLE
fix: remove changing layout name to kebab-case

### DIFF
--- a/packages/nuxt3/src/pages/utils.ts
+++ b/packages/nuxt3/src/pages/utils.ts
@@ -2,7 +2,6 @@ import { basename, extname, relative, resolve } from 'pathe'
 import { encodePath } from 'ufo'
 import type { Nuxt, NuxtRoute } from '@nuxt/schema'
 import { resolveFiles } from '@nuxt/kit'
-import { kebabCase } from 'scule'
 
 enum SegmentParserState {
   initial,
@@ -220,7 +219,7 @@ export async function resolveLayouts (nuxt: Nuxt) {
   const files = await resolveFiles(layoutDir, `*{${nuxt.options.extensions.join(',')}}`)
 
   return files.map((file) => {
-    const name = kebabCase(basename(file).replace(extname(file), '')).replace(/["']/g, '')
+    const name = basename(file).replace(extname(file), '').replace(/["']/g, '')
     return { name, file }
   })
 }


### PR DESCRIPTION
### 🔗 Linked issue

#2518 #2567

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes transformation of name of a layout to kebab-case during resolving. Pages are resolved exactly as their file names, so should layouts. 
As far as I know it was the same behavior in Nuxt 2.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

