### PR TITLE
fix(nuxt3): extends components with wrongly prefix copy the prefix

### DIFF
--- a/examples/extends-components-bug/app.vue
+++ b/examples/extends-components-bug/app.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <!-- Should be <UHello /> -->
+    <UHello />
+    <UButton>Hello</UButton>
+  </div>
+</template>

--- a/examples/extends-components-bug/components/Hello.vue
+++ b/examples/extends-components-bug/components/Hello.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Hello world</div>
+</template>

--- a/examples/extends-components-bug/nuxt.config.ts
+++ b/examples/extends-components-bug/nuxt.config.ts
@@ -1,0 +1,5 @@
+import { defineNuxtConfig } from 'nuxt3'
+
+export default defineNuxtConfig({
+  extends: './ui'
+})

--- a/examples/extends-components-bug/package.json
+++ b/examples/extends-components-bug/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example-extends-components-bug",
+  "private": true,
+  "scripts": {
+    "build": "nuxi build",
+    "dev": "nuxi dev",
+    "start": "nuxi preview"
+  },
+  "devDependencies": {
+    "nuxt3": "latest"
+  }
+}

--- a/examples/extends-components-bug/tsconfig.json
+++ b/examples/extends-components-bug/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/examples/extends-components-bug/ui/components/Button.vue
+++ b/examples/extends-components-bug/ui/components/Button.vue
@@ -1,0 +1,14 @@
+<script setup>
+defineProps({
+  color: {
+    type: String,
+    default: 'black'
+  }
+})
+</script>
+
+<template>
+  <button :style="{ color }">
+    <slot />
+  </button>
+</template>

--- a/examples/extends-components-bug/ui/nuxt.config.ts
+++ b/examples/extends-components-bug/ui/nuxt.config.ts
@@ -1,0 +1,7 @@
+import { defineNuxtConfig } from 'nuxt3'
+
+export default defineNuxtConfig({
+  components: [
+    { path: './components', prefix: 'U' }
+  ]
+})

--- a/packages/nuxt3/src/components/module.ts
+++ b/packages/nuxt3/src/components/module.ts
@@ -59,6 +59,9 @@ export default defineNuxtModule<ComponentsOptions>({
           .map(layer => normalizeDirs(layer.config.components, layer.cwd))
           .flat()
       ]
+      console.log('componentOptions', componentOptions)
+      nuxt.options._extends.forEach(layer => console.log('layer', layer.config.components))
+      console.log('allDirs', allDirs)
 
       await nuxt.callHook('components:dirs', allDirs)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10482,6 +10482,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"example-extends-components-bug@workspace:examples/extends-components-bug":
+  version: 0.0.0-use.local
+  resolution: "example-extends-components-bug@workspace:examples/extends-components-bug"
+  dependencies:
+    nuxt3: latest
+  languageName: unknown
+  linkType: soft
+
 "example-hello-world@workspace:examples/hello-world":
   version: 0.0.0-use.local
   resolution: "example-hello-world@workspace:examples/hello-world"


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Having a simple example using `extends` with a `ui` directory having a `prefix` for its components dir.

```js
ui/
  components/
    Button.vue
  nuxt.config.ts // using { path: './components', prefix: 'U' }
components/
  Hello.vue
app.vue
nuxt.config.ts // using extends: './ui'
```

When looking at the `/.nuxt/types/components.d.ts` it shows:

```ts
// Generated by components discovery
declare module 'vue' {
  export interface GlobalComponents {
    'UHello': typeof import("../../components/Hello.vue")['default'],
    'UButton': typeof import("../../ui/components/Button.vue")['default'],
    'NuxtWelcome': typeof import("../../../../node_modules/@nuxt/ui-templates/dist/templates/welcome.vue")['default'],
    'ClientOnly': typeof import("../../../../packages/nuxt3/src/app/components/client-only")['default']
  }
}
export {}
```

#### The problem?

We should have `Button` instead of `UButton`, the `prefix: U` should be applied only to the `~/ui/component/` dir.

```ts
declare module 'vue' {
  export interface GlobalComponents {
    'Hello': typeof import("../../components/Hello.vue")['default'],
    'UButton': typeof import("../../ui/components/Button.vue")['default'],
    // ...
  }
}
export {}
```

#### Current reproduction

Creation a pull request directly to have an easy way to reproduce the bug:
```bash
yarn install
yarn example extends-components-bug
```

Open http://localhost:4000/_vfs/ and click to `/.nuxt/types/components.d.ts`

I also added a logs in [packages/nuxt3/src/components/module.ts](https://github.com/nuxt/framework/blob/a1769f4b10b875099c916d02934c2c93a6742e76/packages/nuxt3/src/components/module.ts#L62-L64) to debug:

```
componentOptions {                                                                                                                            
  dirs: [
    {
      path: './components',
      prefix: 'U'
    }
  ]
}
layer [                                                                                                                                        
  {
    path: './components',
    prefix: 'U'
  }
]
allDirs [                                                                                                                                     
  {
    path: '/Users/atinux/Projects/nuxt/framework/examples/extends-components-bug/components',
    prefix: 'U'
  },
  {
    path: '/Users/atinux/Projects/nuxt/framework/examples/extends-components-bug/ui/components',
    prefix: 'U'
  }
]
```

Seems that `componentsOptions` is wrongly merged.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

