### PR TITLE
fix(nuxt3): normalize page paths (for windows support)

### DIFF
--- a/packages/nuxt3/src/pages/utils.ts
+++ b/packages/nuxt3/src/pages/utils.ts
@@ -1,4 +1,4 @@
-import { basename, extname, relative, resolve } from 'pathe'
+import { basename, extname, normalize, relative, resolve } from 'pathe'
 import { encodePath } from 'ufo'
 import type { Nuxt, NuxtPage } from '@nuxt/schema'
 import { resolveFiles } from '@nuxt/kit'
@@ -229,13 +229,14 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
   return {
     imports: metaImports,
     routes: routes.map((route) => {
-      const metaImportName = `${pascalCase(route.file.replace(/[^\w]/g, ''))}Meta`
-      metaImports.add(`import { meta as ${metaImportName} } from '${route.file}?macro=true'`)
+      const file = normalize(route.file)
+      const metaImportName = `${pascalCase(file.replace(/[^\w]/g, ''))}Meta`
+      metaImports.add(`import { meta as ${metaImportName} } from '${file}?macro=true'`)
       return {
         ...route,
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta || `{${metaImportName}}` as any,
-        component: `{() => import('${route.file}')}`
+        component: `{() => import('${file}')}`
       }
     })
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2822

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For Windows systems, we need to normalize paths (or escape `\` characters) if users have insert their own un-normalised values.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

