### PR TITLE
docs(schema): clarify aliases and use more obvious example path

### DIFF
--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -9,7 +9,7 @@ export default defineBuildConfig({
       name: 'config',
       builder: 'untyped',
       defaults: {
-        rootDir: '/path/to/your/app/'
+        rootDir: '/<rootDir>/'
       }
     },
     'src/index'

--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -9,7 +9,7 @@ export default defineBuildConfig({
       name: 'config',
       builder: 'untyped',
       defaults: {
-        rootDir: '/project/'
+        rootDir: '/path/to/your/app/'
       }
     },
     'src/index'

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -506,6 +506,8 @@ export default {
    * @note Within a webpack context (image sources, CSS - but not JavaScript) you _must_ access
    * your alias by prefixing it with `~`.
    *
+   * @note These aliases will be automatically added to the generated `.nuxt/tsconfig.json` .
+   *
    * @example
    * ```js
    * import { resolve } from 'pathe'

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -506,9 +506,6 @@ export default {
    * @note Within a webpack context (image sources, CSS - but not JavaScript) you _must_ access
    * your alias by prefixing it with `~`.
    *
-   * @note If you are using TypeScript and want to use the alias you define within
-   * your TypeScript files, you will need to add the aliases to your `paths` object within `tsconfig.json` .
-   *
    * @example
    * ```js
    * import { resolve } from 'pathe'

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -506,7 +506,9 @@ export default {
    * @note Within a webpack context (image sources, CSS - but not JavaScript) you _must_ access
    * your alias by prefixing it with `~`.
    *
-   * @note These aliases will be automatically added to the generated `.nuxt/tsconfig.json` .
+   * @note These aliases will be automatically added to the generated `.nuxt/tsconfig.json` so you can get full
+   * type support and path auto-complete. In case you need to extend options provided by `./.nuxt/tsconfig.json`
+   * further, make sure to add them here or within the `typescript.tsConfig` property in `nuxt.config`.
    *
    * @example
    * ```js


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3138

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`/project` has led to one or two issues with people thinking it's a shortcut to the project path, as also has `<rootDir>` in the nuxtjs.org docs. I think `/path/to/your/app` (or something similar) might help.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

