### PR TITLE
feat(kit): `createResolver` utility

### DIFF
--- a/docs/content/3.docs/4.advanced/2.modules.md
+++ b/docs/content/3.docs/4.advanced/2.modules.md
@@ -177,12 +177,12 @@ Commonly, modules provide one or more run plugins to add runtime logic.
 ```ts
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { defineNuxtModule, addPlugin } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
 
 export default defineNuxtModule<ModuleOptions>({
   setup (options, nuxt) {
-    const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
-    addPlugin(resolve(runtimeDir, 'plugin'))
+    const resolver = createResolver(import.meta.url)
+    addPlugin(resolver.resolve('runtime/plugin'))
   }
 })
 ```

--- a/docs/content/3.docs/4.advanced/2.modules.md
+++ b/docs/content/3.docs/4.advanced/2.modules.md
@@ -175,8 +175,6 @@ If you have an already published and working module and want to transfer it to n
 Commonly, modules provide one or more run plugins to add runtime logic.
 
 ```ts
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
 import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
 
 export default defineNuxtModule<ModuleOptions>({

--- a/docs/content/3.docs/4.advanced/3.kit.md
+++ b/docs/content/3.docs/4.advanced/3.kit.md
@@ -114,6 +114,7 @@ console.log(getNuxtVersion())
 - `resolvePath (path, resolveOptions?)`
 - `resolveAlias (path, aliases?)`
 - `findPath (paths, resolveOptions?)`
+- `createResolver (base)`
 
 ### Builder
 

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -117,7 +117,7 @@ export interface Resolver {
  */
 export function createResolver (base: string | URL): Resolver {
   if (!base) {
-    base = useNuxt().options.rootDir
+    throw new Error('`base` argument is missing for createResolver(base)!')
   }
 
   base = base.toString()

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -1,4 +1,5 @@
 import { promises as fsp, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
 import { basename, dirname, resolve, join, normalize, isAbsolute } from 'pathe'
 import { globby } from 'globby'
 import { useNuxt } from './context'
@@ -22,18 +23,19 @@ export interface ResolvePathOptions {
  */
 export async function resolvePath (path: string, opts: ResolvePathOptions = {}): Promise<string> {
   // Always normalize input
+  const _path = path
   path = normalize(path)
 
   // Fast return if the path exists
-  if (existsSync(path)) {
+  if (isAbsolute(path) && existsSync(path)) {
     return path
   }
 
   // Use current nuxt options
   const nuxt = useNuxt()
-  const cwd = opts.cwd || nuxt.options.rootDir
-  const extensions = opts.extensions || nuxt.options.extensions
-  const modulesDir = nuxt.options.modulesDir
+  const cwd = opts.cwd || (nuxt ? nuxt.options.rootDir : process.cwd())
+  const extensions = opts.extensions || (nuxt ? nuxt.options.extensions : ['.ts', '.mjs', '.cjs', '.json'])
+  const modulesDir = nuxt ? nuxt.options.modulesDir : []
 
   // Resolve aliases
   path = resolveAlias(path)
@@ -67,7 +69,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   }
 
   // Try to resolve as module id
-  const resolveModulePath = tryResolveModule(path, { paths: modulesDir })
+  const resolveModulePath = tryResolveModule(_path, { paths: modulesDir })
   if (resolveModulePath) {
     return resolveModulePath
   }
@@ -94,7 +96,7 @@ export async function findPath (paths: string[], opts?: ResolvePathOptions): Pro
  */
 export function resolveAlias (path: string, alias?: Record<string, string>): string {
   if (!alias) {
-    alias = useNuxt().options.alias
+    alias = useNuxt()?.options.alias || {}
   }
   for (const key in alias) {
     if (key === '@' && !path.startsWith('@/')) { continue } // Don't resolve @foo/bar
@@ -103,6 +105,32 @@ export function resolveAlias (path: string, alias?: Record<string, string>): str
     }
   }
   return path
+}
+
+export interface Resolver {
+  readonly _base: string
+  resolve(...path): string
+  resolvePath(path: string, opts?: ResolvePathOptions): Promise<string>
+}
+
+/**
+ * Create a relative resolver
+ */
+export function createResolver (base: string | URL): Resolver {
+  if (!base) {
+    base = useNuxt().options.rootDir
+  }
+
+  base = base.toString()
+  if (base.startsWith('file://')) {
+    base = dirname(fileURLToPath(base))
+  }
+
+  return {
+    _base: base,
+    resolve: (...path) => resolve(base as string, ...path),
+    resolvePath: (path, opts) => resolvePath(path, { cwd: base as string, ...opts })
+  }
 }
 
 // --- Internal ---

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -108,7 +108,6 @@ export function resolveAlias (path: string, alias?: Record<string, string>): str
 }
 
 export interface Resolver {
-  readonly _base: string
   resolve(...path): string
   resolvePath(path: string, opts?: ResolvePathOptions): Promise<string>
 }
@@ -127,7 +126,6 @@ export function createResolver (base: string | URL): Resolver {
   }
 
   return {
-    _base: base,
     resolve: (...path) => resolve(base as string, ...path),
     resolvePath: (path, opts) => resolvePath(path, { cwd: base as string, ...opts })
   }

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -69,7 +69,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   }
 
   // Try to resolve as module id
-  const resolveModulePath = tryResolveModule(_path, { paths: modulesDir })
+  const resolveModulePath = tryResolveModule(_path, { paths: [cwd, ...modulesDir] })
   if (resolveModulePath) {
     return resolveModulePath
   }

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,5 @@
 import { defineNuxtConfig } from 'nuxt3'
-import { createResolver } from '@nuxt/kit'
 
-setTimeout(() => { createResolver(import.meta.url).resolvePath('ufo').then(console.log) }, 2000)
 export default defineNuxtConfig({
   extends: './base',
   modules: [

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,7 @@
 import { defineNuxtConfig } from 'nuxt3'
+import { createResolver } from '@nuxt/kit'
 
+setTimeout(() => { createResolver(import.meta.url).resolvePath('ufo').then(console.log) }, 2000)
 export default defineNuxtConfig({
   extends: './base',
   modules: [


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A new `createResolver` utility, makes life easier for module authors resolving relative paths.

Usage:

```js
const resolver = createResolver(import.meta.url)
addPlugin(resolver.resolve('runtime/plugin'))
console.log(await resolver.resolvePath('some-lib'))
```

This PR adds some fixes and improvements to `resovlePath` and `resolveAlias` to work when nuxt is not ready yet

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

