### PR TITLE
fix(vite): assign different hmr port for each instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "eslint": "^8.8.0",
     "eslint-plugin-jsdoc": "^37.8.2",
     "execa": "^6.0.0",
-    "get-port-please": "^2.3.0",
     "globby": "^13.1.1",
     "jiti": "^1.12.15",
     "lerna": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^8.8.0",
     "eslint-plugin-jsdoc": "^37.8.2",
     "execa": "^6.0.0",
+    "get-port-please": "^2.3.0",
     "globby": "^13.1.1",
     "jiti": "^1.12.15",
     "lerna": "^4.0.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -29,6 +29,7 @@
     "escape-string-regexp": "^5.0.0",
     "externality": "^0.1.6",
     "fs-extra": "^10.0.0",
+    "get-port-please": "^2.3.0",
     "knitwork": "^0.1.0",
     "magic-string": "^0.25.7",
     "mlly": "^0.4.2",

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -6,6 +6,7 @@ import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { Connect } from 'vite'
 
 import { joinURL } from 'ufo'
+import { getPort } from 'get-port-please'
 import { cacheDirPlugin } from './plugins/cache-dir'
 import { analyzePlugin } from './plugins/analyze'
 import { wpfs } from './utils/wpfs'
@@ -15,6 +16,13 @@ import { devStyleSSRPlugin } from './plugins/dev-ssr-css'
 import { DynamicBasePlugin, RelativeAssetPlugin } from './plugins/dynamic-base'
 
 export async function buildClient (ctx: ViteBuildContext) {
+  // TODO: After nitropack refactor, try if we can resuse the same server port as Nuxt
+  const hmrPortDefault = 24678 // Vite's default HMR port
+  const hmrPort = await getPort({
+    port: hmrPortDefault,
+    ports: Array.from({ length: 20 }, (_, i) => hmrPortDefault + 1 + i)
+  })
+
   const clientConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
     define: {
       'process.server': false,
@@ -48,7 +56,11 @@ export async function buildClient (ctx: ViteBuildContext) {
       })
     ],
     server: {
-      middlewareMode: true
+      middlewareMode: true,
+      hmr: {
+        port: hmrPort,
+        clientPort: hmrPort
+      }
     }
   } as ViteOptions)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11231,6 +11231,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-port-please@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "get-port-please@npm:2.3.0"
+  dependencies:
+    fs-memo: ^1.2.0
+  checksum: ae361940392d44a3157f9256e366ea4f979202d7c52a7d323eebc0cbe24e32b1b196405be0b06af1d898db0f6d36b859479489f849e7ee698aefa9db1110c292
+  languageName: node
+  linkType: hard
+
 "get-port@npm:^5.1.1":
   version: 5.1.1
   resolution: "get-port@npm:5.1.1"
@@ -15069,6 +15078,7 @@ __metadata:
     eslint: ^8.8.0
     eslint-plugin-jsdoc: ^37.8.2
     execa: ^6.0.0
+    get-port-please: ^2.3.0
     globby: ^13.1.1
     jiti: ^1.12.15
     lerna: ^4.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,6 +3263,7 @@ __metadata:
     escape-string-regexp: ^5.0.0
     externality: ^0.1.6
     fs-extra: ^10.0.0
+    get-port-please: ^2.3.0
     knitwork: ^0.1.0
     magic-string: ^0.25.7
     mlly: ^0.4.2
@@ -15078,7 +15079,6 @@ __metadata:
     eslint: ^8.8.0
     eslint-plugin-jsdoc: ^37.8.2
     execa: ^6.0.0
-    get-port-please: ^2.3.0
     globby: ^13.1.1
     jiti: ^1.12.15
     lerna: ^4.0.0


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Fix #3006, Fix partially #1036
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

*Thanks a lot for @danielroe's help!*

The root cause of HMR breakage is because in middleware mode of Vite, the HMR port is fixed to 24678. Which means when you have multiple Vite/Nuxt instances running, it causes the later server to connect to the wrong Websocket instance, making the HMR fail to trigger. This PR makes the port dynamic with the currently available ports.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

