### PR TITLE
feat(nuxt3): make layout and other page meta reactive

### DIFF
--- a/docs/content/3.docs/2.directory-structure/6.layouts.md
+++ b/docs/content/3.docs/2.directory-structure/6.layouts.md
@@ -79,12 +79,10 @@ You can also use a ref or computed property for your layout.
 <script setup>
 const route = useRoute()
 function enableCustomLayout () {
-  // Note: because it's within a ref, it will persist if 
-  // you navigate away and then back to the page.
-  route.meta.layout.value = "custom"
+  route.meta.layout = "custom"
 }
 definePageMeta({
-  layout: ref(false),
+  layout: false,
 });
 </script>
 ```

--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -112,8 +112,27 @@ export default defineNuxtModule({
       }
     })
 
+    addTemplate({
+      filename: 'layouts.d.ts',
+      write: true,
+      getContents: async () => {
+        const composablesFile = resolve(runtimeDir, 'composables')
+        const layouts = await resolveLayouts(nuxt)
+        return [
+          'import { ComputedRef, Ref } from \'vue\'',
+          `export type LayoutKey = ${layouts.map(layout => `"${layout.name}"`).join(' | ') || 'string'}`,
+          `declare module '${composablesFile}' {`,
+          '  interface PageMeta {',
+          '    layout?: false | LayoutKey | Ref<LayoutKey> | ComputedRef<LayoutKey>',
+          '  }',
+          '}'
+        ].join('\n')
+      }
+    })
+
     nuxt.hook('prepare:types', ({ references }) => {
       references.push({ path: resolve(nuxt.options.buildDir, 'middleware.d.ts') })
+      references.push({ path: resolve(nuxt.options.buildDir, 'layouts.d.ts') })
     })
 
     // Add layouts template

--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -1,4 +1,4 @@
-import { KeepAliveProps, TransitionProps } from 'vue'
+import { KeepAliveProps, TransitionProps, UnwrapRef } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
 import { useNuxtApp } from '#app'
 
@@ -19,7 +19,7 @@ export interface PageMeta {
 }
 
 declare module 'vue-router' {
-  interface RouteMeta extends PageMeta {}
+  interface RouteMeta extends UnwrapRef<PageMeta> {}
 }
 
 const warnRuntimeUsage = (method: string) =>

--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -1,4 +1,4 @@
-import { ComputedRef, KeepAliveProps, Ref, TransitionProps } from 'vue'
+import { KeepAliveProps, TransitionProps } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
 import { useNuxtApp } from '#app'
 
@@ -14,7 +14,6 @@ export interface PageMeta {
   [key: string]: any
   pageTransition?: false | TransitionProps
   layoutTransition?: false | TransitionProps
-  layout?: false | string | Ref<false | string> | ComputedRef<false | string>
   key?: string | ((route: RouteLocationNormalizedLoaded) => string)
   keepalive?: false | KeepAliveProps
 }

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -66,6 +66,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   router.beforeEach(async (to, from) => {
+    to.meta = reactive(to.meta)
     nuxtApp._processingMiddleware = true
 
     type MiddlewareDef = string | NavigationGuard


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/2867

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR:
 1. types layout strings in page meta, just as middleware is (that is, adds hints) - this should resolve 
https://github.com/nuxt/framework/issues/2567 and resolve https://github.com/nuxt/framework/issues/2518
 2. makes page meta reactive by default - [improving experience for making reactive layouts, for example](https://github.com/nuxt/framework/issues/2867#issuecomment-1019261409)
 3. fixes an issue with transitioning to and from pages with layouts (we now render fragments in place of missing transition/layout components rather than omitting the nodes entirely)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

