### PR TITLE
fix(bridge): respect `--fail-on-error` in generation

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -216,15 +216,13 @@ function createNuxt2DevServer (nitroContext: NitroContext) {
     if (!listener) {
       throw new Error('There is no server listener to call `server.renderRoute()`')
     }
-    const r = await fetch(joinURL(listener.url, route), {
+    const res = await fetch(joinURL(listener.url, route), {
       headers: { 'nuxt-render-context': stringifyQuery(renderContext) }
     })
 
-    const html = await r.text()
+    const html = await res.text()
 
-    if (r.status === 500) {
-      return { html, error: r.statusText }
-    }
+    if (!res.ok) { return { html, error: res.statusText } }
 
     return { html }
   }

--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -1,7 +1,7 @@
 import { promises as fsp } from 'fs'
 import fetch from 'node-fetch'
 import { addPluginTemplate, useNuxt } from '@nuxt/kit'
-import { stringifyQuery } from 'ufo'
+import { joinURL, stringifyQuery } from 'ufo'
 import { resolve } from 'pathe'
 import { build, generate, prepare, getNitroContext, NitroContext, createDevServer, wpfs, resolveMiddleware, scanMiddleware, writeTypes } from '@nuxt/nitro'
 import { AsyncLoadingPlugin } from './async-loading'
@@ -216,9 +216,15 @@ function createNuxt2DevServer (nitroContext: NitroContext) {
     if (!listener) {
       throw new Error('There is no server listener to call `server.renderRoute()`')
     }
-    const html = await fetch(listener.url + route, {
+    const r = await fetch(joinURL(listener.url, route), {
       headers: { 'nuxt-render-context': stringifyQuery(renderContext) }
-    }).then(r => r.text())
+    })
+
+    const html = await r.text()
+
+    if (r.status === 500) {
+      return { html, error: r.statusText }
+    }
 
     return { html }
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1968

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We weren't passing on any errors when generating pages with Nitro.

This PR (minimally) returns error text, which allows nuxt 2 to respect the `--fail-on-error` flag.

We could _additionally_ always fail on error, which feels safer, and would just be a matter of adding two lines of code here: https://github.com/nuxt/framework/blob/00dea14b4287276caf36c4ca27abe7c6c7ada4a0/packages/bridge/src/nitro.ts#L195-L198

Thoughts welcome.

(**Note**: I also swapped joinURL as the URL being fetched had a double slash.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

