### PR TITLE
docs(cloudflare): update build command

### DIFF
--- a/docs/content/3.docs/3.deployment/2.cloudflare.md
+++ b/docs/content/3.docs/3.deployment/2.cloudflare.md
@@ -32,7 +32,7 @@ bucket = ".output/public"
 entry-point = ".output"
 
 [build]
-command = "NITRO_PRESET=cloudflare yarn nuxt build"
+command = "true"
 upload.format = "service-worker"
 ```
 


### PR DESCRIPTION
### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

So the problem is if you just copy & paste the documentation from https://v3.nuxtjs.org/docs/deployment/cloudflare/
You will be getting into a problem on github actions with 

```
$ /github/workspace/node_modules/.bin/nuxt build
[log] Nuxt CLI v3.0.0-27449808.ac40c97
Error:  Unexpected token '.'
``` 

But when checking the example repo:  
https://github.com/nuxt/nitro-demo/blob/main/wrangler.toml#L13
It was updated. it that make sense cause we are already building the application before in the gitub actions.

### 📝 Checklist
- [ ] I have linked an issue or discussion. ( DId this PR directly from the docs page ) 
- [X] I have updated the documentation accordingly.

