### PR TITLE
feat(kit)!: expose `resolvePath`

### DIFF
--- a/docs/content/3.docs/4.advanced/3.kit.md
+++ b/docs/content/3.docs/4.advanced/3.kit.md
@@ -111,8 +111,8 @@ console.log(getNuxtVersion())
 
 [source code](https://github.com/nuxt/framework/blob/main/packages/kit/src/resolve.ts)
 
-- `resolvePath (path, resolveOptions?)`
-- `tryResolvePath (path, resolveOptions?)`
+- `resolvePath (path)`
+- `resolveAlias (path)`
 
 ### Builder
 

--- a/docs/content/3.docs/4.advanced/3.kit.md
+++ b/docs/content/3.docs/4.advanced/3.kit.md
@@ -111,9 +111,9 @@ console.log(getNuxtVersion())
 
 [source code](https://github.com/nuxt/framework/blob/main/packages/kit/src/resolve.ts)
 
-- `resolvePath (path)`
-- `resolveAlias (path)`
-- `findPath (paths)`
+- `resolvePath (path, resolveOptions?)`
+- `resolveAlias (path, aliases?)`
+- `findPath (paths, resolveOptions?)`
 
 ### Builder
 

--- a/docs/content/3.docs/4.advanced/3.kit.md
+++ b/docs/content/3.docs/4.advanced/3.kit.md
@@ -113,6 +113,7 @@ console.log(getNuxtVersion())
 
 - `resolvePath (path)`
 - `resolveAlias (path)`
+- `findPath (paths)`
 
 ### Builder
 

--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -133,7 +133,7 @@ export function setupNitroBridge () {
     await nuxt.callHook('nitro:context', nitroDevContext)
 
     // Resolve middleware
-    const { middleware, legacyMiddleware } = resolveMiddleware(nuxt)
+    const { middleware, legacyMiddleware } = await resolveMiddleware(nuxt)
     if (nuxt.server) {
       nuxt.server.setLegacyMiddleware(legacyMiddleware)
     }

--- a/packages/kit/src/internal/cjs.ts
+++ b/packages/kit/src/internal/cjs.ts
@@ -97,7 +97,7 @@ export function resolveModule (id: string, opts: ResolveModuleOptions = {}) {
 }
 
 /** Try to resolve the path of a module, but don't emit an error if it can't be found. */
-export function tryResolveModule (path: string, opts: ResolveModuleOptions = {}) {
+export function tryResolveModule (path: string, opts: ResolveModuleOptions = {}): string | null {
   try {
     return resolveModule(path, opts)
   } catch (error) {
@@ -105,6 +105,7 @@ export function tryResolveModule (path: string, opts: ResolveModuleOptions = {})
       throw error
     }
   }
+  return null
 }
 
 /** Require a module and return it. */

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -18,7 +18,7 @@ export async function installModule (nuxtModule: string | NuxtModule, inlineOpti
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    const _src = resolveModule(resolveAlias(nuxtModule, nuxt.options.alias), { paths: nuxt.options.modulesDir })
+    const _src = resolveModule(resolveAlias(nuxtModule), { paths: nuxt.options.modulesDir })
     // TODO: also check with type: 'module' in closest `package.json`
     const isESM = _src.endsWith('.mjs')
     nuxtModule = isESM ? await importModule(_src) : requireModule(_src)

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -25,7 +25,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   path = normalize(path)
 
   // Fast return if the path exists
-  if (await existsSensitive(path)) {
+  if (existsSync(path)) {
     return path
   }
 
@@ -45,7 +45,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
 
   // Check if resolvedPath is a file
   let isDirectory = false
-  if (await existsSync(path)) {
+  if (existsSync(path)) {
     isDirectory = (await fsp.lstat(path)).isDirectory()
     if (!isDirectory) {
       return path

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -79,9 +79,9 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
 /**
  * Try to resolve first existing file in paths
  */
-export async function findPath (paths: string[]): Promise<string|null> {
+export async function findPath (paths: string[], opts?: ResolvePathOptions): Promise<string|null> {
   for (const path of paths) {
-    const rPath = await resolvePath(path)
+    const rPath = await resolvePath(path, opts)
     if (await existsSensitive(rPath)) {
       return rPath
     }
@@ -92,9 +92,10 @@ export async function findPath (paths: string[]): Promise<string|null> {
 /**
  * Resolve path aliases respecting Nuxt alias options
  */
-export function resolveAlias (path: string): string {
-  const nuxt = useNuxt()
-  const alias = nuxt.options.alias
+export function resolveAlias (path: string, alias?: Record<string, string>): string {
+  if (!alias) {
+    alias = useNuxt().options.alias
+  }
   for (const key in alias) {
     if (key === '@' && !path.startsWith('@/')) { continue } // Don't resolve @foo/bar
     if (path.startsWith(key)) {

--- a/packages/nitro/src/server/middleware.ts
+++ b/packages/nitro/src/server/middleware.ts
@@ -2,7 +2,7 @@ import { resolve, join, extname } from 'pathe'
 import { joinURL } from 'ufo'
 import { globby } from 'globby'
 import { watch } from 'chokidar'
-import { tryResolveModule, tryResolvePath } from '@nuxt/kit'
+import { resolvePath } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import type { Middleware } from 'h3'
 
@@ -68,7 +68,7 @@ export function scanMiddleware (serverDir: string, onChange?: (results: ServerMi
   return scan()
 }
 
-export function resolveMiddleware (nuxt: Nuxt) {
+export async function resolveMiddleware (nuxt: Nuxt) {
   const middleware: ServerMiddleware[] = []
   const legacyMiddleware: ServerMiddleware[] = []
 
@@ -83,11 +83,7 @@ export function resolveMiddleware (nuxt: Nuxt) {
       delete m.path
       middleware.push({
         ...m,
-        handle: tryResolvePath(handle, {
-          extensions: ['.ts', '.mjs', '.js', '.cjs'],
-          alias: nuxt.options.alias,
-          base: nuxt.options.srcDir
-        }) || tryResolveModule(handle, { paths: nuxt.options.modulesDir }),
+        handle: await resolvePath(handle),
         route
       })
     }

--- a/packages/nuxt3/src/auto-imports/module.ts
+++ b/packages/nuxt3/src/auto-imports/module.ts
@@ -112,7 +112,7 @@ function generateDts (ctx: AutoImportContext) {
   const resolved = {}
   const r = (id: string) => {
     if (resolved[id]) { return resolved[id] }
-    let path = resolveAlias(id, nuxt.options.alias)
+    let path = resolveAlias(id)
     if (isAbsolute(path)) {
       path = relative(join(nuxt.options.buildDir, 'types'), path)
     }

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -27,7 +27,7 @@ export default defineNuxtModule<ComponentsOptions>({
 
       componentDirs = options.dirs.filter(isPureObjectOrString).map((dir) => {
         const dirOptions: ComponentsDir = typeof dir === 'object' ? dir : { path: dir }
-        const dirPath = resolveAlias(dirOptions.path, nuxt.options.alias)
+        const dirPath = resolveAlias(dirOptions.path)
         const transpile = typeof dirOptions.transpile === 'boolean' ? dirOptions.transpile : 'auto'
         const extensions = (dirOptions.extensions || nuxt.options.extensions).map(e => e.replace(/^\./g, ''))
 

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -2,7 +2,7 @@ import { promises as fsp } from 'fs'
 import { dirname, resolve } from 'pathe'
 import defu from 'defu'
 import type { Nuxt, NuxtApp } from '@nuxt/schema'
-import { tryResolvePath, resolveFiles, normalizePlugin, normalizeTemplate, compileTemplate, templateUtils } from '@nuxt/kit'
+import { findPath, resolveFiles, normalizePlugin, normalizeTemplate, compileTemplate, templateUtils } from '@nuxt/kit'
 
 import * as defaultTemplates from './templates'
 
@@ -54,15 +54,9 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp) {
 }
 
 export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
-  const resolveOptions = {
-    base: nuxt.options.srcDir,
-    alias: nuxt.options.alias,
-    extensions: nuxt.options.extensions
-  }
-
   // Resolve main (app.vue)
   if (!app.mainComponent) {
-    app.mainComponent = tryResolvePath('~/App', resolveOptions) || tryResolvePath('~/app', resolveOptions)
+    app.mainComponent = await findPath(['~/App', '~/app'])
   }
   if (!app.mainComponent) {
     app.mainComponent = resolve(nuxt.options.appDir, 'components/nuxt-welcome.vue')

--- a/packages/nuxt3/src/core/nitro.ts
+++ b/packages/nuxt3/src/core/nitro.ts
@@ -59,7 +59,7 @@ export function initNitro (nuxt: Nuxt) {
     await nuxt.callHook('nitro:context', nitroDevContext)
 
     // Resolve middleware
-    const { middleware, legacyMiddleware } = resolveMiddleware(nuxt)
+    const { middleware, legacyMiddleware } = await resolveMiddleware(nuxt)
     nuxt.server.setLegacyMiddleware(legacyMiddleware)
     nitroContext.middleware.push(...middleware)
     nitroDevContext.middleware.push(...middleware)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Merge `tryResolvePath` and expose as new `resolvePath` utility from `@nuxt/kit`:

- Use nuxt context for default options (`aliases`, `rootDir`, `extensions` and `modulesDir`
- Always return a Promise
- Return original input value (normalized) in case of resolve failing instead of throwing an error or returning `null`
- For performance, case sensitivity is no longer checked based on dir files

A new `findPath` utility was also introduced to search for paths (case sensitive). Internally used for finding `App.vue`.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

