### PR TITLE
refactor!: extract `<NuxtLayout>` from `<NuxtPage>`

### DIFF
--- a/docs/content/3.docs/2.directory-structure/15.app.md
+++ b/docs/content/3.docs/2.directory-structure/15.app.md
@@ -25,7 +25,9 @@ If you have a [`pages/`](/docs/directory-structure/pages) directory, to display 
 ```vue [app.vue]
 <template>
   <div>
-    <NuxtPage/>
+    <NuxtLayout>
+      <NuxtPage/>
+    </NuxtLayout>
   </div>
 </template>
 ```

--- a/packages/nuxt3/src/pages/runtime/app.vue
+++ b/packages/nuxt3/src/pages/runtime/app.vue
@@ -1,3 +1,5 @@
 <template>
-  <NuxtPage />
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>

--- a/packages/nuxt3/src/pages/runtime/layout.ts
+++ b/packages/nuxt3/src/pages/runtime/layout.ts
@@ -1,24 +1,33 @@
-import { defineComponent, h, Ref } from 'vue'
+import { defineComponent, isRef, Ref, Transition } from 'vue'
+import { useRoute } from 'vue-router'
+import { wrapIf } from './utils'
 // @ts-ignore
 import layouts from '#build/layouts'
+
+const defaultLayoutTransition = { name: 'layout', mode: 'out-in' }
 
 export default defineComponent({
   props: {
     name: {
       type: [String, Boolean, Object] as unknown as () => string | false | Ref<string | false>,
-      default: 'default'
+      default: null
     }
   },
   setup (props, context) {
+    const route = useRoute()
+
     return () => {
-      const layout = (props.name && typeof props.name === 'object' ? props.name.value : props.name) ?? 'default'
-      if (!layouts[layout]) {
-        if (process.dev && layout && layout !== 'default') {
-          console.warn(`Invalid layout \`${layout}\` selected.`)
-        }
-        return context.slots.default()
+      const layout = (isRef(props.name) ? props.name.value : props.name) ?? route.meta.layout as string ?? 'default'
+
+      const hasLayout = layout && layout in layouts
+      if (process.dev && layout && !hasLayout && layout !== 'default') {
+        console.warn(`Invalid layout \`${layout}\` selected.`)
       }
-      return h(layouts[layout], props, context.slots)
+
+      // We avoid rendering layout transition if there is no layout to render
+      return wrapIf(Transition, hasLayout && (route.meta.layoutTransition ?? defaultLayoutTransition),
+        wrapIf(layouts[layout], hasLayout, context.slots)
+      ).default()
     }
   }
 })

--- a/packages/nuxt3/src/pages/runtime/page.ts
+++ b/packages/nuxt3/src/pages/runtime/page.ts
@@ -1,59 +1,27 @@
-import { Component, defineComponent, KeepAlive, h, Suspense, Transition } from 'vue'
-import { RouterView, useRoute } from 'vue-router'
-import NuxtLayout from './layout'
+import { defineComponent, h, Suspense, Transition } from 'vue'
+import { RouterView } from 'vue-router'
+import { wrapIf, wrapInKeepAlive } from './utils'
 import { useNuxtApp } from '#app'
-// @ts-ignore
-import layouts from '#build/layouts'
 
 type InstanceOf<T> = T extends new (...args: any[]) => infer R ? R : never
 type RouterViewSlotProps = Parameters<InstanceOf<typeof RouterView>['$slots']['default']>[0]
 
 export default defineComponent({
   name: 'NuxtPage',
-  props: {
-    layout: {
-      type: String,
-      default: null
-    }
-  },
-  setup (props) {
+  setup () {
     const nuxtApp = useNuxtApp()
-    const route = useRoute()
 
     return () => {
-      // We avoid rendering layout transition if there is no layout to render
-      const hasLayout = props.layout ?? route.meta.layout ?? 'default' in layouts
-
       return h(RouterView, {}, {
-        default: ({ Component }: RouterViewSlotProps) => Component &&
-        wrapIf(Transition, hasLayout && (route.meta.layoutTransition ?? defaultLayoutTransition),
-          wrapIf(NuxtLayout, hasLayout && { name: props.layout ?? route.meta.layout },
+        default: ({ Component, route }: RouterViewSlotProps) => Component &&
             wrapIf(Transition, route.meta.pageTransition ?? defaultPageTransition,
               wrapInKeepAlive(route.meta.keepalive, h(Suspense, {
                 onPending: () => nuxtApp.callHook('page:start', Component),
                 onResolve: () => nuxtApp.callHook('page:finish', Component)
-              }, { default: () => h(Component) })
-              )
-            )
-          )).default()
+              }, { default: () => h(Component) }))).default()
       })
     }
   }
 })
 
-const Fragment = {
-  setup (props, { slots }) {
-    return () => slots.default()
-  }
-}
-
-const wrapIf = (component: Component, props: any, slots: any) => {
-  return { default: () => props ? h(component, props === true ? {} : props, slots) : h(Fragment, {}, slots) }
-}
-
-const wrapInKeepAlive = (props: any, children: any) => {
-  return { default: () => process.client && props ? h(KeepAlive, props === true ? {} : props, children) : children }
-}
-
-const defaultLayoutTransition = { name: 'layout', mode: 'out-in' }
 const defaultPageTransition = { name: 'page', mode: 'out-in' }

--- a/packages/nuxt3/src/pages/runtime/utils.ts
+++ b/packages/nuxt3/src/pages/runtime/utils.ts
@@ -1,0 +1,15 @@
+import { Component, KeepAlive, h } from 'vue'
+
+const Fragment = {
+  setup (_props, { slots }) {
+    return () => slots.default()
+  }
+}
+
+export const wrapIf = (component: Component, props: any, slots: any) => {
+  return { default: () => props ? h(component, props === true ? {} : props, slots) : h(Fragment, {}, slots) }
+}
+
+export const wrapInKeepAlive = (props: any, children: any) => {
+  return { default: () => process.client && props ? h(KeepAlive, props === true ? {} : props, children) : children }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2074

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR extracts `<NuxtLayout>` from `<NuxtPage>` while preserving its behaviour. (Though we do move the transition into the layout component.)

**Note**: This will mean once we have [aligned the behaviour of route keys between pages/nested pages](https://github.com/nuxt/framework/pull/2976), we can actually replace `<NuxtNestedPage>` with `<NuxtPage>` entirely, which will improve UX for transitions between nested pages.

### 👉 Migration

* Add `<NuxtLayout>` to `app.vue` if you are using layouts:
   ```diff
    <template>
   +  <NuxtLayout>
        <NuxtPage />
   +  </NuxtLayout>
    </template>
   ```

* If you were passing layout manually to `<NuxtPage>`, move this to `<NuxtLayout>` instead:
   ```diff
    <template>
   +  <NuxtLayout name="my-layout">
   -     <NuxtPage layout="my-layout" />
   +     <NuxtPage />
   +  </NuxtLayout>
    </template>
   ```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

