### PR TITLE
Adding callWithNuxtAsync to allow the use of async/await inside middleware

### DIFF
--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -191,6 +191,22 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp, 
 }
 
 /**
+ * Async version of callWithNuxt
+ *
+ * @param nuxt A Nuxt instance
+ * @param setup The function to call
+ */
+export async function callWithNuxtAsync<T extends (...args: any[]) => any> (nuxt: NuxtApp, setup: T, args?: Parameters<T>) {
+  setNuxtAppInstance(nuxt)
+  const p: ReturnType<T> =  args ? await setup(...args as Parameters<T>) : await setup()
+  if (process.server) {
+    // Unset nuxt instance to prevent context-sharing in server-side
+    setNuxtAppInstance(null)
+  }
+  return p
+}
+
+/**
  * Returns the current Nuxt instance.
  */
 export function useNuxtApp (): NuxtApp {

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -8,7 +8,7 @@ import {
 } from 'vue-router'
 import NuxtPage from './page'
 import NuxtLayout from './layout'
-import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { callWithNuxtAsync, defineNuxtPlugin, useRuntimeConfig } from '#app'
 // @ts-ignore
 import routes from '#build/routes'
 // @ts-ignore
@@ -92,7 +92,7 @@ export default defineNuxtPlugin((nuxtApp) => {
         console.warn(`Unknown middleware: ${entry}. Valid options are ${Object.keys(namedMiddleware).join(', ')}.`)
       }
 
-      const result = await callWithNuxt(nuxtApp, middleware, [to, from])
+      const result = await callWithNuxtAsync(nuxtApp, middleware, [to, from])
       if (result || result === false) { return result }
     }
   })


### PR DESCRIPTION
### 🔗 Linked issue

#3105 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adding an async version of callWithNuxt to allow middleware to be async too.
The current issue is when the middleware return a promise (async/await), the nuxt instance is set to null, because the call stack is splitted, and as there are no await on the function inside the callWithNuxt, it leads to the issue linked.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

