### PR TITLE
fix(kit): allow `src` for `addPluginTemplate`

### DIFF
--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -68,7 +68,7 @@ export function addPlugin (_plugin: NuxtPlugin | string, opts: AddPluginOptions 
 /**
  * Adds a template and registers as a nuxt plugin.
  */
-export function addPluginTemplate (plugin: NuxtPluginTemplate | string, opts: AddPluginOptions = {}): NuxtPluginTemplate {
+export function addPluginTemplate (plugin: NuxtPluginTemplate | string, opts: AddPluginOptions = {}): NuxtPlugin {
   const normalizedPlugin: NuxtPlugin = typeof plugin === 'string'
     ? { src: plugin }
     // Update plugin src to template destination

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -68,8 +68,8 @@ export function addPlugin (_plugin: NuxtPlugin | string, opts: AddPluginOptions 
 /**
  * Adds a template and registers as a nuxt plugin.
  */
-export function addPluginTemplate (plugin: Omit<NuxtPluginTemplate, 'src'> | string, opts: AddPluginOptions = {}): NuxtPluginTemplate {
-  const normalizedPlugin: NuxtPluginTemplate = typeof plugin === 'string'
+export function addPluginTemplate (plugin: NuxtPluginTemplate | string, opts: AddPluginOptions = {}): NuxtPluginTemplate {
+  const normalizedPlugin: NuxtPlugin = typeof plugin === 'string'
     ? { src: plugin }
     // Update plugin src to template destination
     : { ...plugin, src: addTemplate(plugin).dst }

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -59,5 +59,5 @@ export interface NuxtApp {
   templates: NuxtTemplate[]
 }
 
-type _TemplatePlugin = Partial<NuxtPlugin> & NuxtTemplate
+type _TemplatePlugin = Omit<NuxtPlugin, 'src'> & NuxtTemplate
 export interface NuxtPluginTemplate extends _TemplatePlugin { }

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -59,5 +59,5 @@ export interface NuxtApp {
   templates: NuxtTemplate[]
 }
 
-type _TemplatePlugin = NuxtPlugin & NuxtTemplate
+type _TemplatePlugin = Partial<NuxtPlugin> & NuxtTemplate
 export interface NuxtPluginTemplate extends _TemplatePlugin { }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously, we actually errored if `src` was provided, e.g. https://github.com/nuxt/framework/blob/e674d0f60d52e26122ce54f6c82a5723f8fc8e23/packages/bridge/src/capi.ts#L26. This PR makes it optional.
