### PR TITLE
fix(nuxt3): allow customising page keys

### DIFF
--- a/docs/content/3.docs/2.directory-structure/9.pages.md
+++ b/docs/content/3.docs/2.directory-structure/9.pages.md
@@ -134,6 +134,29 @@ To display the `child.vue` component, you have to insert the `<NuxtNestedPage
 </template>
 ```
 
+### Child route keys
+
+If you want more control over when the `<NuxtNestedPage>` component is re-rendered (for example, for transitions), you can either pass a string or function via the `childKey` prop, or you can define a `key` value via `definePageMeta`:
+
+```html{}[pages/parent.vue]
+<template>
+  <div>
+    <h1>I am the parent view</h1>
+    <NuxtNestedPage :child-key="someKey" />
+  </div>
+</template>
+```
+
+Or alternatively:
+
+```html{}[pages/child.vue]
+<script setup>
+definePageMeta({
+  key: route => route.fullPath
+})
+</script>
+```
+
 ## Page Metadata
 
 You might want to define metadata for each route in your app. You can do this using the `definePageMeta` macro, which will work both in `<script>` and in `<script setup>`:
@@ -174,6 +197,10 @@ definePageMeta({
 ### Special Metadata
 
 Of course, you are welcome to define metadata for your own use throughout your app. But some metadata defined with `definePageMeta` has a particular purpose:
+
+#### `key`
+
+[See above](#child-route-keys).
 
 #### `layout`
 

--- a/examples/with-pages/app.vue
+++ b/examples/with-pages/app.vue
@@ -20,6 +20,12 @@ const route = useRoute()
         <NuxtLink to="/parent/b" class="n-link-base">
           Parent (b)
         </NuxtLink>
+        <button class="n-link-base" @click="$router.push(`/parent/reload-${(Math.random() * 100).toFixed()}`)">
+          Keyed child
+        </button>
+        <button class="n-link-base" @click="$router.push(`/parent/static-${(Math.random() * 100).toFixed()}`)">
+          Non-keyed child
+        </button>
       </nav>
     </template>
 

--- a/examples/with-pages/pages/parent/reload-[id].vue
+++ b/examples/with-pages/pages/parent/reload-[id].vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    Child reloaded: {{ reloads }}
+  </div>
+</template>
+
+<script setup>
+const reloads = useState('reload', () => 0)
+onMounted(() => { reloads.value++ })
+definePageMeta({
+  key: route => route.path
+})
+</script>

--- a/examples/with-pages/pages/parent/static-[id].vue
+++ b/examples/with-pages/pages/parent/static-[id].vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    Child reloaded: {{ reloads }}
+  </div>
+</template>
+
+<script setup>
+const reloads = useState('static', () => 0)
+onMounted(() => { reloads.value++ })
+</script>

--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -14,6 +14,7 @@ export interface PageMeta {
   [key: string]: any
   transition?: false | TransitionProps
   layout?: false | string | Ref<false | string> | ComputedRef<false | string>
+  key?: string | ((route: RouteLocationNormalizedLoaded) => string)
   // TODO: https://github.com/vuejs/vue-next/issues/3652
   // keepalive?: false | KeepAliveProps
 }

--- a/packages/nuxt3/src/pages/runtime/nested-page.vue
+++ b/packages/nuxt3/src/pages/runtime/nested-page.vue
@@ -1,11 +1,26 @@
 <template>
-  <RouterView v-slot="{ Component }">
-    <component :is="Component" :key="$route.path" />
+  <RouterView v-slot="{ Component, route }">
+    <component :is="Component" :key="getKeyFor(childKey || route.meta.key, route)" />
   </RouterView>
 </template>
 
-<script>
+<script lang="ts">
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+
+const getKeyFor = (key: string | ((route: RouteLocationNormalizedLoaded) => string), route?: RouteLocationNormalizedLoaded) => {
+  return key && typeof key === 'function' ? key(route) : key
+}
+
 export default {
-  name: 'NuxtNestedPage'
+  name: 'NuxtNestedPage',
+  props: {
+    childKey: {
+      type: [Function, String] as unknown as () => string | ((route: RouteLocationNormalizedLoaded) => string),
+      default: null
+    }
+  },
+  setup () {
+    return { getKeyFor }
+  }
 }
 </script>

--- a/packages/nuxt3/src/pages/runtime/nested-page.vue
+++ b/packages/nuxt3/src/pages/runtime/nested-page.vue
@@ -21,7 +21,7 @@ export default {
     const route = useRoute()
     const key = computed(() => {
       const source = props.childKey ?? route.meta.key
-      return source && typeof source === 'function' ? source(route) : source
+      return typeof source === 'function' ? source(route) : source
     })
     return {
       key

--- a/packages/nuxt3/src/pages/runtime/nested-page.vue
+++ b/packages/nuxt3/src/pages/runtime/nested-page.vue
@@ -1,15 +1,13 @@
 <template>
-  <RouterView v-slot="{ Component, route }">
-    <component :is="Component" :key="getKeyFor(childKey || route.meta.key, route)" />
+  <RouterView v-slot="{ Component }">
+    <component :is="Component" :key="key" />
   </RouterView>
 </template>
 
 <script lang="ts">
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-
-const getKeyFor = (key: string | ((route: RouteLocationNormalizedLoaded) => string), route?: RouteLocationNormalizedLoaded) => {
-  return key && typeof key === 'function' ? key(route) : key
-}
+import { useRoute } from 'vue-router'
+import { computed } from 'vue'
 
 export default {
   name: 'NuxtNestedPage',
@@ -19,8 +17,15 @@ export default {
       default: null
     }
   },
-  setup () {
-    return { getKeyFor }
+  setup (props) {
+    const route = useRoute()
+    const key = computed(() => {
+      const source = props.childKey ?? route.meta.key
+      return source && typeof source === 'function' ? source(route) : source
+    })
+    return {
+      key
+    }
   }
 }
 </script>

--- a/packages/nuxt3/src/pages/runtime/page.vue
+++ b/packages/nuxt3/src/pages/runtime/page.vue
@@ -3,7 +3,7 @@
     <NuxtLayout v-if="Component" :name="layout || route.meta.layout">
       <NuxtTransition :options="route.meta.transition ?? { name: 'page', mode: 'out-in' }">
         <Suspense @pending="() => onSuspensePending(Component)" @resolve="() => onSuspenseResolved(Component)">
-          <component :is="Component" :key="route.path" />
+          <component :is="Component" />
         </Suspense>
       </NuxtTransition>
     </NuxtLayout>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/2309

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the default keying of routes to the full path, meaning that parent routes won't rerender when child routes change. It also adds support for setting custom keys for child routes, either a string or a function that receives the current route.

The key can either be set in `definePageMeta` or via a prop for `<NuxtNestedPage />`.

Contrary to [my earlier RFC](https://github.com/nuxt/framework/discussions/2468), I now think it makes sense to set the page key via meta as that way we can implement logic in a key function that will handle both child routes and deeply nested child routes (see following note).

**Note**: nested routes which have children themselves [behaved differently in Nuxt 2](https://github.com/nuxt/nuxt.js/blob/a2495a68736f9af96cd25209a948beb1ca665d4d/packages/vue-app/template/components/nuxt.js#L47-L72). I can restore this behaviour if desired.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

