### PR TITLE
docs(server): add example for early spiking middleware

### DIFF
--- a/docs/content/3.docs/2.directory-structure/13.server.md
+++ b/docs/content/3.docs/2.directory-structure/13.server.md
@@ -89,7 +89,7 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 }
 ```
 
-To pass the request deeper into the application, you can simply `return` inside the function: 
+To pass the request deeper into the application, you can simply `return` inside the function:
 
 ```js
 export default async (req, res) => {

--- a/docs/content/3.docs/2.directory-structure/13.server.md
+++ b/docs/content/3.docs/2.directory-structure/13.server.md
@@ -97,10 +97,9 @@ export default async (req, res, next) => {
   if(isNotHandledByThisMiddleware) {
     return next()
   }
-  
+
   // Actual logic here
 }
 ```
-
 
 More information about custom middleware can be found in the documentation for [nuxt.config.js](/docs/directory-structure/nuxt.config#servermiddleware)

--- a/docs/content/3.docs/2.directory-structure/13.server.md
+++ b/docs/content/3.docs/2.directory-structure/13.server.md
@@ -89,13 +89,13 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 }
 ```
 
-To pass the request deeper into the application, you can call `next`, which is the third argument of a middleware function: 
+To pass the request deeper into the application, you can simply `return` inside the function: 
 
 ```js
 export default async (req, res, next) => {
   const isNotHandledByThisMiddleware = req.url.includes('/some-unhandled-url-path/')
   if(isNotHandledByThisMiddleware) {
-    return next()
+    return
   }
 
   // Actual logic here

--- a/docs/content/3.docs/2.directory-structure/13.server.md
+++ b/docs/content/3.docs/2.directory-structure/13.server.md
@@ -89,4 +89,18 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 }
 ```
 
+To pass the request deeper into the application, you can call `next`, which is the third argument of a middleware function: 
+
+```js
+export default async (req, res, next) => {
+  const isNotHandledByThisMiddleware = req.url.includes('/some-unhandled-url-path/')
+  if(isNotHandledByThisMiddleware) {
+    return next()
+  }
+  
+  // Actual logic here
+}
+```
+
+
 More information about custom middleware can be found in the documentation for [nuxt.config.js](/docs/directory-structure/nuxt.config#servermiddleware)

--- a/docs/content/3.docs/2.directory-structure/13.server.md
+++ b/docs/content/3.docs/2.directory-structure/13.server.md
@@ -92,7 +92,7 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
 To pass the request deeper into the application, you can simply `return` inside the function: 
 
 ```js
-export default async (req, res, next) => {
+export default async (req, res) => {
   const isNotHandledByThisMiddleware = req.url.includes('/some-unhandled-url-path/')
   if(isNotHandledByThisMiddleware) {
     return


### PR DESCRIPTION
### Linked issue

#3561 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds an example that showcases the usage of `next` inside a server middleware.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

