### PR TITLE
feat(nitro): add http.server timeout configuration

### DIFF
--- a/packages/nitro/src/runtime/entries/server.ts
+++ b/packages/nitro/src/runtime/entries/server.ts
@@ -13,6 +13,16 @@ const server = cert && key ? new HttpsServer({ key, cert }, handle) : new HttpSe
 const port = (destr(process.env.NUXT_PORT || process.env.PORT) || 3000) as number
 const hostname = process.env.NUXT_HOST || process.env.HOST || 'localhost'
 
+if (process.env.NITRO_TIMEOUT) {
+  server.timeout = destr(process.env.NITRO_TIMEOUT) as number
+}
+if (process.env.NITRO_KEEP_ALIVE_TIMEOUT) {
+  server.keepAliveTimeout = destr(process.env.NITRO_KEEP_ALIVE_TIMEOUT) as number
+}
+if (process.env.NITRO_HEADERS_TIMEOUT) {
+  server.headersTimeout = destr(process.env.NITRO_HEADERS_TIMEOUT) as number
+}
+
 // @ts-ignore
 server.listen(port, hostname, (err) => {
   if (err) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
Related https://github.com/nuxt/framework/issues/2499

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I added `NITRO_TIMEOUT`, `NITRO_KEEP_ALIVE_TIMEOUT` and `NITRO_HEADERS_TIMEOUT` to set `http.server`'s timeout, keepAliveTimeout and headersTimeout.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

