### PR TITLE
feat!(nuxt3): extends support for `components/` directory

### DIFF
--- a/examples/config-extends/app.vue
+++ b/examples/config-extends/app.vue
@@ -6,6 +6,8 @@ const themeConfig = useRuntimeConfig().theme
   <NuxtExampleLayout example="config-extends">
     theme runtimeConfig
     <pre>{{ JSON.stringify(themeConfig, null, 2) }}</pre>
+    <BaseButton>Base Button</BaseButton>
+    <FancyButton>Fancy Button</FancyButton>
   </NuxtExampleLayout>
 </template>
 

--- a/examples/config-extends/base/components/BaseButton.vue
+++ b/examples/config-extends/base/components/BaseButton.vue
@@ -1,0 +1,5 @@
+<template>
+  <button role="button">
+    <slot />
+  </button>
+</template>

--- a/examples/config-extends/base/components/FancyButton.vue
+++ b/examples/config-extends/base/components/FancyButton.vue
@@ -1,0 +1,5 @@
+<template>
+  <BaseButton>
+    <slot />
+  </BaseButton>
+</template>

--- a/examples/config-extends/components/FancyButton.vue
+++ b/examples/config-extends/components/FancyButton.vue
@@ -1,0 +1,16 @@
+<template>
+  <BaseButton class="fancy-button">
+    <slot />
+  </BaseButton>
+</template>
+
+<style scoped>
+button {
+  appearance: none;
+  background-color: #FAFBFC;
+  border: 1px solid rgba(27, 31, 35, 0.15);
+  border-radius: 6px;
+  box-shadow: rgba(27, 31, 35, 0.04) 0 1px 0, rgba(255, 255, 255, 0.25) 0 1px 0 inset;
+  color: #24292E;
+}
+</style>

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'fs'
-import { resolve } from 'pathe'
+import { resolve, basename } from 'pathe'
 import { defineNuxtModule, resolveAlias, addVitePlugin, addWebpackPlugin } from '@nuxt/kit'
 import type { Component, ComponentsDir, ComponentsOptions } from '@nuxt/schema'
 import { componentsTemplate, componentsTypeTemplate } from './templates'
@@ -8,6 +8,9 @@ import { loaderPlugin } from './loader'
 
 const isPureObjectOrString = (val: any) => (!Array.isArray(val) && typeof val === 'object') || typeof val === 'string'
 const isDirectory = (p: string) => { try { return statSync(p).isDirectory() } catch (_e) { return false } }
