### PR TITLE
fix(nuxt3): add `app:suspense:resolve` hooks

### DIFF
--- a/packages/nuxt3/src/app/bootstrap.ts
+++ b/packages/nuxt3/src/app/bootstrap.ts
@@ -48,7 +48,7 @@ if (process.client) {
     await nuxt.hooks.callHook('app:created', vueApp)
     await nuxt.hooks.callHook('app:beforeMount', vueApp)
 
-    nuxt.hooks.hookOnce('page:finish', () => {
+    nuxt.hooks.hookOnce('app:finish', () => {
       nuxt.isHydrating = false
     })
 

--- a/packages/nuxt3/src/app/bootstrap.ts
+++ b/packages/nuxt3/src/app/bootstrap.ts
@@ -48,7 +48,7 @@ if (process.client) {
     await nuxt.hooks.callHook('app:created', vueApp)
     await nuxt.hooks.callHook('app:beforeMount', vueApp)
 
-    nuxt.hooks.hookOnce('app:finish', () => {
+    nuxt.hooks.hookOnce('app:suspense:resolve', () => {
       nuxt.isHydrating = false
     })
 

--- a/packages/nuxt3/src/app/components/nuxt-root.vue
+++ b/packages/nuxt3/src/app/components/nuxt-root.vue
@@ -1,5 +1,5 @@
 <template>
-  <Suspense @pending="onPending" @resolve="onResolve">
+  <Suspense @resolve="onResolve">
     <App />
   </Suspense>
 </template>
@@ -15,8 +15,7 @@ export default {
       console.error('[nuxt] Error in `vue:setup`. Callbacks must be synchronous.')
     }
     return {
-      onPending: () => nuxtApp.callHook('app:start'),
-      onResolve: () => nuxtApp.callHook('app:finish')
+      onResolve: () => nuxtApp.callHook('app:suspense:resolve')
     }
   }
 }

--- a/packages/nuxt3/src/app/components/nuxt-root.vue
+++ b/packages/nuxt3/src/app/components/nuxt-root.vue
@@ -1,5 +1,5 @@
 <template>
-  <Suspense>
+  <Suspense @pending="onPending" @resolve="onResolve">
     <App />
   </Suspense>
 </template>
@@ -13,6 +13,10 @@ export default {
     const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup')
     if (process.dev && results && results.some(i => i && 'then' in i)) {
       console.error('[nuxt] Error in `vue:setup`. Callbacks must be synchronous.')
+    }
+    return {
+      onPending: () => nuxtApp.callHook('app:start'),
+      onResolve: () => nuxtApp.callHook('app:finish')
     }
   }
 }

--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -20,6 +20,8 @@ export interface RuntimeNuxtHooks {
   'app:beforeMount': (app: App<Element>) => HookResult
   'app:mounted': (app: App<Element>) => HookResult
   'app:rendered': () => HookResult
+  'app:start': (Component?: VNode) => HookResult
+  'app:finish': (Component?: VNode) => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
   'meta:register': (metaRenderers: Array<(nuxt: NuxtApp) => NuxtMeta | Promise<NuxtMeta>>) => HookResult

--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -20,8 +20,7 @@ export interface RuntimeNuxtHooks {
   'app:beforeMount': (app: App<Element>) => HookResult
   'app:mounted': (app: App<Element>) => HookResult
   'app:rendered': () => HookResult
-  'app:start': (Component?: VNode) => HookResult
-  'app:finish': (Component?: VNode) => HookResult
+  'app:suspense:resolve': (Component?: VNode) => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
   'meta:register': (metaRenderers: Array<(nuxt: NuxtApp) => NuxtMeta | Promise<NuxtMeta>>) => HookResult


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/2938

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Our asyncData implementation was dependent on a hook being called within the pages module. This adds a similar hook at `app` level meaning that `asyncData` will work as expected on client-side.

Ideas for better hook naming welcome.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

