### PR TITLE
fix(vite): invalidate virtual modules when templates are regenerated

### DIFF
--- a/packages/bridge/src/vite/server.ts
+++ b/packages/bridge/src/vite/server.ts
@@ -92,6 +92,15 @@ export async function buildServer (ctx: ViteBuildContext) {
   const viteServer = await vite.createServer(serverConfig)
   ctx.nuxt.hook('close', () => viteServer.close())
 
+  // Invalidate virtual modules when templates are re-generated
+  ctx.nuxt.hook('app:templatesGenerated', () => {
+    for (const [id, mod] of viteServer.moduleGraph.idToModuleMap) {
+      if (id.startsWith('\x00virtual:')) {
+        viteServer.moduleGraph.invalidateModule(mod)
+      }
+    }
+  })
+
   // Initialize plugins
   await viteServer.pluginContainer.buildStart({})
 

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -101,6 +101,15 @@ export async function buildServer (ctx: ViteBuildContext) {
   // Start development server
   const viteServer = await vite.createServer(serverConfig)
 
+  // Invalidate virtual modules when templates are re-generated
+  ctx.nuxt.hook('app:templatesGenerated', () => {
+    for (const [id, mod] of viteServer.moduleGraph.idToModuleMap) {
+      if (id.startsWith('\x00virtual:')) {
+        viteServer.moduleGraph.invalidateModule(mod)
+      }
+    }
+  })
+
   // Close server on exit
   ctx.nuxt.hook('close', () => viteServer.close())
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1367

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR invalidates the vite server modules that correspond to the vfs templates that are generated in the app.

A possible enhancement could be only invalidating templates that have _changed_ but that would involve slightly more interrelation with the app part of nuxt3, though it's certainly also possible.

Note that this PR fixes vite but a similar issue exists with regard to webpack - see https://github.com/sysgears/webpack-virtual-modules/issues/89

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

