### PR TITLE
fix(bridge): don't instantiate vite builder if only preparing types

### DIFF
--- a/packages/bridge/src/vite/module.ts
+++ b/packages/bridge/src/vite/module.ts
@@ -45,6 +45,7 @@ export default defineNuxtModule<ViteOptions>({
     addPluginTemplate(middlewareTemplate)
 
     nuxt.hook('builder:prepared', async (builder) => {
+      if (nuxt.options._prepare) { return }
       builder.bundleBuilder.close()
       delete builder.bundleBuilder
       const { ViteBuilder } = await import('./vite')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2978

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We mock bundleBuilder.build() in nuxi prepare but if vite is enabled in Bridge, we entirely replace webpack builder, meaning we have to run a full build. This avoids replacing the bundle builder if we are running with `nuxi prepare`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

