### PR TITLE
fix(nuxt3): only warn about error handlers on client-side

### DIFF
--- a/packages/nuxt3/src/app/plugins/router.ts
+++ b/packages/nuxt3/src/app/plugins/router.ts
@@ -103,7 +103,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
 
   const route: Route = reactive(getRouteFromPath(process.client ? window.location.href : nuxtApp.ssrContext.url))
   async function handleNavigation (url: string, replace?: boolean): Promise<void> {
-    if (process.dev && !hooks.error.length) {
+    if (process.dev && process.client && !hooks.error.length) {
       console.warn('No error handlers registered to handle middleware errors. You can register an error handler with `router.onError()`')
     }
     try {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The warning is only appropriate when navigating, but every time we load a page we navigate on SSR, so best to defer the warning to client-side.