### PR TITLE
feat(nuxt3): add import protection patterns

### DIFF
--- a/packages/nuxt3/src/core/nuxt.ts
+++ b/packages/nuxt3/src/core/nuxt.ts
@@ -1,13 +1,14 @@
 import { resolve } from 'pathe'
 import { createHooks } from 'hookable'
 import type { Nuxt, NuxtOptions, NuxtConfig, ModuleContainer, NuxtHooks } from '@nuxt/schema'
-import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent } from '@nuxt/kit'
+import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, addVitePlugin, addWebpackPlugin } from '@nuxt/kit'
 import pagesModule from '../pages/module'
 import metaModule from '../meta/module'
 import componentsModule from '../components/module'
 import autoImportsModule from '../auto-imports/module'
 import { distDir, pkgDir } from '../dirs'
 import { version } from '../../package.json'
+import { ImportProtectionPlugin, vueAppPatterns } from './plugins/import-protection'
 import { initNitro } from './nitro'
 import { addModuleTranspiles } from './modules'
 
@@ -49,6 +50,15 @@ async function initNuxt (nuxt: Nuxt) {
       opts.references.push({ path: resolve(nuxt.options.buildDir, 'vue-shim.d.ts') })
     }
   })
+
+  // Add import protection
+
+  const config = {
+    rootDir: nuxt.options.rootDir,
+    patterns: vueAppPatterns(nuxt)
+  }
+  addVitePlugin(ImportProtectionPlugin.vite(config))
+  addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Init user modules
   await nuxt.callHook('modules:before', { nuxt } as ModuleContainer)

--- a/packages/nuxt3/src/core/plugins/import-protection.ts
+++ b/packages/nuxt3/src/core/plugins/import-protection.ts
@@ -14,7 +14,7 @@ interface ImportProtectionOptions {
 const escapeRE = (str: string) => str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
 
 export const vueAppPatterns = (nuxt: Nuxt) => [
-  [/(^|node_modules\/)(nuxt3|nuxt)/, '`nuxt3`/`nuxt` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or /`#imports`.'],
+  [/(^|node_modules\/)(nuxt3|nuxt)/, '`nuxt3`/`nuxt` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or `#imports`.'],
   [/nuxt\.config/, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
   [/(^|node_modules\/)@vue\/composition-api/],
   ...nuxt.options.modules.filter(m => typeof m === 'string').map((m: string) =>

--- a/packages/nuxt3/src/core/plugins/import-protection.ts
+++ b/packages/nuxt3/src/core/plugins/import-protection.ts
@@ -1,0 +1,54 @@
+import { createRequire } from 'module'
+import { createUnplugin } from 'unplugin'
+import consola from 'consola'
+import { isAbsolute, relative, resolve } from 'pathe'
+import type { Nuxt } from '@nuxt/schema'
+
+const _require = createRequire(import.meta.url)
+
+interface ImportProtectionOptions {
+  rootDir: string
+  patterns: [importPattern: string | RegExp, warning?: string][]
+}
+
+const escapeRE = (str: string) => str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+
+export const vueAppPatterns = (nuxt: Nuxt) => [
+  [/(^|node_modules\/)(nuxt3|nuxt)/, '`nuxt3`/`nuxt` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or /`#imports`.'],
+  [/nuxt\.config/, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
+  [/(^|node_modules\/)@vue\/composition-api/],
+  ...nuxt.options.modules.filter(m => typeof m === 'string').map((m: string) =>
+    [new RegExp(`^${escapeRE(m)}$`), 'Importing directly from module entrypoints is not allowed.']),
+  ...['#static-assets', '#static', '#config', '#assets', '#storage', '#server-middleware']
+    .map(i => [i, 'Nitro aliases cannot be imported in the Vue part of your app.']),
+  ...[/(^|node_modules\/)@nuxt\/kit/, /(^|node_modules\/)@nuxt\/nitro/]
+    .map(i => [i, 'This module cannot be imported in the Vue part of your app.']),
+  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server'))), 'Importing from server middleware is not allowed in the Vue part of your app.']
+] as ImportProtectionOptions['patterns']
+
+export const ImportProtectionPlugin = createUnplugin(function (options: ImportProtectionOptions) {
+  const cache: Record<string, Map<string | RegExp, boolean>> = {}
+  return {
+    name: 'nuxt:import-protection',
+    enforce: 'pre',
+    resolveId (id, importer) {
+      const invalidImports = options.patterns.filter(([pattern]) => pattern instanceof RegExp ? pattern.test(id) : pattern === id)
+      let matched: boolean
+      for (const match of invalidImports) {
+        cache[id] = cache[id] || new Map()
+        const [pattern, warning] = match
+        // Skip if already warned
+        if (cache[id].has(pattern)) { continue }
+
+        const relativeImporter = isAbsolute(importer) ? relative(options.rootDir, importer) : importer
+        consola.error(warning || 'Invalid import', `[importing \`${id}\` from \`${relativeImporter}\`]`)
+        cache[id].set(pattern, true)
+        matched = true
+      }
+      if (matched) {
+        return _require.resolve('unenv/runtime/mock/proxy')
+      }
+      return null
+    }
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1471

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a plugin for rollup (Nitro), vite, and webpack to detect common patterns of wrong imports. It then can give helpful warnings (suggestions for better wording welcomed), and returns a proxy so the build doesn't completely fail (in this case the helpful warnings might be obscured by pages of cryptic errors)...

Rather than add the plugin in Nitro, I've added it in nuxt3 as it is protecting _against_ nuxt3 aliases.

#### Example output

![CleanShot 2022-01-20 at 13 14 50](https://user-images.githubusercontent.com/28706372/150345803-4a6d663c-d735-4294-9485-b5519561c152.png)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

