### PR TITLE
perf!(nuxt3): disable global components by default

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -29,10 +29,11 @@ export default defineNuxtModule<ComponentsOptions>({
         return dir.map(dir => normalizeDirs(dir, cwd)).flat().sort(compareDirByPathLength)
       }
       if (dir === true || dir === undefined) {
-        return [{ path: resolve(cwd, 'components') }]
+        return [{ global: componentOptions.global, path: resolve(cwd, 'components') }]
       }
       if (typeof dir === 'string') {
         return {
+          global: componentOptions.global,
           path: resolve(cwd, resolveAlias(dir, {
             ...nuxt.options.alias,
             '~': cwd

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -29,11 +29,10 @@ export default defineNuxtModule<ComponentsOptions>({
         return dir.map(dir => normalizeDirs(dir, cwd)).flat().sort(compareDirByPathLength)
       }
       if (dir === true || dir === undefined) {
-        return [{ global: componentOptions.global, path: resolve(cwd, 'components') }]
+        return [{ path: resolve(cwd, 'components') }]
       }
       if (typeof dir === 'string') {
         return {
-          global: componentOptions.global,
           path: resolve(cwd, resolveAlias(dir, {
             ...nuxt.options.alias,
             '~': cwd
@@ -69,6 +68,7 @@ export default defineNuxtModule<ComponentsOptions>({
         }
 
         return {
+          global: componentOptions.global,
           ...dirOptions,
           // TODO: https://github.com/nuxt/framework/pull/251
           enabled: true,

--- a/packages/nuxt3/src/components/templates.ts
+++ b/packages/nuxt3/src/components/templates.ts
@@ -28,7 +28,7 @@ export const componentsTemplate = {
   getContents ({ options }: { options: ComponentsTemplateOptions }) {
     return `import { defineAsyncComponent } from 'vue'
 
-const components = ${genObjectFromRawEntries(options.components.filter(c => c.global !== false).map((c) => {
+const components = ${genObjectFromRawEntries(options.components.filter(c => c.global === true).map((c) => {
   const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
   const comment = createImportMagicComments(c)
 

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -92,5 +92,16 @@ export interface ComponentsDir extends ScanDir {
 
 export interface ComponentsOptions {
   dirs: (string | ComponentsDir)[]
+  /**
+   * The default value for whether to globally register components.
+   *
+   * When components are registered globally, they will still be directly imported where used,
+   * but they can also be used dynamically, for example `<component :is="`icon-${myIcon}`">`.
+   *
+   * This can be overridden by an individual component directory entry.
+   *
+   * @default false
+   */
+  global?: boolean
   loader?: boolean
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/2237

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change defaults to only using the loader to register components, rather than generating async chunks for every possible component. (This makes a huge difference with component libraries, as we don't need to compile all of their components, just the ones needed.)

This also adds a top-level `components.global` option to set the default value for component dirs which haven't set the global value.

### 👉 Migration

If you were relying on global registration of your components - for example, because you wanted to use a dynamically computed component name (e.g. `<component :is="'icon-' + myIcon" />`) then you can re-enable the previous behaviour by setting `components.global`:

```diff
  import { defineNuxtConfig } from 'nuxt3'
  
  export default defineNuxtConfig({
    components: {
+     global: true
    },
  })
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

