### PR TITLE
fix(nuxt3): strip file extensions in `imports.d.ts`

### DIFF
--- a/packages/nuxt3/src/auto-imports/module.ts
+++ b/packages/nuxt3/src/auto-imports/module.ts
@@ -107,6 +107,9 @@ export default defineNuxtModule<AutoImportsOptions>({
 function addDeclarationTemplates (ctx: AutoImportContext) {
   const nuxt = useNuxt()
 
+  // Remove file extension for benefit of TypeScript
+  const stripExtension = (path: string) => path.replace(/\.[a-z]+$/, '')
+
   const resolved = {}
   const r = (id: string) => {
     if (resolved[id]) { return resolved[id] }
@@ -114,15 +117,14 @@ function addDeclarationTemplates (ctx: AutoImportContext) {
     if (isAbsolute(path)) {
       path = relative(join(nuxt.options.buildDir, 'types'), path)
     }
-    // Remove file extension for benefit of TypeScript
-    path = path.replace(/\.[a-z]+$/, '')
+    path = stripExtension(path)
     resolved[id] = path
     return path
   }
 
   addTemplate({
     filename: 'imports.d.ts',
-    getContents: () => toExports(ctx.autoImports)
+    getContents: () => toExports(ctx.autoImports.map(i => ({ ...i, from: stripExtension(i.from) })))
   })
 
   addTemplate({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
When `autoImports` are resolved from directories `autoImports:dirs`, the file extensions are NOT stripped when `imports.d.ts` is generated ( though, they are being stripped in `auto-imports.d.ts`)

Stripping the file extension improves DX & Typescript experience .
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
