### PR TITLE
feat(nitro)!: support overriding runtime config at a second level

### DIFF
--- a/docs/content/3.docs/1.usage/5.runtime-config.md
+++ b/docs/content/3.docs/1.usage/5.runtime-config.md
@@ -33,12 +33,16 @@ In addition to any process environment variables, if you have a `.env` file in y
 ```sh [.env]
 BASE_URL=https://nuxtjs.org
 API_SECRET=api_secret_token
+MY_MODULE_KEY=overridden_value
 ```
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   publicRuntimeConfig: {
-    BASE_URL: process.env.BASE_URL
+    BASE_URL: process.env.BASE_URL,
+    myModule: {
+      key: 'default-value'
+    }
   },
   privateRuntimeConfig: {
     API_SECRET: process.env.API_SECRET
@@ -46,7 +50,9 @@ export default defineNuxtConfig({
 })
 ```
 
-**💡 Tip:** While it is not necessary, by using identical runtime config names as env variables, you can easily override them in production using platform environment variables.
+::alert{icon=💡 type=info}
+Nitro will convert any keys to upper-snake-case (`baseURL` becomes `BASE_URL`) and allows overriding configuration up to two levels down, so you can override config within an object.
+::
 
 ## Accessing runtime config
 

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -61,6 +61,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.5.4",
+    "scule": "^0.2.1",
     "serve-placeholder": "^1.2.4",
     "serve-static": "^1.14.2",
     "std-env": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,6 +2972,7 @@ __metadata:
     rollup: ^2.66.1
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-visualizer: ^5.5.4
+    scule: ^0.2.1
     serve-placeholder: ^1.2.4
     serve-static: ^1.14.2
     std-env: ^3.0.1


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we can only override at the top level of runtime config. This now allows for overriding at a second (nested) level, for example, for modules which want to allow runtime configuration. At the same time, we also normalise to upper-snake-case (`baseURL` -> `BASE_URL`)

Consider this example:

```js
export default defineNuxtConfig({
  publicRuntimeConfig: {
    // this previously required overriding with `baseURL=other node .output/server/index.mjs`
    // but is now normalised to `BASE_URL`
    baseURL: 'test',
    // this was previously impossible to override piece-meal
    // but can now be overriden with `MY_MODULE_SOME_KEY=false node .output/server/index.mjs`
    myModule: {
      someKey: true
    }
  }
})
```

#### Notes

1. Note that we have special handling for app config - perhaps we can abandon this and default to (e.g.) APP_CDN_URL instead of NUXT_APP_CDN_URL?

   https://github.com/nuxt/framework/blob/a971aab2728fb412f865140a8faa47542aa913ab/packages/nitro/src/runtime/app/config.ts#L24-L28

2. ~~If we're happy with this approach, I will update the documentation.~~

### 👉 Migration

* If you are depending on overriding with a **mixed-case** environment variable, you should convert it to upper-snake-case instead (`baseURL` -> `BASE_URL`).

### 📝 Checklist

- [x] I have updated the documentation accordingly.

