### PR TITLE
fix(nuxt3): only warn within error handling routine

### DIFF
--- a/packages/nuxt3/src/app/plugins/router.ts
+++ b/packages/nuxt3/src/app/plugins/router.ts
@@ -103,9 +103,6 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
 
   const route: Route = reactive(getRouteFromPath(process.client ? window.location.href : nuxtApp.ssrContext.url))
   async function handleNavigation (url: string, replace?: boolean): Promise<void> {
-    if (process.dev && process.client && !hooks.error.length) {
-      console.warn('No error handlers registered to handle middleware errors. You can register an error handler with `router.onError()`')
-    }
     try {
       // Resolve route
       const to = getRouteFromPath(url)
@@ -131,6 +128,9 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
         await middleware(to, route)
       }
     } catch (err) {
+      if (process.dev && !hooks.error.length) {
+        console.warn('No error handlers registered to handle middleware errors. You can register an error handler with `router.onError()`', err)
+      }
       for (const handler of hooks.error) {
         await handler(err)
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

follow-up on #3345

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We will move warning out of the nav handler entirely, and only warn + show error in event of error.