### PR TITLE
docs: add api req helpers example

### DIFF
--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -49,6 +49,17 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 }
 ```
 
+#### Accessing req data
+```js
+import { useBody } from 'h3'
+
+export default async (req, res) => {
+  const body = await useBody(req)
+  
+  return body;
+}
+```
+
 ## Server Middleware
 
 Nuxt will automatically read in any files in the `~/server/middleware` to create server middleware for your project.

--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -52,7 +52,7 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 #### Accessing req data
 
 ```js
-import { useBody, useQuery } from 'h3'
+import { useBody, useCookies, useQuery } from 'h3'
 
 export default async (req, res) => {
   const query = await useQuery(req)

--- a/docs/content/3.docs/2.directory-structure/12.server.md
+++ b/docs/content/3.docs/2.directory-structure/12.server.md
@@ -50,15 +50,20 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 ```
 
 #### Accessing req data
+
 ```js
-import { useBody } from 'h3'
+import { useBody, useQuery } from 'h3'
 
 export default async (req, res) => {
-  const body = await useBody(req)
+  const query = await useQuery(req)
+  const body = await useBody(req) // only for POST request
+  const cookies = useCookies(req)
   
-  return body;
+  return { query, body, cookies }
 }
 ```
+
+Learn more about [h3 methods](https://www.jsdocs.io/package/h3#package-index-functions).
 
 ## Server Middleware
 


### PR DESCRIPTION
### 🔗 Linked issue
#1860 

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description
<!-- Describe your changes in detail -->
Adding example of accessing req body in docs

<!-- Why is this change required? What problem does it solve? -->
It is not possible to know how to access the req body without an example

### 📝 Checklist
<!-- If your change requires a documentation PR, please link it appropriately -->
Doc link:
https://v3.nuxtjs.org/docs/directory-structure/server

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

