### PR TITLE
fix(nuxt3): remove lookbehind for safari support

### DIFF
--- a/packages/nuxt3/src/pages/runtime/utils.ts
+++ b/packages/nuxt3/src/pages/runtime/utils.ts
@@ -6,8 +6,8 @@ export type RouterViewSlotProps = Parameters<InstanceOf<typeof RouterView>['$slo
 
 const interpolatePath = (route: RouteLocationNormalizedLoaded, match: RouteLocationMatched) => {
   return match.path
-    .replace(/(?<=:\w+)\([^)]+\)/g, '')
-    .replace(/(?<=:\w+)[?+*]/g, '')
+    .replace(/(:\w+)\([^)]+\)/g, '$1')
+    .replace(/(:\w+)[?+*]/g, '$1')
     .replace(/:\w+/g, r => route.params[r.slice(1)]?.toString() || '')
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3113

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

O Safari, how my heart breaks. [source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility)

Thankfully the fix is relatively simple.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

