### PR TITLE
fix(nuxt3): respect dirs as objects

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule<ComponentsOptions>({
     configKey: 'components'
   },
   defaults: {
-    dirs: ['~/components']
+    dirs: []
   },
   setup (componentOptions, nuxt) {
     let componentDirs = []

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -39,6 +39,15 @@ export default defineNuxtModule<ComponentsOptions>({
           }))
         }
       }
+      if (dir && typeof dir === 'object') {
+        return {
+          ...dir,
+          path: resolve(cwd, resolveAlias(dir.path, {
+            ...nuxt.options.alias,
+            '~': cwd
+          }))
+        }
+      }
       return []
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/2748

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Recently component dirs passed as objects were no longer respected (https://github.com/nuxt/framework/pull/3108). This PR adds a test for object dir syntax.

In addition, because we always added `~/components` to the dirs list, customisations of this root directory were lost. By dropping it from the module options, we _still_ get this added by default (by schema) when the user does not provide input, but allows the user to override or configure this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

