### PR TITLE
fix(bridge): don't override existing `baseURL` property

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -18,7 +18,7 @@ export function setupNitroBridge () {
   // Handle legacy property name `assetsPath`
   nuxt.options.app.buildAssetsDir = nuxt.options.app.buildAssetsDir || nuxt.options.app.assetsPath
   nuxt.options.app.assetsPath = nuxt.options.app.buildAssetsDir
-  nuxt.options.app.baseURL = (nuxt.options.app as any).basePath
+  nuxt.options.app.baseURL = nuxt.options.app.baseURL || (nuxt.options.app as any).basePath
   // Nitro expects app config on `config.app` rather than `config._app`
   nuxt.options.publicRuntimeConfig.app = nuxt.options.publicRuntimeConfig.app || {}
   Object.assign(nuxt.options.publicRuntimeConfig.app, nuxt.options.publicRuntimeConfig._app)


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Once https://github.com/nuxt/nuxt.js/pull/10197 is merged, we don't want to override `baseURL` if it's properly set.
