### PR TITLE
feat!(nuxt3): allow modules to manage autoImports on `generateApp`

### DIFF
--- a/packages/nuxt3/src/auto-imports/composables.ts
+++ b/packages/nuxt3/src/auto-imports/composables.ts
@@ -6,39 +6,45 @@ import { AutoImport } from '@nuxt/schema'
 import { resolveFiles } from '@nuxt/kit'
 import { filterInPlace } from './utils'
 
-export async function scanForComposables (dir: string, autoImports: AutoImport[]) {
-  if (!existsSync(dir)) { return }
+export async function scanForComposables (dir: string | string[], autoImports: AutoImport[]) {
+  const performScan = async (entry: string) => {
+    const files = await resolveFiles(entry, [
+      '*.{ts,js,mjs,cjs,mts,cts}',
+      '*/index.{ts,js,mjs,cjs,mts,cts}'
+    ])
 
-  const files = await resolveFiles(dir, [
-    '*.{ts,js,mjs,cjs,mts,cts}',
-    '*/index.{ts,js,mjs,cjs,mts,cts}'
-  ])
+    await Promise.all(
+      files.map(async (path) => {
+        // Remove original entries from the same import (for build watcher)
+        filterInPlace(autoImports, i => i.from !== path)
 
-  await Promise.all(
-    files.map(async (path) => {
-      // Remove original entries from the same import (for build watcher)
-      filterInPlace(autoImports, i => i.from !== path)
+        const code = await fsp.readFile(path, 'utf-8')
+        const exports = findExports(code)
+        const defaultExport = exports.find(i => i.type === 'default')
 
-      const code = await fsp.readFile(path, 'utf-8')
-      const exports = findExports(code)
-      const defaultExport = exports.find(i => i.type === 'default')
-
-      if (defaultExport) {
-        let name = parsePath(path).name
-        if (name === 'index') {
-          name = parsePath(path.split('/').slice(0, -1).join('/')).name
-        }
-        autoImports.push({ name: 'default', as: camelCase(name), from: path })
-      }
-      for (const exp of exports) {
-        if (exp.type === 'named') {
-          for (const name of exp.names) {
-            autoImports.push({ name, as: name, from: path })
+        if (defaultExport) {
+          let name = parsePath(path).name
+          if (name === 'index') {
+            name = parsePath(path.split('/').slice(0, -1).join('/')).name
           }
-        } else if (exp.type === 'declaration') {
-          autoImports.push({ name: exp.name, as: exp.name, from: path })
+          autoImports.push({ name: 'default', as: camelCase(name), from: path })
         }
-      }
-    })
-  )
+        for (const exp of exports) {
+          if (exp.type === 'named') {
+            for (const name of exp.names) {
+              autoImports.push({ name, as: name, from: path })
+            }
+          } else if (exp.type === 'declaration') {
+            autoImports.push({ name: exp.name, as: exp.name, from: path })
+          }
+        }
+      })
+    )
+  }
+
+  for (const entry of Array.isArray(dir) ? dir : [dir]) {
+    if (!existsSync(entry)) { continue }
+
+    await performScan(entry)
+  }
 }

--- a/packages/nuxt3/src/auto-imports/module.ts
+++ b/packages/nuxt3/src/auto-imports/module.ts
@@ -72,9 +72,7 @@ export default defineNuxtModule<AutoImportsOptions>({
           : { name: importName.name, as: importName.as || importName.name, from: source.from }
       ))
       // Scan composables/
-      for (const composablesDir of composablesDirs) {
-        await scanForComposables(composablesDir, ctx.autoImports)
-      }
+      await scanForComposables(composablesDirs, ctx.autoImports)
       // Allow modules extending
       await nuxt.callHook('autoImports:extend', ctx.autoImports)
       // Update context
@@ -96,9 +94,12 @@ export default defineNuxtModule<AutoImportsOptions>({
     nuxt.hook('builder:watch', async (_, path) => {
       const _resolved = resolve(nuxt.options.srcDir, path)
       if (composablesDirs.find(dir => _resolved.startsWith(dir))) {
-        await regenerateAutoImports()
         await nuxt.callHook('builder:generateApp')
       }
+    })
+
+    nuxt.hook('builder:generateApp', async () => {
+      await regenerateAutoImports()
     })
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
I've modified the `autoImport` module to update the autoImport context when the `builder:generateApp` hook is called. 
<!-- Why is this change required? What problem does it solve? -->
This change allows modules that provide their own autoImports to manage them ( add / remove as needed ) when the `builder:generateApp` hook is triggered.

```ts
// current drawback: only called on initial run in current nuxt3 versions
nuxt.hook('autoImports:extend', (autoimports) => {
  console.log('autoImports:extend')

  // manage autoImports
})

nuxt.hook('builder:watch', async (_event, path) => {
  if (!path.endsWith('.special')) return

  // run logic needed when important files are modified
  await nuxt.callHook('builder:generateApp')
})
```

Current nuxt3 implementation requires the dev server to be restarted for any changes to autoImports to take effect, because the `autoImports:extend` hook is never recalled after it's initial load.

This PR allows for much better DX and is particularly useful when a module needs to watch certain files within a project then generate code based on those files to be used in the app. 

The video below shows a working example from a [Nuxt 3 GraphQL module](https://github.com/Diizzayy/nuxt-gql) that I'm currently developing ( this is the last feature needed for launch )

> Amazing DX

https://user-images.githubusercontent.com/19627670/156457824-7c3b6e97-c0b5-4d56-a722-45d2d0ad9365.mov 

There may be a better way of achieving this outcome? @danielroe @pi0 

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

