### PR TITLE
fix(nuxi): updated rmdir to rm and checked paths exists

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-import { promises as fsp } from 'fs'
+import { promises as fsp, existsSync } from 'fs'
 import consola from 'consola'
 import { resolve } from 'pathe'
 import { resolveModule } from '../utils/cjs'
@@ -44,9 +44,9 @@ export default defineNuxtCommand({
       execSync(`${packageManager} install`, { stdio: 'inherit' })
     } else {
       consola.info('Upgrading nuxt...')
-      await fsp.rmdir('node_modules/.cache', { recursive: true })
-      await fsp.rmdir(resolve(rootDir, '.nuxt'), { recursive: true })
-      await fsp.rmdir('node_modules/.vite', { recursive: true })
+      await Promise.all(['node_modules/.cache', resolve(rootDir, '.nuxt'), 'node_modules/.vite'].map((path) => {
+        return existsSync(path) ? fsp.rm(path, { recursive: true }) : undefined
+      }))
       execSync(`${packageManager} ${packageManager === 'yarn' ? 'add' : 'install'} -D nuxt3@latest`, { stdio: 'inherit' })
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#2951

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The nuxi upgrade now fails with `ENOENT` after this commit: https://github.com/nuxt/framework/commit/6e06d2b4c9c7dd8f59442e93962f48e4a8bb156b#diff-6adc9cccbbc7f61fcf38abdc8a1521338913c2215e3d099d1b71ebadbfc53b9dR47

`rmdir` [has been deprecated](https://nodejs.org/api/fs.html#fspromisesrmdirpath-options) in `v14.14.0` of node 
I have also added a path check beforehand as I got it to fail with `ERROR  ENOENT: no such file or directory, stat 'node_modules/.cache'`

This resolves #2951 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

