### PR TITLE
fix(nitro): handle incoming cookies on lambda payload format 2.0

### DIFF
--- a/packages/nitro/src/runtime/entries/lambda.ts
+++ b/packages/nitro/src/runtime/entries/lambda.ts
@@ -1,12 +1,16 @@
-import type { APIGatewayProxyEvent, APIGatewayProxyEventHeaders, APIGatewayProxyEventV2, Context } from 'aws-lambda'
+import type { APIGatewayProxyEvent, APIGatewayProxyEventHeaders, APIGatewayProxyEventV2, APIGatewayProxyResult, APIGatewayProxyResultV2, Context } from 'aws-lambda'
 import '#polyfill'
 import { withQuery } from 'ufo'
 import type { HeadersObject } from 'unenv/runtime/_internal/types'
 import { localCall } from '../server'
 
-export const handler = async function handler (event: APIGatewayProxyEvent & APIGatewayProxyEventV2, context: Context) {
-  const url = withQuery(event.path || event.rawPath, event.queryStringParameters)
-  const method = event.httpMethod || event.requestContext?.http?.method || 'get'
+export const handler = async function handler (event: APIGatewayProxyEvent | APIGatewayProxyEventV2, context: Context): Promise<APIGatewayProxyResult | APIGatewayProxyResultV2> {
+  const url = withQuery((event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath, event.queryStringParameters)
+  const method = (event as APIGatewayProxyEvent).httpMethod || (event as APIGatewayProxyEventV2).requestContext?.http?.method || 'get'
+
+  if ('cookies' in event) {
+    event.headers.cookie = event.cookies.join(',')
+  }
 
   const r = await localCall({
     event,
@@ -26,7 +30,7 @@ export const handler = async function handler (event: APIGatewayProxyEvent & API
 }
 
 function normalizeIncomingHeaders (headers: APIGatewayProxyEventHeaders) {
-  return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value as string]))
+  return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]))
 }
 
 function normalizeOutgoingHeaders (headers: HeadersObject) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

[AWS Payload 2.0 passes cookies in an array on event](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) rather than within headers. This PR adds them to the headers object.

In addition, I've attempted a type refactor. I've left the runtime code intact, but by annotating with `as` it should help future readers of the code see how the properties related to the payload version, and it means we also will get a compile error if we access a property that exists in one format but not the other unless we specifically annotate that access.
