### PR TITLE
docs: fix typo in prepare command

### DIFF
--- a/docs/content/3.docs/4.advanced/2.modules.md
+++ b/docs/content/3.docs/4.advanced/2.modules.md
@@ -21,7 +21,7 @@ Starter template and module starter is a standard path of creating a Nuxt module
 
 - Open `my-module` in IDE of your choice (VSCode is recommended)
 - Install dependencies using the package manager of your choice (Yarn is recommended)
-- Ensure local files are generated using `npm run prepare`
+- Ensure local files are generated using `npm run dev:prepare`
 - Start playground using `npm run dev`
 - **Follow this document to learn more about Nuxt modules**
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There was a typo in de docs, instead of running `npm run prepare` you need to run `npm run dev:prepare`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

