### PR TITLE
fix(bridge): use vue server build

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -22,15 +22,17 @@ export function setupAppBridge (_options: any) {
   }
 
   // Resolve vue2 builds
-  nuxt.options.alias.vue2 = resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
+  const vue2ESM = resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
+  const vue2CJS = resolveModule('vue/dist/vue.runtime.common.js', { paths: nuxt.options.modulesDir })
+  nuxt.options.alias.vue2 = vue2ESM
   nuxt.options.build.transpile.push('vue')
-  extendWebpackConfig((config) => {
-    (config.resolve.alias as any).vue2 = resolveModule('vue/dist/vue.runtime.common.js', { paths: nuxt.options.modulesDir })
-  }, { client: false })
 
+  extendWebpackConfig((config) => {
+    (config.resolve.alias as any).vue2 = vue2CJS
+  }, { client: false })
   nuxt.hook('vite:extendConfig', (config, { isServer }) => {
     if (isServer && !nuxt.options.dev) {
-      (config.resolve.alias as any).vue2 = resolveModule('vue/dist/vue.runtime.common.js', { paths: nuxt.options.modulesDir })
+      (config.resolve.alias as any).vue2 = vue2CJS
     }
   })
 

--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -1,4 +1,4 @@
-import { useNuxt, resolveModule, addTemplate, resolveAlias } from '@nuxt/kit'
+import { useNuxt, resolveModule, addTemplate, resolveAlias, extendWebpackConfig, extendViteConfig } from '@nuxt/kit'
 import { NuxtModule } from '@nuxt/schema'
 import { resolve } from 'pathe'
 import { componentsTypeTemplate } from '../../nuxt3/src/components/templates'
@@ -24,6 +24,15 @@ export function setupAppBridge (_options: any) {
   // Resolve vue2 builds
   nuxt.options.alias.vue2 = resolveModule('vue/dist/vue.runtime.esm.js', { paths: nuxt.options.modulesDir })
   nuxt.options.build.transpile.push('vue')
+  extendWebpackConfig((config) => {
+    (config.resolve.alias as any).vue2 = resolveModule('vue/dist/vue.runtime.common.js', { paths: nuxt.options.modulesDir })
+  }, { client: false })
+
+  nuxt.hook('vite:extendConfig', (config, { isServer }) => {
+    if (isServer && !nuxt.options.dev) {
+      (config.resolve.alias as any).vue2 = resolveModule('vue/dist/vue.runtime.common.js', { paths: nuxt.options.modulesDir })
+    }
+  })
 
   // Disable legacy fetch polyfills
   nuxt.options.fetch.server = false

--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -1,4 +1,4 @@
-import { useNuxt, resolveModule, addTemplate, resolveAlias, extendWebpackConfig, extendViteConfig } from '@nuxt/kit'
+import { useNuxt, resolveModule, addTemplate, resolveAlias, extendWebpackConfig } from '@nuxt/kit'
 import { NuxtModule } from '@nuxt/schema'
 import { resolve } from 'pathe'
 import { componentsTypeTemplate } from '../../nuxt3/src/components/templates'

--- a/packages/nitro/src/rollup/config.ts
+++ b/packages/nitro/src/rollup/config.ts
@@ -165,7 +165,9 @@ export const getRollupConfig = (nitroContext: NitroContext) => {
       'process.env.NUXT_FULL_STATIC': nitroContext._nuxt.fullStatic as unknown as string,
       'process.env.NITRO_PRESET': JSON.stringify(nitroContext.preset),
       'process.env.RUNTIME_CONFIG': devalue(nitroContext._nuxt.runtimeConfig),
-      'process.env.DEBUG': JSON.stringify(nitroContext._nuxt.dev)
+      'process.env.DEBUG': JSON.stringify(nitroContext._nuxt.dev),
+      // Needed for vue 2 server build
+      'commonjsGlobal.process.env.VUE_ENV': '"server"'
     }
   }))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3431, resolves https://github.com/nuxt/framework/issues/3329

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were always using the Vue ESM build, which caused memory leaks in production. This PR re-aliases the Vue CJS build in the server build, as well as ensures that `$isServer` is correctly set.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

