### PR TITLE
feat(nuxi): add jsx option to generated tsconfig

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -10,6 +10,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
 
   const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
     compilerOptions: {
+      jsx: 'preserve',
       target: 'ESNext',
       module: 'ESNext',
       moduleResolution: 'Node',


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This purely improves DX for users. Without it we get this when trying to use `.tsx`:

<img width="704" alt="CleanShot 2022-02-28 at 22 29 25@2x" src="https://user-images.githubusercontent.com/28706372/156069185-f399adca-ccf0-49a9-a71e-7b532e6fef32.png">

[**tsconfig docs**](https://www.typescriptlang.org/tsconfig#jsx).
