### PR TITLE
fix(nuxt3)!: custom response type for `useFetch` using first generic

### DIFF
--- a/packages/nuxt3/src/app/composables/fetch.ts
+++ b/packages/nuxt3/src/app/composables/fetch.ts
@@ -13,13 +13,14 @@ export type UseFetchOptions<
 > = AsyncDataOptions<DataT, Transform, PickKeys> & FetchOptions & { key?: string }
 
 export function useFetch<
+  ResT = void,
   ReqT extends string = string,
-  ResT = FetchResult<ReqT>,
-  Transform extends (res: ResT) => any = (res: ResT) => ResT,
+  _ResT = ResT extends void ? FetchResult<ReqT> : ResT,
+  Transform extends (res: _ResT) => any = (res: _ResT) => _ResT,
   PickKeys extends KeyOfRes<Transform> = KeyOfRes<Transform>
 > (
   url: ReqT,
-  opts: UseFetchOptions<ResT, Transform, PickKeys> = {}
+  opts: UseFetchOptions<_ResT, Transform, PickKeys> = {}
 ) {
   if (!opts.key) {
     const keys: any = { u: url }
@@ -35,17 +36,18 @@ export function useFetch<
     opts.key = generateKey(keys)
   }
 
-  return useAsyncData(opts.key, () => $fetch(url, opts) as Promise<ResT>, opts)
+  return useAsyncData(opts.key, () => $fetch(url, opts) as Promise<_ResT>, opts)
 }
 
 export function useLazyFetch<
+  ResT = void,
   ReqT extends string = string,
-  ResT = FetchResult<ReqT>,
-  Transform extends (res: ResT) => any = (res: ResT) => ResT,
+  _ResT = ResT extends void ? FetchResult<ReqT> : ResT,
+  Transform extends (res: _ResT) => any = (res: _ResT) => _ResT,
   PickKeys extends KeyOfRes<Transform> = KeyOfRes<Transform>
 > (
   url: ReqT,
-  opts: Omit<UseFetchOptions<ResT, Transform, PickKeys>, 'lazy'> = {}
+  opts: Omit<UseFetchOptions<_ResT, Transform, PickKeys>, 'lazy'> = {}
 ) {
   return useFetch(url, { ...opts, lazy: true })
 }

--- a/test/fixtures/basic/tests/types.ts
+++ b/test/fixtures/basic/tests/types.ts
@@ -7,11 +7,13 @@ import { defineNuxtConfig } from '~~/../../../packages/nuxt3/src'
 import { useRouter } from '#imports'
 import { isVue3 } from '#app'
 
+interface TestResponse { message: string }
+
 describe('API routes', () => {
   it('generates types for routes', () => {
     expectTypeOf($fetch('/api/hello')).toMatchTypeOf<Promise<string>>()
     expectTypeOf($fetch('/api/hey')).toMatchTypeOf<Promise<{ foo:string, baz: string }>>()
-    expectTypeOf($fetch('/api/other')).toMatchTypeOf<Promise<unknown>>()
+    expectTypeOf($fetch<TestResponse>('/test')).toMatchTypeOf<Promise<TestResponse>>()
   })
 
   it('works with useFetch', () => {
@@ -19,10 +21,13 @@ describe('API routes', () => {
     expectTypeOf(useFetch('/api/hey').data).toMatchTypeOf<Ref<{ foo:string, baz: string }>>()
     expectTypeOf(useFetch('/api/hey', { pick: ['baz'] }).data).toMatchTypeOf<Ref<{ baz: string }>>()
     expectTypeOf(useFetch('/api/other').data).toMatchTypeOf<Ref<unknown>>()
+    expectTypeOf(useFetch<TestResponse>('/test').data).toMatchTypeOf<Ref<TestResponse>>()
     expectTypeOf(useLazyFetch('/api/hello').data).toMatchTypeOf<Ref<string>>()
     expectTypeOf(useLazyFetch('/api/hey').data).toMatchTypeOf<Ref<{ foo:string, baz: string }>>()
     expectTypeOf(useLazyFetch('/api/hey', { pick: ['baz'] }).data).toMatchTypeOf<Ref<{ baz: string }>>()
     expectTypeOf(useLazyFetch('/api/other').data).toMatchTypeOf<Ref<unknown>>()
+    expectTypeOf(useLazyFetch('/api/other').data).toMatchTypeOf<Ref<unknown>>()
+    expectTypeOf(useLazyFetch<TestResponse>('/test').data).toMatchTypeOf<Ref<TestResponse>>()
   })
 })
 

--- a/test/fixtures/basic/tests/types.ts
+++ b/test/fixtures/basic/tests/types.ts
@@ -13,6 +13,7 @@ describe('API routes', () => {
   it('generates types for routes', () => {
     expectTypeOf($fetch('/api/hello')).toMatchTypeOf<Promise<string>>()
     expectTypeOf($fetch('/api/hey')).toMatchTypeOf<Promise<{ foo:string, baz: string }>>()
+    expectTypeOf($fetch('/api/other')).toMatchTypeOf<Promise<unknown>>()
     expectTypeOf($fetch<TestResponse>('/test')).toMatchTypeOf<Promise<TestResponse>>()
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #3263

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow setting custom response type of useFetch using first generic param similar to `$fetch`

Breaking change! If you was already using `useFetch` or `useLazyFetch` with custom type, it needs to be updated:

```diff
--- useFetch<string, ResponseType>(....)
+++ useFetch<ResponseType>(....)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

