### PR TITLE
docs(usage): add references of nuxi commands and options

### DIFF
--- a/docs/content/1.getting-started/5.commands.md
+++ b/docs/content/1.getting-started/5.commands.md
@@ -66,28 +66,8 @@ npm run build
 
 Nuxt will create a [`.output`](/docs/directory-structure/output) directory with all your application, server and dependencies ready to be deployed. Check out the [deployment](/docs/deployment) section to learn where and how you can deploy a Nuxt application using Nitro.
 
-## Previewing your production build
+## CLI glossary
 
-Once you've built your Nuxt application, you can preview it locally:
-
-```bash
-npx nuxi preview
-```
-
-If you're using a supported preset, this will start a local server (for testing purposes only).
-
-## Upgrade Nuxt3 version
-
-To upgrade Nuxt3 version:
-
-```bash
-npx nuxi upgrade
-```
-
-## Checking types
-
-To type-check your application, you can use `nuxi typecheck`. This uses [`vue-tsc`](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-tsc) under the hood. If you have both a locally installed version of `typescript` and `vue-tsc`, nuxi will use these when type-checking.
-
-```bash
-npx nuxi typecheck
-```
+::alert{type="success"}
+Nuxi has more commands listed in a complete [CLI glossary](/docs/usage/cli)
+::

--- a/docs/content/3.docs/1.usage/8.cli.md
+++ b/docs/content/3.docs/1.usage/8.cli.md
@@ -1,0 +1,96 @@
+# Nuxi CLI
+
+Nuxi is the new Command-line interface (CLI) for Nuxt 3. This page references the commands and options of Nuxi.
+
+## Init
+
+```{bash}
+npx nuxi init|create [--verbose|-v] [--template,-t] [dir]
+```
+
+The `init` command initializes a fresh Nuxt project.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`--verbose, -v` | `false` | Log informations about the installation process.
+`--template, -t` | `nuxt/starter#v3` | Specify a Git repository to use as a template.
+`dir` | `nuxt-app` | Name of the install directory.
+
+## Dev
+
+```{bash}
+npx nuxi dev [rootDir] [--clipboard] [--open, -o] [--port, -p] [--host, -h] [--https] [--ssl-cert] [--ssl-key]
+```
+
+The `dev` command starts a development server with hot module replacement at http://localhost:3000
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The root directory of the application to serve.
+`--clipboard` | `false` | Copy URL to clipboard.
+`--open, -o` | `false` | Open URL in browser.
+`--port, -p` | `3000` | Port to listen.
+`--host, -h` | `localhost` | Hostname of the server.
+`--https` | `false` | Listen with `https` protocol with a self-signed certificate by default.
+`--ssl-cert` |`null` | Specify a certificate for https.
+`--ssl-key` |`null` | Specify the key for the https certificate.
+
+## Build
+
+```{bash}
+npx nuxi build [rootDir]
+```
+
+The `build` command creates a `.output` directory with all your application, server and dependencies ready for production.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The root directory of the application to bundle.
+
+## Preview
+
+```{bash}
+npx nuxi preview [rootDir]
+```
+
+The `preview` command starts a server to preview your Nuxt application after running the `build` command.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The root directory of the application to preview.
+
+## Info
+
+```{bash}
+npx nuxi info [rootDir]
+```
+
+The `info` command logs informations about the current or specified Nuxt project.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The directory of the target application.
+
+## Typecheck
+
+```{bash}
+npx nuxi typecheck [rootDir]
+```
+
+The `typecheck` command runs [`vue-tsc`](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-tsc) to check types throughout your app.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The directory of the target application.
+
+## Upgrade
+
+```{bash}
+npx nuxi upgrade [--force|-f]
+```
+
+The `upgrade` upgrades Nuxt 3 to the lastest version.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`--force, -f` | `false` | Removes `node_modules` and lock files before upgrade.

--- a/docs/content/3.docs/1.usage/8.cli.md
+++ b/docs/content/3.docs/1.usage/8.cli.md
@@ -22,7 +22,7 @@ Option        | Default          | Description
 npx nuxi dev [rootDir] [--clipboard] [--open, -o] [--port, -p] [--host, -h] [--https] [--ssl-cert] [--ssl-key]
 ```
 
-The `dev` command starts a development server with hot module replacement at http://localhost:3000
+The `dev` command starts a development server with hot module replacement at [http://localhost:3000](https://localhost:3000)
 
 Option        | Default          | Description
 -------------------------|-----------------|------------------


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a page in the Usage section of the docs to list Nuxi commands and options.

