### PR TITLE
feat(nuxt3): allow disabling vue type shims

### DIFF
--- a/docs/content/1.getting-started/1.introduction.md
+++ b/docs/content/1.getting-started/1.introduction.md
@@ -18,8 +18,20 @@ Before getting started, please make sure you have installed the recommended setu
 * **Node.js**<sup>*</sup> (latest LTS version) 👉 [[Download](https://nodejs.org/en/download/)]
 * **Visual Studio Code** 👉 [[Download](https://code.visualstudio.com/)]
 * **Volar Extension** 👉 [[Download](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)]
+  * Either enable [**Take Over Mode**](https://github.com/johnsoncodehk/volar/discussions/471) (recommended)
+  * ... or add **TypeScript Vue Plugin (Volar)** 👉 [[Download](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin)]
 
 <sup>*</sup> If you already have Node.js installed, check with `node --version` that you are using `v14` or `v16`.
+
+If you are not using Volar you may need to add the following file to your project (`~/shims.d.ts`):
+
+```ts
+declare module '*.vue' {
+  import { DefineComponent } from '@vue/runtime-core'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}
+```
 
 ## Nuxt 3 or Bridge?
 

--- a/docs/content/1.getting-started/1.introduction.md
+++ b/docs/content/1.getting-started/1.introduction.md
@@ -23,15 +23,19 @@ Before getting started, please make sure you have installed the recommended setu
 
 <sup>*</sup> If you already have Node.js installed, check with `node --version` that you are using `v14` or `v16`.
 
-If you are not using Volar you may need to add the following file to your project (`~/shims.d.ts`):
+::alert{type=info}
 
-```ts
-declare module '*.vue' {
-  import { DefineComponent } from '@vue/runtime-core'
-  const component: DefineComponent<{}, {}, any>
-  export default component
-}
+If you have enabled **Take Over Mode** or installed the **TypeScript Vue Plugin (Volar)** you can disable generating the shim for `*.vue` files:
+
+```js
+export default defineNuxtConfig({
+  typescript: {
+    shim: false
+  }
+})
 ```
+
+::
 
 ## Nuxt 3 or Bridge?
 

--- a/packages/nuxt3/src/app/types/index.d.ts
+++ b/packages/nuxt3/src/app/types/index.d.ts
@@ -1,5 +1,4 @@
 import './augments'
-import './shims'
 
 // eslint-disable-next-line
 export * from '../index'

--- a/packages/nuxt3/src/app/types/shims.d.ts
+++ b/packages/nuxt3/src/app/types/shims.d.ts
@@ -1,6 +1,0 @@
-// https://github.com/vitejs/vite/blob/main/packages/create-vite/template-vue-ts/src/env.d.ts
-declare module '*.vue' {
-  import { DefineComponent } from '@vue/runtime-core'
-  const component: DefineComponent<{}, {}, any>
-  export default component
-}

--- a/packages/nuxt3/src/core/nuxt.ts
+++ b/packages/nuxt3/src/core/nuxt.ts
@@ -44,6 +44,10 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.hook('prepare:types', (opts) => {
     opts.references.push({ types: 'nuxt3' })
     opts.references.push({ path: resolve(nuxt.options.buildDir, 'plugins.d.ts') })
+    // Add vue shim
+    if (nuxt.options.typescript.shim) {
+      opts.references.push({ path: resolve(nuxt.options.buildDir, 'vue-shim.d.ts') })
+    }
   })
 
   // Init user modules

--- a/packages/nuxt3/src/core/templates.ts
+++ b/packages/nuxt3/src/core/templates.ts
@@ -8,6 +8,19 @@ type TemplateContext = {
   app: NuxtApp;
 }
 
+export const vueShim = {
+  filename: 'vue-shim.d.ts',
+  write: true,
+  getContents: () =>
+    [
+      'declare module \'*.vue\' {',
+      '  import { DefineComponent } from \'@vue/runtime-core\'',
+      '  const component: DefineComponent<{}, {}, any>',
+      '  export default component',
+      '}'
+    ].join('\n')
+}
+
 // TODO: Use an alias
 export const appComponentTemplate = {
   filename: 'app-component.mjs',

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -10,5 +10,12 @@ export default {
    * You can extend generated `.nuxt/tsconfig.json` using this option
    * @typedef {Awaited<ReturnType<typeof import('pkg-types')['readPackageJSON']>>}
    */
-  tsConfig: {}
+  tsConfig: {},
+
+  /**
+   * Generate a `*.vue` shim.
+   *
+   * We recommend instead either enabling [**Take Over Mode**](https://github.com/johnsoncodehk/volar/discussions/471) or adding **TypeScript Vue Plugin (Volar)** 👉 [[Download](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin)].
+   */
+  shim: true
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/vuejs/create-vue/pull/26

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the default '*.vue'* shim so that Volar can provide better type inference, such as clicking through directly to the component definition rather than the shim. (It may still be necessary for users of other IDEs  to add the shim themselves.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

