### PR TITLE
docs: add example of `useRuntimeConfig()` within a plugin

### DIFF
--- a/docs/content/3.docs/1.usage/5.runtime-config.md
+++ b/docs/content/3.docs/1.usage/5.runtime-config.md
@@ -77,6 +77,24 @@ const config = useRuntimeConfig()
 **`useRuntimeConfig` only works during `setup` or `Lifecycle Hooks`**.
 ::
 
+### Plugins
+
+If you want to use the runtime confg within any (custom) plugin, you can use `useRuntimeConfig()` inside of your `defineNuxtPlugin` function.
+
+For example:
+```ts
+import Urql from '@urql/vue';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const config = useRuntimeConfig();
+
+  const isServer = !!nuxtApp.ssrContext;
+  const url = isServer ? config.serverUrl : config.clientUrl;
+  
+  // Do something with url & isServer.
+});
+```
+
 ### API routes
 
 Within the API routes, you can access runtime config by directly importing from virtual `#config`.

--- a/docs/content/3.docs/1.usage/5.runtime-config.md
+++ b/docs/content/3.docs/1.usage/5.runtime-config.md
@@ -83,8 +83,6 @@ If you want to use the runtime confg within any (custom) plugin, you can use `us
 
 For example:
 ```ts
-import Urql from '@urql/vue';
-
 export default defineNuxtPlugin((nuxtApp) => {
   const config = useRuntimeConfig();
 

--- a/docs/content/3.docs/1.usage/5.runtime-config.md
+++ b/docs/content/3.docs/1.usage/5.runtime-config.md
@@ -86,8 +86,7 @@ For example:
 export default defineNuxtPlugin((nuxtApp) => {
   const config = useRuntimeConfig();
 
-  const isServer = !!nuxtApp.ssrContext;
-  const url = isServer ? config.serverUrl : config.clientUrl;
+  const url = process.server ? config.serverUrl : config.clientUrl;
   
   // Do something with url & isServer.
 });


### PR DESCRIPTION
I'd like to propose an example for using runtime configuration within plugins.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
An example plugin that uses the runtime config. This is not well conveyed in the runtime plugins and so I thought this would be nice to have.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

