### PR TITLE
fix(nuxt3): don't add superfluous templates

### DIFF
--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -22,7 +22,7 @@ export default defineNuxtModule<ComponentsOptions>({
   },
   setup (componentOptions, nuxt) {
     let componentDirs = []
-    let components: Component[] = []
+    const components: Component[] = []
 
     const normalizeDirs = (dir: any, cwd: string) => {
       if (Array.isArray(dir)) {
@@ -90,21 +90,23 @@ export default defineNuxtModule<ComponentsOptions>({
       nuxt.options.build!.transpile!.push(...componentDirs.filter(dir => dir.transpile).map(dir => dir.path))
     })
 
+    const options = { components, buildDir: nuxt.options.buildDir }
+
     addTemplate({
       ...componentsTypeTemplate,
-      options: { components, buildDir: nuxt.options.buildDir }
+      options
     })
 
     addTemplate({
       ...componentsTemplate,
-      options: { components }
+      options
     })
 
     addPlugin({ src: '#build/components' })
 
     // Scan components and add to plugin
     nuxt.hook('app:templates', async () => {
-      components = await scanComponents(componentDirs, nuxt.options.srcDir!)
+      options.components = await scanComponents(componentDirs, nuxt.options.srcDir!)
       await nuxt.callHook('components:extend', components)
       await nuxt.callHook('builder:generateApp')
     })


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When renaming a page the following error would be thrown. The cause was that every time the components scan function was running, it was adding another (duplicate) template to the list.

```bash
 WARN  [SSR] Error transforming virtual:/framework/playground/.nuxt/plugins/server.mjs: Parse failure: Identifier 'components_515c5644' has already been declared (9:7)
Contents of line 9: import components_515c5644 from "/@id/__x00__virtual:/framework/playground/.nuxt/components.mjs";

  Contents of line 9: import components_515c5644 from "/@id/__x00__virtual:playground/.nuxt/components.mjs";
  at ssrTransform (packages/vite/node_modules/vite/dist/node/chunks/dep-971d9e33.js:52119:15)
  at doTransform (packages/vite/node_modules/vite/dist/node/chunks/dep-971d9e33.js:53036:48)
  at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

This PR moves the templates out of the scanning function.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

