### PR TITLE
docs(modules): fix npm script name

### DIFF
--- a/docs/content/3.docs/4.advanced/2.modules.md
+++ b/docs/content/3.docs/4.advanced/2.modules.md
@@ -22,7 +22,7 @@ Starter template and module starter is a standard path of creating a Nuxt module
 - Open `my-module` in IDE of your choice (VSCode is recommended)
 - Install dependencies using the package manager of your choice (Yarn is recommended)
 - Ensure local files are generated using `npm run prepare`
-- Start playground using `npm run dev`
+- Start playground using `npm run play`
 - **Follow this document to learn more about Nuxt modules**
 
 ::alert{type=warning icon=🚧}


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description
[The module docs ](https://v3.nuxtjs.org/docs/advanced/modules#quick-start) points you to use `npm run dev` to start the module playground, but according to the starter said npm script isn't defined and it seems to be `npm run play` instead.  See: https://github.com/nuxt/starter/blob/module/package.json#L19

