### PR TITLE
fix(nitro): treat bootrap dep as an entry file

### DIFF
--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -36,6 +36,7 @@ const getSPARenderer = cachedResult(async () => {
     let entryFiles = Object.values(clientManifest).filter(
       (fileValue: any) => fileValue.isEntry
     )
+    entryFiles.push(...entryFiles.flatMap((e: any) => e.dynamicImports).map(i => clientManifest[i]))
     if ('all' in clientManifest && 'initial' in clientManifest) {
       // Upgrade legacy manifest (also see normalizeClientManifest in vue-bundle-renderer)
       // https://github.com/nuxt-contrib/vue-bundle-renderer/issues/12

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -36,7 +36,7 @@ const getSPARenderer = cachedResult(async () => {
     let entryFiles = Object.values(clientManifest).filter(
       (fileValue: any) => fileValue.isEntry
     )
-    entryFiles.push(...entryFiles.flatMap((e: any) => e.dynamicImports).map(i => clientManifest[i]))
+    entryFiles.push(...entryFiles.flatMap((e: any) => e.dynamicImports || []).map(i => clientManifest[i]).filter(Boolean))
     if ('all' in clientManifest && 'initial' in clientManifest) {
       // Upgrade legacy manifest (also see normalizeClientManifest in vue-bundle-renderer)
       // https://github.com/nuxt-contrib/vue-bundle-renderer/issues/12

--- a/packages/nitro/src/runtime/app/render.ts
+++ b/packages/nitro/src/runtime/app/render.ts
@@ -36,6 +36,7 @@ const getSPARenderer = cachedResult(async () => {
     let entryFiles = Object.values(clientManifest).filter(
       (fileValue: any) => fileValue.isEntry
     )
+    // https://github.com/nuxt/framework/pull/3106
     entryFiles.push(...entryFiles.flatMap((e: any) => e.dynamicImports || []).map(i => clientManifest[i]).filter(Boolean))
     if ('all' in clientManifest && 'initial' in clientManifest) {
       // Upgrade legacy manifest (also see normalizeClientManifest in vue-bundle-renderer)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3041, resolves #2553

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When we moved to bootstrap + entry pattern (for module federation support), we inadvertently made the real entrypoint show up in the manifest as a dynamic entrypoint. This fixes that by making all top-level dynamic dependencies of the entrypoint entrypoints too (for SPA renderer).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

