### PR TITLE
feat(nuxi): call nuxt `listen` hook for dev

### DIFF
--- a/examples/hello-world/nuxt.config.ts
+++ b/examples/hello-world/nuxt.config.ts
@@ -1,11 +1,4 @@
 import { defineNuxtConfig } from 'nuxt3'
-import {useNuxt} from "@nuxt/kit";
 
 export default defineNuxtConfig({
-  hooks: {
-    listen (server, listener) {
-      const nuxt = useNuxt()
-      console.log(nuxt.server.app, server.address(), listener)
-    },
-  }
 })

--- a/examples/hello-world/nuxt.config.ts
+++ b/examples/hello-world/nuxt.config.ts
@@ -1,4 +1,11 @@
 import { defineNuxtConfig } from 'nuxt3'
+import {useNuxt} from "@nuxt/kit";
 
 export default defineNuxtConfig({
+  hooks: {
+    listen (server, listener) {
+      const nuxt = useNuxt()
+      console.log(nuxt.server.app, server.address(), listener)
+    },
+  }
 })

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -93,5 +93,6 @@ export default defineNuxtCommand({
     })
 
     await load(false)
+    await currentNuxt.hooks.callHook('listen', listener.server, listener)
   }
 })

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -93,6 +93,8 @@ export default defineNuxtCommand({
     })
 
     await load(false)
-    await currentNuxt.hooks.callHook('listen', listener.server, listener)
+    if (currentNuxt) {
+      await currentNuxt.hooks.callHook('listen', listener.server, listener)
+    }
   }
 })

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -1,6 +1,5 @@
-import type http from 'http'
-import type https from 'https'
-import type { IncomingMessage, ServerResponse } from 'http'
+import type { Server as HttpServer, IncomingMessage, ServerResponse } from 'http'
+import type { Server as HttpsServer } from 'https'
 import type { Compiler, Configuration, Stats } from 'webpack'
 import type { TSConfig } from 'pkg-types'
 import type { ModuleContainer } from './module'
@@ -103,7 +102,7 @@ export interface NuxtHooks {
   'render:setupMiddleware': (app: any) => HookResult
   'render:errorMiddleware': (app: any) => HookResult
   'render:done': (server: Server) => HookResult
-  'listen': (listenerServer: http.Server | https.Server, listener: any) => HookResult
+  'listen': (listenerServer: HttpServer | HttpsServer, listener: any) => HookResult
   'server:nuxt:renderLoading': (req: IncomingMessage, res: ServerResponse) => HookResult
   'render:route': (url: string, result: RenderResult, context: any) => HookResult
   'render:routeDone': (url: string, result: RenderResult, context: any) => HookResult

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -1,3 +1,6 @@
+import type http from 'http'
+import type https from 'https'
+import type { Listener } from 'listhen'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { Compiler, Configuration, Stats } from 'webpack'
 import type { TSConfig } from 'pkg-types'
@@ -101,7 +104,7 @@ export interface NuxtHooks {
   'render:setupMiddleware': (app: any) => HookResult
   'render:errorMiddleware': (app: any) => HookResult
   'render:done': (server: Server) => HookResult
-  'listen': (listenerServer: any, listener: any) => HookResult
+  'listen': (listenerServer: http.Server | https.Server, listener: Listener) => HookResult
   'server:nuxt:renderLoading': (req: IncomingMessage, res: ServerResponse) => HookResult
   'render:route': (url: string, result: RenderResult, context: any) => HookResult
   'render:routeDone': (url: string, result: RenderResult, context: any) => HookResult

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -1,6 +1,5 @@
 import type http from 'http'
 import type https from 'https'
-import type { Listener } from 'listhen'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { Compiler, Configuration, Stats } from 'webpack'
 import type { TSConfig } from 'pkg-types'
@@ -104,7 +103,7 @@ export interface NuxtHooks {
   'render:setupMiddleware': (app: any) => HookResult
   'render:errorMiddleware': (app: any) => HookResult
   'render:done': (server: Server) => HookResult
-  'listen': (listenerServer: http.Server | https.Server, listener: Listener) => HookResult
+  'listen': (listenerServer: http.Server | https.Server, listener: any) => HookResult
   'server:nuxt:renderLoading': (req: IncomingMessage, res: ServerResponse) => HookResult
   'render:route': (url: string, result: RenderResult, context: any) => HookResult
   'render:routeDone': (url: string, result: RenderResult, context: any) => HookResult


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/issues/2499

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [] ✨ New feature (a non-breaking change that adds functionality)
- [] ⚠️ Breaking change (fix or feature that would cause existing functionality to change) 

### 📚 Description

The listen hook is a feature from nuxt v2 that is typed in nuxt v3. but nothing calls it (as far as I can tell).

It's a useful hook to expose the server used for local development, giving module authors functionality to see the server address and hook into the server if needed.

Specifically a module I'm working on needs it, this is the equivalent nuxt 2 code.

```ts
nuxt.hook('listen', (ctx) => {
  setServerContext({
    url: ctx.listeners[0].url,
    server: ctx.listeners[0].server,
    app: ctx.app,
  })
})
```


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. - **no hook documentation section, needs it's own page**

