### PR TITLE
chore(nitro): use new dotprop export

### DIFF
--- a/packages/nitro/src/utils/index.ts
+++ b/packages/nitro/src/utils/index.ts
@@ -6,7 +6,7 @@ import defu from 'defu'
 import { mergeHooks } from 'hookable'
 import consola from 'consola'
 import chalk from 'chalk'
-import dotProp from 'dot-prop'
+import { getProperty } from 'dot-prop'
 import type { NitroPreset, NitroInput } from '../context'
 
 export function hl (str: string) {
@@ -20,7 +20,7 @@ export function prettyPath (p: string, highlight = true) {
 
 export function compileTemplate (contents: string) {
   return (params: Record<string, any>) => contents.replace(/{{ ?([\w.]+) ?}}/g, (_, match) => {
-    const val = dotProp.get(params, match)
+    const val = getProperty(params, match)
     if (!val) {
       consola.warn(`cannot resolve template param '${match}' in ${contents.slice(0, 20)}`)
     }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹Chore

### 📚 Description

`dot-prop` exports have changed.