### PR TITLE
fix(vite): invalidate client modules too

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -72,15 +72,6 @@ export async function buildClient (ctx: ViteBuildContext) {
   }
   await ctx.nuxt.callHook('server:devMiddleware', viteMiddleware)
 
-  // Invalidate virtual modules when templates are re-generated
-  ctx.nuxt.hook('app:templatesGenerated', () => {
-    for (const [id, mod] of viteServer.moduleGraph.idToModuleMap) {
-      if (id.startsWith('\x00virtual:')) {
-        viteServer.moduleGraph.invalidateModule(mod)
-      }
-    }
-  })
-
   ctx.nuxt.hook('close', async () => {
     await viteServer.close()
   })

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -72,6 +72,15 @@ export async function buildClient (ctx: ViteBuildContext) {
   }
   await ctx.nuxt.callHook('server:devMiddleware', viteMiddleware)
 
+  // Invalidate virtual modules when templates are re-generated
+  ctx.nuxt.hook('app:templatesGenerated', () => {
+    for (const [id, mod] of viteServer.moduleGraph.idToModuleMap) {
+      if (id.startsWith('\x00virtual:')) {
+        viteServer.moduleGraph.invalidateModule(mod)
+      }
+    }
+  })
+
   ctx.nuxt.hook('close', async () => {
     await viteServer.close()
   })

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -131,15 +131,7 @@ export async function buildServer (ctx: ViteBuildContext) {
 
   // Start development server
   const viteServer = await vite.createServer(serverConfig)
-
-  // Invalidate virtual modules when templates are re-generated
-  ctx.nuxt.hook('app:templatesGenerated', () => {
-    for (const [id, mod] of viteServer.moduleGraph.idToModuleMap) {
-      if (id.startsWith('\x00virtual:')) {
-        viteServer.moduleGraph.invalidateModule(mod)
-      }
-    }
-  })
+  await ctx.nuxt.callHook('vite:serverCreated', viteServer)
 
   // Close server on exit
   ctx.nuxt.hook('close', () => viteServer.close())

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -104,6 +104,15 @@ export async function bundle (nuxt: Nuxt) {
   await nuxt.callHook('vite:extend', ctx)
 
   nuxt.hook('vite:serverCreated', (server: vite.ViteDevServer) => {
+    // Invalidate virtual modules when templates are re-generated
+    ctx.nuxt.hook('app:templatesGenerated', () => {
+      for (const [id, mod] of server.moduleGraph.idToModuleMap) {
+        if (id.startsWith('\x00virtual:')) {
+          server.moduleGraph.invalidateModule(mod)
+        }
+      }
+    })
+
     const start = Date.now()
     warmupViteServer(server, ['/entry.mjs']).then(() => {
       consola.info(`Vite warmed up in ${Date.now() - start}ms`)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2942

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Seems that the invalidation needs to happen in both server & client servers. I've also tentatively decided to warm them both up too - but please let me know if this is unnecessary for some reason.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

