### PR TITLE
fix(nuxt3): re-enable tree-shaking `definePageMeta`

### DIFF
--- a/packages/nuxt3/src/pages/macros.ts
+++ b/packages/nuxt3/src/pages/macros.ts
@@ -13,7 +13,7 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
     enforce: 'post',
     transformInclude (id) {
       const { search, pathname } = parseURL(id)
-      return pathname.endsWith('.vue') || parseQuery(search).macro
+      return pathname.endsWith('.vue') || !!parseQuery(search).macro
     },
     transform (code, id) {
       const originalCode = code

--- a/packages/nuxt3/src/pages/macros.ts
+++ b/packages/nuxt3/src/pages/macros.ts
@@ -16,6 +16,7 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
       return pathname.endsWith('.vue') || parseQuery(search).macro
     },
     transform (code, id) {
+      const originalCode = code
       const { search } = parseURL(id)
 
       // Tree-shake out any runtime references to the macro.
@@ -27,7 +28,9 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
         }
       }
 
-      if (!parseQuery(search).macro) { return }
+      if (!parseQuery(search).macro) {
+        return originalCode === code ? undefined : code
+      }
 
       // [webpack] Re-export any imports from script blocks in the components
       // with workaround for vue-loader bug: https://github.com/vuejs/vue-loader/pull/1911
@@ -65,14 +68,6 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
   }
 })
 
-const starts = {
-  '{': '}',
-  '[': ']',
-  '(': ')',
-  '<': '>',
-  '"': '"',
-  "'": "'"
-}
 
 function extractObject (code: string) {
   // Strip comments

--- a/packages/nuxt3/src/pages/macros.ts
+++ b/packages/nuxt3/src/pages/macros.ts
@@ -68,6 +68,14 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
   }
 })
 
+const starts = {
+  '{': '}',
+  '[': ']',
+  '(': ')',
+  '<': '>',
+  '"': '"',
+  "'": "'"
+}
 
 function extractObject (code: string) {
   // Strip comments

--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -25,7 +25,7 @@ declare module 'vue-router' {
 const warnRuntimeUsage = (method: string) =>
   console.warn(
     `${method}() is a compiler-hint helper that is only usable inside ` +
-      '<script setup> of a single file component. Its arguments should be ' +
+      'the script block of a single file component. Its arguments should be ' +
       'compiled away and passing it at runtime has no effect.'
   )
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3175

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This follows up on #3150 - I missed the fact that when we early return, we've potentially also changed code. This is also the cause of the new warning people are receiving about using `definePageMeta` outside of setup.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

