### PR TITLE
fix(nuxt3): return error page on blocked initial navigation

### DIFF
--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -105,7 +105,12 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (process.server) {
       router.push(nuxtApp.ssrContext.url)
 
-      router.afterEach((to) => {
+      router.afterEach((to, from, failure) => {
+        if (failure) {
+          // TODO: https://github.com/nuxt/framework/discussions/559
+          nuxtApp.ssrContext.res.statusCode = 401
+          nuxtApp.ssrContext.res.end()
+        }
         if (to.fullPath !== nuxtApp.ssrContext.url) {
           nuxtApp.ssrContext.res.setHeader('Location', to.fullPath)
         }

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -127,10 +127,10 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       const is404 = router.currentRoute.value.matched.length === 0
       if (process.server && is404) {
-        const error = new Error(`Page not found: ${nuxtApp.ssrContext.url}`)
-        // @ts-ignore
-        error.statusCode = 404
-        nuxtApp.ssrContext.error = error
+        throw createError({
+          statusCode: 404,
+          statusMessage: `Page not found: ${nuxtApp.ssrContext.url}`
+        })
       }
     } catch (error) {
       nuxtApp.ssrContext.error = error

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -6,6 +6,7 @@ import {
   RouterLink,
   NavigationGuard
 } from 'vue-router'
+import { createError } from 'h3'
 import NuxtPage from './page'
 import NuxtLayout from './layout'
 import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig } from '#app'
@@ -95,7 +96,11 @@ export default defineNuxtPlugin((nuxtApp) => {
       const result = await callWithNuxt(nuxtApp, middleware, [to, from])
       if (process.server) {
         if (result === false || result instanceof Error) {
-          throw result || new Error(`Route navigation aborted: ${nuxtApp.ssrContext.url}`)
+          const error = result || createError({
+            statusMessage: `Route navigation aborted: ${nuxtApp.ssrContext.url}`
+          })
+          nuxtApp.ssrContext.error = error
+          throw error
         }
       }
       if (result || result === false) { return result }
@@ -128,7 +133,6 @@ export default defineNuxtPlugin((nuxtApp) => {
         nuxtApp.ssrContext.error = error
       }
     } catch (error) {
-      error.statusCode = error.statusCode || 500
       nuxtApp.ssrContext.error = error
     }
   })

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -107,7 +107,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       router.afterEach((to, from, failure) => {
         if (failure) {
-          // TODO: https://github.com/nuxt/framework/discussions/559
           nuxtApp.ssrContext.res.statusCode = 401
           nuxtApp.ssrContext.res.end()
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3186

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a hotfix for #3186, pending reworking with result of https://github.com/nuxt/framework/discussions/559. It returns an (empty) 401 response.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

