### PR TITLE
feat(bridge): support `addRouteMiddleware`, `navigateTo` and `abortNavigation`

### DIFF
--- a/packages/bridge/src/auto-imports.ts
+++ b/packages/bridge/src/auto-imports.ts
@@ -33,6 +33,7 @@ export async function setupAutoImports () {
     autoImports.push({ name: 'addRouteMiddleware', as: 'addRouteMiddleware', from: '#app' })
     autoImports.push({ name: 'navigateTo', as: 'navigateTo', from: '#app' })
     autoImports.push({ name: 'abortNavigation', as: 'abortNavigation', from: '#app' })
+    autoImports.push({ name: 'defineNuxtRouteMiddleware', as: 'defineNuxtRouteMiddleware', from: '#app' })
 
     // Add bridge-only auto-imports
     autoImports.push({ name: 'useNuxt2Meta', as: 'useNuxt2Meta', from: '#app' })

--- a/packages/bridge/src/auto-imports.ts
+++ b/packages/bridge/src/auto-imports.ts
@@ -30,6 +30,9 @@ export async function setupAutoImports () {
     // Add auto-imports that are added by ad-hoc modules in nuxt 3
     autoImports.push({ name: 'useRouter', as: 'useRouter', from: '#app' })
     autoImports.push({ name: 'useRoute', as: 'useRoute', from: '#app' })
+    autoImports.push({ name: 'addRouteMiddleware', as: 'addRouteMiddleware', from: '#app' })
+    autoImports.push({ name: 'navigateTo', as: 'navigateTo', from: '#app' })
+    autoImports.push({ name: 'abortNavigation', as: 'abortNavigation', from: '#app' })
 
     // Add bridge-only auto-imports
     autoImports.push({ name: 'useNuxt2Meta', as: 'useNuxt2Meta', from: '#app' })

--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { createHooks } from 'hookable'
-import { setNuxtAppInstance } from '#app'
+import { callWithNuxt, setNuxtAppInstance } from '#app'
 
 // Reshape payload to match key `useLazyAsyncData` expects
 function proxiedState (state) {
@@ -19,7 +19,7 @@ function proxiedState (state) {
   })
 }
 
-export default (ctx, inject) => {
+export default async (ctx, inject) => {
   const nuxtApp = {
     vueApp: {
       component: Vue.component.bind(Vue),
@@ -47,6 +47,27 @@ export default (ctx, inject) => {
   nuxtApp.hooks = createHooks()
   nuxtApp.hook = nuxtApp.hooks.hook
   nuxtApp.callHook = nuxtApp.hooks.callHook
+
+  const middleware = await import('#build/middleware')
+  nuxtApp._middleware = nuxtApp._middleware || {
+    global: [],
+    named: middleware
+  }
+
+  ctx.app.router.beforeEach(async (to, from, next) => {
+    nuxtApp._processingMiddleware = true
+
+    for (const middleware of nuxtApp._middleware.global) {
+      const result = await callWithNuxt(nuxtApp, middleware, [to, from])
+      if (result || result === false) { return next(result) }
+    }
+
+    next()
+  })
+
+  ctx.app.router.afterEach(() => {
+    delete nuxtApp._processingMiddleware
+  })
 
   if (!Array.isArray(ctx.app.created)) {
     ctx.app.created = [ctx.app.created].filter(Boolean)

--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -48,7 +48,7 @@ export default async (ctx, inject) => {
   nuxtApp.hook = nuxtApp.hooks.hook
   nuxtApp.callHook = nuxtApp.hooks.callHook
 
-  const middleware = await import('#build/middleware')
+  const middleware = await import('#build/middleware').then(r => r.default)
   nuxtApp._middleware = nuxtApp._middleware || {
     global: [],
     named: middleware

--- a/packages/bridge/src/runtime/composables.ts
+++ b/packages/bridge/src/runtime/composables.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, onBeforeUnmount, isRef, watch, reactive, toRef, isR
 import type { CombinedVueInstance } from 'vue/types/vue'
 import type { MetaInfo } from 'vue-meta'
 import type VueRouter from 'vue-router'
-import type { Route } from 'vue-router'
+import type { Location, Route } from 'vue-router'
 import type { RuntimeConfig } from '@nuxt/schema'
 import { useNuxtApp } from './app'
 
@@ -180,3 +180,11 @@ export const abortNavigation = (err?: Error | string) => {
   }
   return false
 }
+
+type RouteMiddlewareReturn = void | Error | string | Location | boolean
+
+export interface RouteMiddleware {
+  (to: Route, from: Route): RouteMiddlewareReturn | Promise<RouteMiddlewareReturn>
+}
+
+export const defineNuxtRouteMiddleware = (middleware: RouteMiddleware) => middleware

--- a/packages/nuxt3/src/pages/runtime/composables.ts
+++ b/packages/nuxt3/src/pages/runtime/composables.ts
@@ -60,7 +60,10 @@ const isProcessingMiddleware = () => {
     if (useNuxtApp()._processingMiddleware) {
       return true
     }
-  } catch {}
+  } catch {
+    // Within an async middleware
+    return true
+  }
   return false
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This aligns route middleware in Bridge with Nuxt 3, to make it easier for modules which are providing both Bridge + Nuxt 3 support.

It also resolves https://github.com/nuxt/framework/issues/3158, by assuming if we have no nuxt instance we are being called in an async middleware.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

