### PR TITLE
docs: add `https://` to link

### DIFF
--- a/docs/content/3.docs/4.advanced/2.modules.md
+++ b/docs/content/3.docs/4.advanced/2.modules.md
@@ -153,7 +153,7 @@ To make your modules discoverable, use `nuxt-` prefix for the npm package name. 
 
 ### Listing module to modules.nuxtjs.org
 
-Do you have a working Module and want it listed in [modules.nuxtjs.org](modules.nuxtjs.org)? Open an issue in [nuxt/modules](https://github.com/nuxt/modules/issues/new) repository.
+Do you have a working Module and want it listed in [modules.nuxtjs.org](https://modules.nuxtjs.org)? Open an issue in [nuxt/modules](https://github.com/nuxt/modules/issues/new) repository.
 Nuxt team can help you to apply best practices before listing.
 
 ### Do not advertise with a specific Nuxt version


### PR DESCRIPTION
Broken link out to modules.nuxtjs.org

prefix with https://

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Go to https://v3.nuxtjs.org/docs/advanced/modules/#modules-ecosystem
- Click link to modules.nuxt.org
- See 404

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

