### PR TITLE
chore: reverse target/from in eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,9 @@
     "NodeJS": true,
     "$fetch": true
   },
-  "plugins": ["jsdoc"],
+  "plugins": [
+    "jsdoc"
+  ],
   "extends": [
     "plugin:jsdoc/recommended",
     "@nuxtjs/eslint-config-typescript",
@@ -17,30 +19,36 @@
     "jsdoc/require-param": "off",
     "jsdoc/require-returns": "off",
     "jsdoc/require-param-type": "off",
-    "import/no-restricted-paths": ["error", {
-      "zones": [
-        {
-          "target": "packages/nuxt3/src/!(core)/**/*",
-          "from": "packages/nuxt3/src/core",
-          "message": "core should not directly import from modules."
-        },
-        {
-          "target": "packages/nuxt3/src/!(app)/**/*",
-          "from": "packages/nuxt3/src/app",
-          "message": "app should not directly import from modules."
-        },
-        {
-          "target": "packages/nitro",
-          "from": "packages/!(nitro)/**/*",
-          "message": "nitro should not directly import other packages."
-        }
-      ]
-    }],
-    "@typescript-eslint/no-unused-vars": ["error", {
-      "argsIgnorePattern": "^_",
-      "varsIgnorePattern": "^_",
-      "ignoreRestSiblings": true
-    }]
+    "import/no-restricted-paths": [
+      "error",
+      {
+        "zones": [
+          {
+            "from": "packages/nuxt3/src/!(core)/**/*",
+            "target": "packages/nuxt3/src/core",
+            "message": "core should not directly import from modules."
+          },
+          {
+            "from": "packages/nuxt3/src/!(app)/**/*",
+            "target": "packages/nuxt3/src/app",
+            "message": "app should not directly import from modules."
+          },
+          {
+            "from": "packages/nitro",
+            "target": "packages/!(nitro)/**/*",
+            "message": "nitro should not directly import other packages."
+          }
+        ]
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ]
   },
   "settings": {
     "jsdoc": {

--- a/packages/nuxt3/src/core/nuxt.ts
+++ b/packages/nuxt3/src/core/nuxt.ts
@@ -2,10 +2,13 @@ import { resolve } from 'pathe'
 import { createHooks } from 'hookable'
 import type { Nuxt, NuxtOptions, NuxtConfig, ModuleContainer, NuxtHooks } from '@nuxt/schema'
 import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, addVitePlugin, addWebpackPlugin } from '@nuxt/kit'
+// Temporary until finding better placement
+/* eslint-disable import/no-restricted-paths */
 import pagesModule from '../pages/module'
 import metaModule from '../meta/module'
 import componentsModule from '../components/module'
 import autoImportsModule from '../auto-imports/module'
+/* eslint-enable */
 import { distDir, pkgDir } from '../dirs'
 import { version } from '../../package.json'
 import { ImportProtectionPlugin, vueAppPatterns } from './plugins/import-protection'


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹 Chore

### 📚 Description

I think our internal lint rule was enforcing the opposite of what we meant to though I may have misunderstood the intent. But we are, I think, violating it here:

https://github.com/nuxt/framework/blob/aece3518b541663c1731160e42e26e6ac7c79ce8/packages/nuxt3/src/core/nuxt.ts#L5-L8

This PR is an initial stab meant to highlight the issue - we either need to:

1. amend lint error description to reflect what it's meant to do
2. rethink import approach in core/nuxt.ts
3. remove lint rules

cc: @clarkdo 