### PR TITLE
chore: replace `substr` with `slice`

### DIFF
--- a/packages/nitro/src/rollup/plugins/middleware.ts
+++ b/packages/nitro/src/rollup/plugins/middleware.ts
@@ -9,7 +9,7 @@ import virtual from './virtual'
 const unique = (arr: any[]) => Array.from(new Set(arr))
 
 export function middleware (getMiddleware: () => ServerMiddleware[]) {
-  const getImportId = p => '_' + hasha(p).substr(0, 6)
+  const getImportId = p => '_' + hasha(p).slice(0, 6)
 
   let lastDump = ''
 

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -75,7 +75,7 @@ export async function renderMiddleware (req, res: ServerResponse) {
   let isPayloadReq = false
   if (url.startsWith(STATIC_ASSETS_BASE) && url.endsWith(PAYLOAD_JS)) {
     isPayloadReq = true
-    url = url.substr(STATIC_ASSETS_BASE.length, url.length - STATIC_ASSETS_BASE.length - PAYLOAD_JS.length) || '/'
+    url = url.slice(STATIC_ASSETS_BASE.length, url.length - PAYLOAD_JS.length) || '/'
   }
 
   // Initialize ssr context

--- a/packages/nitro/src/server/middleware.ts
+++ b/packages/nitro/src/server/middleware.ts
@@ -28,7 +28,7 @@ function filesToMiddleware (files: string[], baseDir: string, basePath: string, 
     const route = joinURL(
       basePath,
       file
-        .substr(0, file.length - extname(file).length)
+        .slice(0, file.length - extname(file).length)
         .replace(/\/index$/, '')
     )
     const handle = resolve(baseDir, file)

--- a/packages/nitro/src/utils/index.ts
+++ b/packages/nitro/src/utils/index.ts
@@ -22,7 +22,7 @@ export function compileTemplate (contents: string) {
   return (params: Record<string, any>) => contents.replace(/{{ ?([\w.]+) ?}}/g, (_, match) => {
     const val = dotProp.get(params, match)
     if (!val) {
-      consola.warn(`cannot resolve template param '${match}' in ${contents.substr(0, 20)}`)
+      consola.warn(`cannot resolve template param '${match}' in ${contents.slice(0, 20)}`)
     }
     return val as string || `${match}`
   })

--- a/packages/vite/src/utils/index.ts
+++ b/packages/vite/src/utils/index.ts
@@ -30,5 +30,5 @@ export function hash (input: string, length = 8) {
   return createHash('sha256')
     .update(input)
     .digest('hex')
-    .substr(0, length)
+    .slice(0, length)
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹 Chore

### 📚 Description

This PR replaces `.substr` use with `.slice` as the former is deprecated. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

