### PR TITLE
fix(nuxt3): remove existing globals from auto-imports

### DIFF
--- a/packages/nuxt3/src/auto-imports/imports.ts
+++ b/packages/nuxt3/src/auto-imports/imports.ts
@@ -38,11 +38,7 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
     from: 'vue',
     names: [
       // <script setup>
-      'defineEmits',
-      'defineExpose',
-      'defineProps',
       'withCtx',
-      'withDefaults',
       'withDirectives',
       'withKeys',
       'withMemo',
@@ -78,7 +74,6 @@ export const Nuxt3AutoImports: AutoImportSource[] = [
       'shallowReactive',
       'shallowReadonly',
       'shallowRef',
-      'stop',
       'toRaw',
       'toRef',
       'toRefs',

--- a/packages/nuxt3/test/auto-imports.test.ts
+++ b/packages/nuxt3/test/auto-imports.test.ts
@@ -73,6 +73,13 @@ describe('auto-imports:nuxt3', () => {
 })
 
 const excludedVueHelpers = [
+  // Already globally registered
+  'defineEmits',
+  'defineExpose',
+  'defineProps',
+  'withDefaults',
+  'stop',
+  //
   '__esModule',
   'devtools',
   'EffectScope',


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

These are compiler macros or (in the case of `stop`) conflicting with a global object already available - so they shouldn't be auto-imported.