### PR TITLE
fix(nuxt3): prevent removing and re-adding tags before mount

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -77,5 +77,11 @@ export default (ctx, inject) => {
 
   setNuxtAppInstance(proxiedApp)
 
+  if (process.client) {
+    window.onNuxtReady(() => {
+      nuxtApp.hooks.callHook('app:mounted', nuxtApp.vueApp)
+    })
+  }
+
   inject('_nuxtApp', proxiedApp)
 }

--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -1,5 +1,5 @@
 import { createHead, renderHeadToString } from '@vueuse/head'
-import { ref, watchEffect, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { ref, watchEffect, onBeforeUnmount, getCurrentInstance, nextTick } from 'vue'
 import type { MetaObject } from '..'
 import { defineNuxtPlugin } from '#app'
 
@@ -14,9 +14,11 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     if (process.server) { return }
 
-    watchEffect(() => {
-      head.updateDOM()
-    })
+    nextTick(() =>
+      watchEffect(() => {
+        head.updateDOM()
+      })
+    )
 
     const vm = getCurrentInstance()
     if (!vm) { return }

--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -1,5 +1,5 @@
 import { createHead, renderHeadToString } from '@vueuse/head'
-import { ref, watchEffect, onBeforeUnmount, getCurrentInstance, nextTick } from 'vue'
+import { ref, watchEffect, onBeforeUnmount, getCurrentInstance } from 'vue'
 import type { MetaObject } from '..'
 import { defineNuxtPlugin } from '#app'
 
@@ -14,11 +14,15 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     if (process.server) { return }
 
-    nextTick(() =>
+    if (nuxtApp.isHydrating) {
+      nuxtApp.hook('app:mounted', () => watchEffect(() => {
+        head.updateDOM()
+      }))
+    } else {
       watchEffect(() => {
         head.updateDOM()
       })
-    )
+    }
 
     const vm = getCurrentInstance()
     if (!vm) { return }

--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -7,6 +7,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const head = createHead()
 
   nuxtApp.vueApp.use(head)
+  nuxtApp.hook('app:mounted', () => watchEffect(() => head.updateDOM()))
 
   nuxtApp._useMeta = (meta: MetaObject) => {
     const headObj = ref(meta as any)
@@ -14,22 +15,11 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     if (process.server) { return }
 
-    if (nuxtApp.isHydrating) {
-      nuxtApp.hook('app:mounted', () => watchEffect(() => {
-        head.updateDOM()
-      }))
-    } else {
-      watchEffect(() => {
-        head.updateDOM()
-      })
-    }
-
     const vm = getCurrentInstance()
     if (!vm) { return }
 
     onBeforeUnmount(() => {
       head.removeHeadObjs(headObj)
-      head.updateDOM()
     })
   }
 

--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -7,7 +7,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const head = createHead()
 
   nuxtApp.vueApp.use(head)
-  nuxtApp.hookOnce('app:mounted', () => { watchEffect(() => head.updateDOM()) })
+  nuxtApp.hooks.hookOnce('app:mounted', () => { watchEffect(() => head.updateDOM()) })
 
   nuxtApp._useMeta = (meta: MetaObject) => {
     const headObj = ref(meta as any)

--- a/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vueuse-head.plugin.ts
@@ -7,7 +7,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const head = createHead()
 
   nuxtApp.vueApp.use(head)
-  nuxtApp.hook('app:mounted', () => watchEffect(() => head.updateDOM()))
+  nuxtApp.hookOnce('app:mounted', () => { watchEffect(() => head.updateDOM()) })
 
   nuxtApp._useMeta = (meta: MetaObject) => {
     const headObj = ref(meta as any)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/pull/2419

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR follows up on https://github.com/nuxt/framework/issues/2337. The issue it solves occurs in the initial render cycle, if there are multiple `useMeta` tags for the same tag type, e.g.:

```js
useMeta({ script: /* ... */ })
useMeta({ script: /* ... */ })
```

In this case, immediately triggering `updateDOM` after the first call causes a mismatch because we haven't yet registered the second script tag yet, and so it's removed. It's then added back, triggering the rerun.

By deferring updateDOM to mounted on the initial render, we give Vue a chance to process all these tags.

As a side effect, we are also more performant because we only trigger a single update, rather than a different one for every different `useMeta` call and meta tag we insert.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

