### PR TITLE
fix(kit): don't ignore `@` alias

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -85,9 +85,9 @@ function existsSyncSensitive (path: string, files?: string[]) {
  */
 export function resolveAlias (path: string, alias: ResolveOptions['alias']) {
   for (const key in alias) {
-    if (key === '@') { continue } // Don't resolve @foo/bar
+    if (key === '@' && !path.startsWith('@/')) { continue } // Don't resolve @foo/bar
     if (path.startsWith(key)) {
-      path = alias[key] + path.substr(key.length)
+      path = alias[key] + path.slice(key.length)
     }
   }
   return path


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2677

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We're currently completely ignoring the `@` alias to avoid resolving `@foo/bar` incorrectly. This ensures we'd don't skip the `@` alias in other situations.


**Aside**:

It might be worth considering _only_ resolving aliases with a directory separator afterwards as I imagine there could be some wrong resolutions from the current behaviour (e.g. consider aliases `~` and `~someotheralias`). This would of course be a breaking change.

Alternatively, perhaps we could resolve in reverse length order?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

