### PR TITLE
fix(config): add analyze plugin options in bridge mode

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -2,7 +2,7 @@ import { promises as fsp } from 'fs'
 import fetch from 'node-fetch'
 import { addPluginTemplate, useNuxt } from '@nuxt/kit'
 import { joinURL, stringifyQuery } from 'ufo'
-import { resolve } from 'pathe'
+import { resolve, join } from 'pathe'
 import { build, generate, prepare, getNitroContext, NitroContext, createDevServer, wpfs, resolveMiddleware, scanMiddleware, writeTypes } from '@nuxt/nitro'
 import { AsyncLoadingPlugin } from './async-loading'
 import { distDir } from './dirs'
@@ -28,6 +28,15 @@ export function setupNitroBridge () {
   nuxt.options.build.loadingScreen = false
   // @ts-ignore
   nuxt.options.build.indicator = false
+
+  if (nuxt.options.build.analyze === true) {
+    const { rootDir } = nuxt.options
+    nuxt.options.build.analyze = {
+      template: 'treemap',
+      projectRoot: rootDir,
+      filename: join(rootDir, '.nuxt/stats', '{name}.html')
+    }
+  }
 
   // Create contexts
   const nitroOptions = (nuxt.options as any).nitro || {}

--- a/packages/nuxi/src/commands/analyze.ts
+++ b/packages/nuxi/src/commands/analyze.ts
@@ -1,7 +1,6 @@
 import { promises as fsp } from 'fs'
 import { join, resolve } from 'pathe'
 import { createApp, lazyHandle } from 'h3'
-import type { PluginVisualizerOptions } from 'rollup-plugin-visualizer'
 import { createServer } from '../utils/server'
 import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
@@ -22,18 +21,11 @@ export default defineNuxtCommand({
 
     const { loadNuxt, buildNuxt } = await loadKit(rootDir)
 
-    const analyzeOptions: PluginVisualizerOptions = {
-      template: 'treemap',
-      projectRoot: rootDir,
-      filename: join(statsDir, '{name}.html')
-    }
-
     const nuxt = await loadNuxt({
       rootDir,
       config: {
         build: {
-          // @ts-ignore
-          analyze: analyzeOptions
+          analyze: true
         }
       }
     })

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -29,7 +29,7 @@ export default {
   analyze: {
     $resolve: (val, get) => {
       if(val !== true) {
-        return val
+        return val ?? false
       }
       const rootDir = get('rootDir')
       return {

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -1,3 +1,4 @@
+import { join } from 'pathe'
 import { isCI, isTest } from 'std-env'
 import { normalizeURL, withTrailingSlash } from 'ufo'
 
@@ -25,7 +26,19 @@ export default {
    * ```
    * @type {boolean | typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options | typeof import('rollup-plugin-visualizer').PluginVisualizerOptions}
    */
-  analyze: false,
+  analyze: {
+    $resolve: (val, get) => {
+      if(val !== true) {
+        return val
+      }
+      const rootDir = get('rootDir')
+      return {
+        template: 'treemap',
+        projectRoot: rootDir,
+        filename: join(rootDir, '.nuxt/stats', '{name}.html')
+      }
+    }
+  },
 
   /**
    * Enable the profiler in webpackbar.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
(https://github.com/nuxt/framework/issues/3216)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When running `nuxi analyze` on bridge mode, we'll see error `Cannot read property 'replace' of undefined` which is because the analyze options is `true` instead of default options object.

This pr is fixing this issue by adding default analyze options in bridge mode

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

