### PR TITLE
feat(nuxt3): extends support for plugins/ directory

### DIFF
--- a/examples/config-extends/app.vue
+++ b/examples/config-extends/app.vue
@@ -8,6 +8,7 @@ const themeConfig = useRuntimeConfig().theme
     <pre>{{ JSON.stringify(themeConfig, null, 2) }}</pre>
     <BaseButton>Base Button</BaseButton>
     <FancyButton>Fancy Button</FancyButton>
+    {{ $myPlugin() }}
   </NuxtExampleLayout>
 </template>
 

--- a/examples/config-extends/base/plugins/my-plugin.ts
+++ b/examples/config-extends/base/plugins/my-plugin.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin((/* nuxtApp */) => {
+  return {
+    provide: {
+      myPlugin: () => 'String generated from my auto-imported plugin!'
+    }
+  }
+})

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -37,6 +37,13 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 
   nuxtConfig._nuxtConfigFile = configFile
   nuxtConfig._nuxtConfigFiles = [configFile]
+
+  // Resolve `rootDir` & `srcDir` of layers
+  for (const layer of layers) {
+    layer.config.rootDir = layer.config.rootDir ?? layer.cwd
+    layer.config.srcDir = resolve(layer.config.rootDir, layer.config.srcDir)
+  }
+
   nuxtConfig._extends = layers
 
   // Resolve and apply defaults

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -1,7 +1,7 @@
 import { promises as fsp } from 'fs'
 import { dirname, resolve } from 'pathe'
 import defu from 'defu'
-import type { Nuxt, NuxtApp } from '@nuxt/schema'
+import type { Nuxt, NuxtApp, NuxtPlugin } from '@nuxt/schema'
 import { findPath, resolveFiles, normalizePlugin, normalizeTemplate, compileTemplate, templateUtils } from '@nuxt/kit'
 
 import * as defaultTemplates from './templates'
@@ -66,13 +66,17 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   app.rootComponent = resolve(nuxt.options.appDir, 'components/nuxt-root.vue')
 
   // Resolve plugins
-  app.plugins = [
-    ...nuxt.options.plugins,
-    ...await resolveFiles(nuxt.options.srcDir, [
-      'plugins/*.{ts,js,mjs,cjs,mts,cts}',
-      'plugins/*/index.*{ts,js,mjs,cjs,mts,cts}'
-    ])
-  ].map(plugin => normalizePlugin(plugin))
+  for (const config of [...nuxt.options._extends.map(layer => layer.config), nuxt.options]) {
+    app.plugins.push(...[
+      // TODO: config.plugins paths for layers should be resolved with layer aliases
+      // TODO: Ex: plugins: ['~/some/path/to/plugin.js'] in layer config should correctly be resolved
+      ...config.plugins ?? [],
+      ...await resolveFiles(config.srcDir, [
+        'plugins/*.{ts,js,mjs,cjs,mts,cts}',
+        'plugins/*/index.*{ts,js,mjs,cjs,mts,cts}'
+      ])
+    ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
+  }
 
   // Extend app
   await nuxt.callHook('app:resolve', app)

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -68,8 +68,6 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // Resolve plugins
   for (const config of [...nuxt.options._extends.map(layer => layer.config), nuxt.options]) {
     app.plugins.push(...[
-      // TODO: config.plugins paths for layers should be resolved with layer aliases
-      // TODO: Ex: plugins: ['~/some/path/to/plugin.js'] in layer config should correctly be resolved
       ...config.plugins ?? [],
       ...await resolveFiles(config.srcDir, [
         'plugins/*.{ts,js,mjs,cjs,mts,cts}',


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following up #3222 (`extends` support progress) this PR allows extending `plugins/` directory for extended config layers

### TO DO
- [ ] Merge https://github.com/nuxt/framework/pull/3423 beforehand so we get the `srcDir` thing for layers
- [x] Extends support for `plugins` directory
- [ ] Extends support for `plugins` config key in layers => Need to resolve aliases
