### PR TITLE
fix(vite, webpack): add missing dependencies

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@nuxt/schema": "3.0.0",
     "@types/cssnano": "^5",
-    "magic-string": "^0.26.0",
     "unbuild": "latest",
     "vue": "3.2.31"
   },
@@ -33,11 +32,14 @@
     "fs-extra": "^10.0.1",
     "get-port-please": "^2.4.3",
     "knitwork": "^0.1.0",
+    "magic-string": "^0.26.0",
     "mlly": "^0.4.3",
     "p-debounce": "^4.0.0",
     "pathe": "^0.2.0",
+    "postcss": "^8.4.7",
     "postcss-import": "^14.0.2",
     "postcss-url": "^10.1.3",
+    "rollup": "^2.68.0",
     "rollup-plugin-visualizer": "^5.6.0",
     "ufo": "^0.7.11",
     "unplugin": "^0.3.3",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -29,6 +29,7 @@
     "fs-extra": "^10.0.1",
     "hash-sum": "^2.0.0",
     "lodash-es": "^4.17.21",
+    "magic-string": "^0.26.0",
     "memfs": "^3.4.1",
     "mini-css-extract-plugin": "^2.5.3",
     "mlly": "^0.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3375,8 +3375,10 @@ __metadata:
     mlly: ^0.4.3
     p-debounce: ^4.0.0
     pathe: ^0.2.0
+    postcss: ^8.4.7
     postcss-import: ^14.0.2
     postcss-url: ^10.1.3
+    rollup: ^2.68.0
     rollup-plugin-visualizer: ^5.6.0
     ufo: ^0.7.11
     unbuild: latest
@@ -3485,6 +3487,7 @@ __metadata:
     fs-extra: ^10.0.1
     hash-sum: ^2.0.0
     lodash-es: ^4.17.21
+    magic-string: ^0.26.0
     memfs: ^3.4.1
     mini-css-extract-plugin: ^2.5.3
     mlly: ^0.4.3


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹 Chore

### 📚 Description

There were a couple of dependencies not being provided in the builder packages where required (rollup & postcss), and magic-string and its dependencies was being inlined.
