### PR TITLE
refactor: rename `options.layers` to `options._extends`

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -37,8 +37,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 
   nuxtConfig._nuxtConfigFile = configFile
   nuxtConfig._nuxtConfigFiles = [configFile]
-
-  nuxtConfig.layers = layers
+  nuxtConfig._extends = layers
 
   // Resolve and apply defaults
   return applyDefaults(NuxtConfigSchema, nuxtConfig) as NuxtOptions

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,16 +1,15 @@
 import { ConfigSchema } from '../../schema/config'
 import type { ResolvedConfig } from 'c12'
 
-/** Normalized Nuxt options available as `nuxt.options.*` */
-export interface NuxtOptions extends ConfigSchema {
-  layers: ResolvedConfig<NuxtOptions>[]
-}
-
 type DeepPartial<T> = T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> | T[P] } : T
 
 /** User configuration in `nuxt.config` file */
 export interface NuxtConfig extends DeepPartial<ConfigSchema> { }
 
+/** Normalized Nuxt options available as `nuxt.options.*` */
+export interface NuxtOptions extends ConfigSchema {
+  _extends: ResolvedConfig<NuxtConfig>[]
+}
 
 export interface PublicRuntimeConfig extends Record<string, any> { }
 export interface PrivateRuntimeConfig extends PublicRuntimeConfig { }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following up https://github.com/nuxt/framework/pull/3008, this PR renames `layers` to `_extends` to make it consistent with `extends` key. Also fixing type which should be NuxtConfig rather than normalized NuxtOptions

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

