### PR TITLE
docs: add stub instruction to docs README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We are using [Docus](https://nuxtlabs.com/docus) for documentation (*It is plann
 
 We recommend to install the [Docus extension](https://marketplace.visualstudio.com/items?itemName=NuxtLabs.docus) for VS Code.
 
-- Run `yarn stub` once in the root directory
+- Run `npx yarn stub` once in the root directory
 - Go into the docs directory: `cd docs`
 - Install docs dependencies with `npx yarn install`
 - Run `npx yarn dev` to start Docus in development mode

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ We are using [Docus](https://nuxtlabs.com/docus) for documentation (*It is plann
 
 We recommend to install the [Docus extension](https://marketplace.visualstudio.com/items?itemName=NuxtLabs.docus) for VS Code.
 
+- Run `yarn stub` once in the root directory
 - Go into the docs directory: `cd docs`
 - Install docs dependencies with `npx yarn install`
 - Run `npx yarn dev` to start Docus in development mode


### PR DESCRIPTION
If you only want to make documentation, you don't necessarily pay attention to the development section. That's why I have adapted it. I refer to this question from myself https://github.com/nuxt/framework/issues/3550#issuecomment-1061534210