### PR TITLE
fix(nitro): replace `global.` in fewer instances

### DIFF
--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -156,7 +156,7 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
     values: {
       'process.env.NODE_ENV': nitroContext._nuxt.dev ? '"development"' : '"production"',
       'typeof window': '"undefined"',
-      'global.': 'globalThis.',
+      ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),
       'process.server': 'true',
       'process.client': 'false',
       'process.env.NUXT_NO_SSR': JSON.stringify(!nitroContext._nuxt.ssr),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1997, resolves #2999

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were being a little over-zealous in our replacement. I hope a stray `global.` won't slip through the net, but by adding a specific list of possible values to replace, we can improve things.

An alternative, which is quite tempting, is to write our own rollup plugin that would add a RegExp that's more precisely targeted to this need (vs `@rollup/plugin-replace` which only supports non-RE delimiters).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

