### PR TITLE
fix(nuxt3): reassign plugins on iterations

### DIFF
--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -71,14 +71,15 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Resolve plugins
+  app.plugins = []
   for (const config of [...nuxt.options._extends.map(layer => layer.config), nuxt.options]) {
-    app.plugins = [
+    app.plugins.push(...[
       ...config.plugins ?? [],
       ...await resolveFiles(config.srcDir, [
         'plugins/*.{ts,js,mjs,cjs,mts,cts}',
         'plugins/*/index.*{ts,js,mjs,cjs,mts,cts}'
       ])
-    ].map(plugin => normalizePlugin(plugin as NuxtPlugin))
+    ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
   }
 
   // Extend app

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -72,13 +72,13 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve plugins
   for (const config of [...nuxt.options._extends.map(layer => layer.config), nuxt.options]) {
-    app.plugins.push(...[
+    app.plugins = [
       ...config.plugins ?? [],
       ...await resolveFiles(config.srcDir, [
         'plugins/*.{ts,js,mjs,cjs,mts,cts}',
         'plugins/*/index.*{ts,js,mjs,cjs,mts,cts}'
       ])
-    ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
+    ].map(plugin => normalizePlugin(plugin as NuxtPlugin))
   }
 
   // Extend app


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#3618 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->
This PR addresses a regression made in #3462 that caused the dev server to crash when changes are made to `autoImport` directories.

Caused by failing to reassign `plugins` on iterations

![Screen Shot 2022-03-11 at 2 14 12 PM](https://user-images.githubusercontent.com/19627670/157929618-8adf9323-df1b-4a9d-b649-54d5e6317ffd.png)

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

