### PR TITLE
fix(nuxt3): return render function for `<Head>`

### DIFF
--- a/packages/nuxt3/src/meta/runtime/components.ts
+++ b/packages/nuxt3/src/meta/runtime/components.ts
@@ -194,7 +194,7 @@ export const Style = defineComponent({
 // <head>
 export const Head = defineComponent({
   name: 'Head',
-  setup: (_props, ctx) => ctx.slots.default
+  setup: (_props, ctx) => () => ctx.slots.default?.()
 })
 
 // <html>

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <Head>
+      <Title>Basic fixture</Title>
+    </Head>
     <h1>Hello Vue 3</h1>
     <div>Config: {{ $config.testConfig }}</div>
   </div>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1909

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We need to return a render function; default slot isn't always an equivalent function at the time the parent setup is run.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

