### PR TITLE
chore: replace constructors with types

### DIFF
--- a/packages/kit/src/auto-import.ts
+++ b/packages/kit/src/auto-import.ts
@@ -12,10 +12,10 @@ export function addAutoImport (_autoImports: AutoImport | AutoImport[]) {
   })
 }
 
-export function addAutoImportDir (_autoImportDirs: String | String[]) {
+export function addAutoImportDir (_autoImportDirs: string | string[]) {
   assertNuxtCompatibility({ bridge: true })
 
-  useNuxt().hook('autoImports:dirs', (autoImportDirs: String[]) => {
+  useNuxt().hook('autoImports:dirs', (autoImportDirs: string[]) => {
     for (const dir of (Array.isArray(_autoImportDirs) ? _autoImportDirs : [_autoImportDirs])) {
       autoImportDirs.push(dir)
     }

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -49,7 +49,7 @@ export function normalizePlugin (plugin: NuxtPlugin | string): NuxtPlugin {
  * })
  * ```
  */
-export interface AddPluginOptions { append?: Boolean }
+export interface AddPluginOptions { append?: boolean }
 export function addPlugin (_plugin: NuxtPlugin | string, opts: AddPluginOptions = {}) {
   const nuxt = useNuxt()
 

--- a/packages/nitro/src/rollup/plugins/assets.ts
+++ b/packages/nitro/src/rollup/plugins/assets.ts
@@ -7,7 +7,7 @@ import { globby } from 'globby'
 import virtual from './virtual'
 
 export interface AssetOptions {
-  inline: Boolean
+  inline: boolean
   dirs: {
     [assetdir: string]: {
       dir: string
@@ -17,10 +17,10 @@ export interface AssetOptions {
 }
 
 interface Asset {
-  fsPath: string,
+  fsPath: string
   meta: {
-    type?: string,
-    etag?: string,
+    type?: string
+    etag?: string
     mtime?: string
   }
 }

--- a/packages/schema/src/types/compatibility.ts
+++ b/packages/schema/src/types/compatibility.ts
@@ -13,7 +13,7 @@ export interface NuxtCompatibility {
    * - `true`:  When using Nuxt 2, using bridge module is required
    * - `false`: When using Nuxt 2, using bridge module is not supported
   */
-  bridge?: Boolean
+  bridge?: boolean
 }
 
 export interface NuxtCompatibilityIssue {

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -90,5 +90,5 @@ export interface ComponentsDir extends ScanDir {
 
 export interface ComponentsOptions {
   dirs: (string | ComponentsDir)[]
-  loader?: Boolean
+  loader?: boolean
 }

--- a/packages/schema/src/types/imports.ts
+++ b/packages/schema/src/types/imports.ts
@@ -18,7 +18,7 @@ export interface AutoImport {
   /**
    * Disable auto import
    */
-  disabled?: Boolean
+  disabled?: boolean
 }
 
 export interface AutoImportSource {
@@ -34,7 +34,7 @@ export interface AutoImportSource {
   /**
    * Disable auto import source
    */
-  disabled?: Boolean
+  disabled?: boolean
 }
 
 export interface AutoImportsOptions {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹 Chore

### 📚 Description

This replaces accidentally included constructors with types instead.