### PR TITLE
fix(nuxt3): hotfix for missing components declaration

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -83,9 +83,7 @@ export default defineNuxtModule<ComponentsOptions>({
     })
 
     nuxt.hook('prepare:types', ({ references }) => {
-      if (components.length) {
-        references.push({ path: resolve(nuxt.options.buildDir, 'components.d.ts') })
-      }
+      references.push({ path: resolve(nuxt.options.buildDir, 'components.d.ts') })
     })
 
     // Watch for changes

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -65,6 +65,12 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('app:templates', async (app) => {
       components = await scanComponents(componentDirs, nuxt.options.srcDir!)
       await nuxt.callHook('components:extend', components)
+
+      app.templates.push({
+        ...componentsTypeTemplate,
+        options: { components, buildDir: nuxt.options.buildDir }
+      })
+
       if (!components.length) {
         return
       }
@@ -72,11 +78,6 @@ export default defineNuxtModule<ComponentsOptions>({
       app.templates.push({
         ...componentsTemplate,
         options: { components }
-      })
-
-      app.templates.push({
-        ...componentsTypeTemplate,
-        options: { components, buildDir: nuxt.options.buildDir }
       })
 
       app.plugins.push({ src: '#build/components' })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/2947

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There have been a number of issues with lacking a reference to `components.d.ts` which is likely to do with some inconsistency between when these hooks are being called (ie. we may not have the components fully resolved by the time we're writing the type file). This PR always adds the file to `nuxt.d.ts`, as a hotfix.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

