### PR TITLE
docs(examples): fix nuxt direct imports errors

### DIFF
--- a/docs/content/3.docs/2.directory-structure/11.plugins.md
+++ b/docs/content/3.docs/2.directory-structure/11.plugins.md
@@ -115,10 +115,11 @@ yarn add --dev vue-gtag-next
 Then create a plugin file `plugins/vue-gtag.client.js`.
 
 ```ts
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin, useNuxtApp } from '#app'
 import VueGtag from 'vue-gtag-next'
 
-export default defineNuxtPlugin((nuxtApp) => {
+export default defineNuxtPlugin(() => {
+  const nuxtApp = useNuxtApp()
   nuxtApp.vueApp.use(VueGtag, {
     property: {
       id: 'GA_MEASUREMENT_ID'


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Updates documentation for using Vue plugins properly as last updates prevents from importing nuxt directly.
Following the documentation caused errors like below:

`[ERROR]  nuxt3/nuxt cannot be imported directly. Instead, import runtime Nuxt composables from #app or #imports. [importing nuxt3/dist/app from plugins/yourplugin.client.js]`


