### PR TITLE
docs: add note about proxying cookies back to client

### DIFF
--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -119,10 +119,9 @@ This composable behaves identically to `useFetch` with the `lazy: true` option s
 
 ## Isomorphic fetch
 
-When we call `fetch` in the browser, user headers like `cookie` will be directly sent to the API.
-But during server-side-rendering, since the `fetch` request is originating from the server, it doesn't include the user's browser cookies.
+When we call `fetch` in the browser, user headers like `cookie` will be directly sent to the API. But during server-side-rendering, since the `fetch` request takes place 'internally' within the server, it doesn't include the user's browser cookies, nor does it pass on cookies from the fetch response.
 
-We can use [`useRequestHeaders`](/docs/usage/ssr) to access and proxy cookies to the API from server-side.
+We can use [`useRequestHeaders`](/docs/usage/ssr) to access and proxy cookies to the API from server-side. (If you want to pass on/proxy cookies in the other direction, from an internal request back to the client, you will need to handle this yourself by accessing the raw response object, for example with `$fetch.raw`.)
 
 **Example:**
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/2479

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a note that it's possible to proxy cookies from local API calls back to the client on the initial render.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

