### PR TITLE
fix(nuxi): don't clear screen on `nuxi dev --help`

### DIFF
--- a/packages/nuxi/src/index.ts
+++ b/packages/nuxi/src/index.ts
@@ -16,7 +16,7 @@ async function _main () {
   // @ts-ignore
   const command = args._.shift() || 'usage'
 
-  showBanner(command === 'dev' && args.clear !== false)
+  showBanner(command === 'dev' && args.clear !== false && !args.help)
 
   if (!(command in commands)) {
     console.log('\n' + red('Invalid command ' + command))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2281

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the event that the user is running `nuxi dev --help` we clear the screen. This is probably an exception to our desired default clearing behaviour.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

