### PR TITLE
fix(nuxt3): update meta return type to `bodyScriptsPrepend`

### DIFF
--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -10,7 +10,7 @@ type NuxtMeta = {
   headAttrs?: string
   bodyAttrs?: string
   headTags?: string
-  bodyPrepend?: string
+  bodyScriptsPrepend?: string
   bodyScripts?: string
 }
 

--- a/packages/nuxt3/src/meta/runtime/lib/vue-meta.plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/lib/vue-meta.plugin.ts
@@ -30,7 +30,7 @@ export default defineNuxtPlugin((nuxtApp) => {
         headAttrs: nuxtApp.ssrContext.teleports.headAttrs || '',
         bodyAttrs: nuxtApp.ssrContext.teleports.bodyAttrs || '',
         headTags: nuxtApp.ssrContext.teleports.head || '',
-        bodyPrepend: nuxtApp.ssrContext.teleports['body-prepend'] || '',
+        bodyScriptsPrepend: nuxtApp.ssrContext.teleports['body-prepend'] || '',
         bodyScripts: nuxtApp.ssrContext.teleports.body || ''
       }
     }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We had an inconsistency in the codebase, although this didn't actually affect the code since it was to a _type_ and the (unused) `vue-meta` implementation:

https://github.com/nuxt/framework/blob/main/packages/nitro/src/runtime/app/render.ts#L133-L144

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

