### PR TITLE
docs: remove `await` in front of `useQuery` in example

### DIFF
--- a/docs/content/3.docs/2.directory-structure/13.server.md
+++ b/docs/content/3.docs/2.directory-structure/13.server.md
@@ -55,7 +55,7 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 import { useBody, useCookies, useQuery } from 'h3'
 
 export default async (req, res) => {
-  const query = await useQuery(req)
+  const query = useQuery(req)
   const body = await useBody(req) // only for POST request
   const cookies = useCookies(req)
   


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
#3406 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves #3406 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

