### PR TITLE
fix(schema): allow untyped keys in nuxt config

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -4,7 +4,9 @@ import type { ResolvedConfig } from 'c12'
 type DeepPartial<T> = T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> | T[P] } : T
 
 /** User configuration in `nuxt.config` file */
-export interface NuxtConfig extends DeepPartial<ConfigSchema> { }
+export interface NuxtConfig extends DeepPartial<ConfigSchema> {
+  [key: string]: any
+}
 
 /** Normalized Nuxt options available as `nuxt.options.*` */
 export interface NuxtOptions extends ConfigSchema {

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -75,7 +75,6 @@ describe('modules', () => {
     defineNuxtConfig({ sampleModule: { enabled: false } })
     // @ts-expect-error
     defineNuxtConfig({ sampleModule: { other: false } })
-    // @ts-expect-error
     defineNuxtConfig({ undeclaredKey: { other: false } })
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #3478

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows untyped keys in `nuxt.config`. (Marking a signature as `@deprecated` has no effect.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

