### PR TITLE
fix(bridge): port nested `_nuxt` dir fix to bridge vite

### DIFF
--- a/packages/bridge/src/vite/utils/fs.ts
+++ b/packages/bridge/src/vite/utils/fs.ts
@@ -1,0 +1,18 @@
+import { promises as fsp, readdirSync, statSync } from 'fs'
+import { join } from 'pathe'
+
+export function readDirRecursively (dir: string) {
+  return readdirSync(dir).reduce((files, file) => {
+    const name = join(dir, file)
+    const isDirectory = statSync(name).isDirectory()
+    return isDirectory ? [...files, ...readDirRecursively(name)] : [...files, name]
+  }, [])
+}
+
+export async function isDirectory (path: string) {
+  try {
+    return (await fsp.stat(path)).isDirectory()
+  } catch (_err) {
+    return false
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3441

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When we moved the static asset dir workaround from nitro -> vite we omitted to do the same in bridge vite implementation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

