### PR TITLE
test(nuxt3): fix exclude test

### DIFF
--- a/packages/nuxt3/test/auto-imports.test.ts
+++ b/packages/nuxt3/test/auto-imports.test.ts
@@ -46,8 +46,8 @@ describe('auto-imports:transform', () => {
     expect(result).to.equal('import { computed } from \'bar\';// import { computed } from "foo"\n;const a = computed(0)')
   })
 
-  it('should exclude files from transform', async () => {
-    expect(await transform('const a = foo()')).to.not.include('import { foo } from "excluded"')
+  it('should exclude files from transform', () => {
+    expect(transformPlugin.transformInclude.call({ error: null, warn: null }, 'excluded')).to.equal(false)
   })
 })
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹 Chore

### 📚 Description

The previous test would always pass as it used `"` rather than `'`. (Discovered in #2216 when the quotation changed.)
