### PR TITLE
fix(nuxt3): only treeshake macro exports when building

### DIFF
--- a/packages/nuxt3/src/pages/macros.ts
+++ b/packages/nuxt3/src/pages/macros.ts
@@ -4,6 +4,7 @@ import { findStaticImports, findExports } from 'mlly'
 
 export interface TransformMacroPluginOptions {
   macros: Record<string, string>
+  dev?: boolean
 }
 
 export const TransformMacroPlugin = createUnplugin((options: TransformMacroPluginOptions) => {
@@ -42,7 +43,7 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
         if (match.specifier && match._type === 'named') {
           // [webpack] Export named exports rather than the default (component)
           return code.replace(match.code, `export {${Object.values(options.macros).join(', ')}} from "${match.specifier}"`)
-        } else {
+        } else if (!options.dev) {
           // ensure we tree-shake any _other_ default exports out of the macro script
           code = code.replace(match.code, '/*#__PURE__*/ false &&')
           code += '\nexport default {}'

--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -47,6 +47,7 @@ export default defineNuxtModule({
 
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
+      dev: nuxt.options.dev,
       macros: {
         definePageMeta: 'meta'
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2794

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR hotfixes the issue with vite HMR by not treeshaking out the normal module exports. (We have to solve proper HMR for page meta, which is not yet working, separately.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

