### PR TITLE
fix(vite): add `cookie` to optimizeDeps

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -45,12 +45,18 @@ export default {
       },
     },
     optimizeDeps: {
+      include: {
+        $resolve: (val, get) => [
+          ...val || [],
+          'cookie'
+        ]
+      },
       exclude: {
         $resolve: (val, get) => [
           ...val || [],
-        ...get('build.transpile').filter(i => typeof i === 'string'),
-        'vue-demi'
-      ],
+          ...get('build.transpile').filter(i => typeof i === 'string'),
+          'vue-demi'
+        ],
       },
     },
     esbuild: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

since h3@0.4.0, we no longer inline `cookie`. Importing from `h3` in vite now poses an issue due to the packaging of `cookie`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

