### PR TITLE
docs(esm): fix typo

### DIFF
--- a/docs/content/2.concepts/4.esm.md
+++ b/docs/content/2.concepts/4.esm.md
@@ -183,7 +183,7 @@ Also when using dynamic import syntax (in both CJS and ESM files), we always hav
 import('cjs-pkg').then(console.log) // [Module: null prototype] { default: { test: '123' } }
 ```
 
-In this case, we need to manually interop default export:
+In this case, we need to manually interop the default export:
 
 ```js
 // Static import

--- a/docs/content/2.concepts/4.esm.md
+++ b/docs/content/2.concepts/4.esm.md
@@ -183,7 +183,7 @@ Also when using dynamic import syntax (in both CJS and ESM files), we always hav
 import('cjs-pkg').then(console.log) // [Module: null prototype] { default: { test: '123' } }
 ```
 
-In this case, we need to manually inerop default export:
+In this case, we need to manually interop default export:
 
 ```js
 // Static import


### PR DESCRIPTION
### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

Fix typo: "inerop" -> "interop"

https://v3.nuxtjs.org/concepts/esm#default-exports