+function compareDirByPathLength ({ path: pathA }, { path: pathB }) {
+  return pathB.split(/[\\/]/).filter(Boolean).length - pathA.split(/[\\/]/).filter(Boolean).length
+}
 
 export default defineNuxtModule<ComponentsOptions>({
   meta: {
@@ -17,15 +20,40 @@ export default defineNuxtModule<ComponentsOptions>({
   defaults: {
     dirs: ['~/components']
   },
-  setup (options, nuxt) {
+  setup (componentOptions, nuxt) {
     let componentDirs = []
     let components: Component[] = []
 
+    const normalizeDirs = (dir: any, cwd: string) => {
+      if (Array.isArray(dir)) {
+        return dir.map(dir => normalizeDirs(dir, cwd)).flat().sort(compareDirByPathLength)
+      }
+      if (dir === true || dir === undefined) {
+        return [{ path: resolve(cwd, 'components') }]
+      }
+      if (typeof dir === 'string') {
+        return {
+          path: resolve(cwd, resolveAlias(dir, {
+            ...nuxt.options.alias,
+            '~': cwd
+          }))
+        }
+      }
+      return []
+    }
+
     // Resolve dirs
     nuxt.hook('app:resolve', async () => {
-      await nuxt.callHook('components:dirs', options.dirs)
+      const allDirs = [
+        ...normalizeDirs(componentOptions.dirs, nuxt.options.srcDir),
+        ...nuxt.options.layers
+          .map(layer => normalizeDirs(layer.config.components, layer.cwd))
+          .flat()
+      ]
 
-      componentDirs = options.dirs.filter(isPureObjectOrString).map((dir) => {
+      await nuxt.callHook('components:dirs', allDirs)
+
+      componentDirs = allDirs.filter(isPureObjectOrString).map((dir) => {
         const dirOptions: ComponentsDir = typeof dir === 'object' ? dir : { path: dir }
         const dirPath = resolveAlias(dirOptions.path, nuxt.options.alias)
         const transpile = typeof dirOptions.transpile === 'boolean' ? dirOptions.transpile : 'auto'
@@ -34,7 +62,7 @@ export default defineNuxtModule<ComponentsOptions>({
         dirOptions.level = Number(dirOptions.level || 0)
 
         const present = isDirectory(dirPath)
-        if (!present && dirOptions.path !== '~/components') {
+        if (!present && basename(dirOptions.path) !== 'components') {
           // eslint-disable-next-line no-console
           console.warn('Components directory not found: `' + dirPath + '`')
         }

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -46,7 +46,7 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('app:resolve', async () => {
       const allDirs = [
         ...normalizeDirs(componentOptions.dirs, nuxt.options.srcDir),
-        ...nuxt.options.layers
+        ...nuxt.options._extends
           .map(layer => normalizeDirs(layer.config.components, layer.cwd))
           .flat()
       ]

--- a/packages/nuxt3/test/scan-components.test.ts
+++ b/packages/nuxt3/test/scan-components.test.ts
@@ -9,7 +9,6 @@ const rFixture = (...p) => resolve(fixtureDir, ...p)
 const dirs: ComponentsDir[] = [
   {
     path: rFixture('components'),
-    level: 0,
     enabled: true,
     extensions: [
       'vue'
@@ -24,7 +23,6 @@ const dirs: ComponentsDir[] = [
   },
   {
     path: rFixture('components'),
-    level: 0,
     enabled: true,
     extensions: [
       'vue'
@@ -43,7 +41,6 @@ const dirs: ComponentsDir[] = [
       'vue'
     ],
     prefix: 'nuxt',
-    level: 0,
     enabled: true,
     pattern: '**/*.{vue,}',
     ignore: [
@@ -63,7 +60,6 @@ const expectedComponents = [
     shortPath: 'components/HelloWorld.vue',
     export: 'default',
     global: undefined,
-    level: 0,
     prefetch: false,
     preload: false
   },
@@ -74,7 +70,6 @@ const expectedComponents = [
     shortPath: 'components/Nuxt3.vue',
     export: 'default',
     global: undefined,
-    level: 0,
     prefetch: false,
     preload: false
   },
@@ -85,7 +80,6 @@ const expectedComponents = [
     shortPath: 'components/parent-folder/index.vue',
     export: 'default',
     global: undefined,
-    level: 0,
     prefetch: false,
     preload: false
   }

--- a/packages/schema/src/config/_adhoc.ts
+++ b/packages/schema/src/config/_adhoc.ts
@@ -12,16 +12,11 @@ export default {
    */
   components: {
     $resolve: (val, get) => {
-      if (!val) {
-        // Nuxt 2 and Nuxt 3 have different default values when this option is not set,
-        // so we defer to the module's own defaults here.
-        return undefined
+      if (Array.isArray(val)) {
+        return { dirs: val }
       }
       if (val === undefined || val === true) {
         return { dirs: ['~/components'] }
-      }
-      if (Array.isArray(val)) {
-        return { dirs: val }
       }
       return val
     }

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -46,6 +46,7 @@ export interface ScanDir {
   enabled?: boolean
   /**
    * Level is used to define a hint when overwriting the components which have the same name in two different directories.
+   * @deprecated Not used by Nuxt 3 anymore
    */
   level?: number
   /**

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -5,11 +5,12 @@ export interface Component {
   filePath: string
   shortPath: string
   chunkName: string
-  level: number
   prefetch: boolean
   preload: boolean
   global?: boolean
 
+  /** @deprecated */
+  level?: number
   /** @deprecated */
   import?: string
   /** @deprecated */

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,6 +1,7 @@
 import { defineNuxtConfig } from 'nuxt3'
 
 export default defineNuxtConfig({
+  extends: './base',
   modules: [
     '@nuxt/ui'
   ]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following up #3008 this PR allows extending `components/` directory for extended config layers

**Breaking change:** Components `level` property is no longer supported. It was a necessary workaround to support [nuxt-extend](https://www.npmjs.com/package/nuxt-extend) but now, layers naturally are ordered and user's config has highest priority.  

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

