### PR TITLE
feat(nitro): ssl nitro support in production

### DIFF
--- a/packages/nitro/src/runtime/entries/server.ts
+++ b/packages/nitro/src/runtime/entries/server.ts
@@ -1,9 +1,13 @@
 import '#polyfill'
-import { Server } from 'http'
+import { Server as HttpServer } from 'http'
+import { Server as HttpsServer } from 'https'
 import destr from 'destr'
 import { handle } from '../server'
 
-const server = new Server(handle)
+const cert = process.env.NITRO_SSL_CERT
+const key = process.env.NITRO_SSL_KEY
+
+const server = cert && key ? new HttpsServer({ key, cert }, handle) : new HttpServer(handle)
 
 const port = (destr(process.env.NUXT_PORT || process.env.PORT) || 3000) as number
 const hostname = process.env.NUXT_HOST || process.env.HOST || 'localhost'
@@ -14,7 +18,8 @@ server.listen(port, hostname, (err) => {
     console.error(err)
     process.exit(1)
   }
-  console.log(`Listening on http://${hostname}:${port}`)
+  const protocol = cert && key ? 'https' : 'http'
+  console.log(`Listening on ${protocol}://${hostname}:${port}`)
 })
 
 export default {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1701

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for initialising an HTTPS server (instead of HTTPS) if `NITRO_SSL_CERT` and `NITRO_SSL_KEY` are set. The provisos in issue #1701 stand.

If we're happy with this in general terms I'll go ahead and add documentation for these env variables to the docs on the server preset.

To test:

```bash
openssl genpkey -out nitro.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
openssl req -text -in nitro.csr -noout
openssl x509 -req -days 365 -in nitro.csr -signkey nitro.key -out nitro.crt
yarn nuxi build
NITRO_SSL_CERT=$(cat nitro.crt) NITRO_SSL_KEY=$(cat nitro.key) node .output/server/index.mjs
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

