### PR TITLE
fix(bridge): add missing process flags for vite

### DIFF
--- a/packages/bridge/src/vite/vite.ts
+++ b/packages/bridge/src/vite/vite.ts
@@ -26,6 +26,10 @@ async function bundle (nuxt: Nuxt, builder: any) {
         mode: nuxt.options.dev ? 'development' : 'production',
         logLevel: 'warn',
         define: {
+          'process.static': nuxt.options.target === 'static',
+          'process.env.NODE_ENV': JSON.stringify(nuxt.options.dev ? 'development' : 'production'),
+          'process.mode': JSON.stringify(nuxt.options.dev ? 'development' : 'production'),
+          'process.target': JSON.stringify(nuxt.options.target),
           'process.dev': nuxt.options.dev
         },
         resolve: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2528

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds missing `process.` flags present in the base nuxt 2 webpack config.

https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js#L180-L186

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

