### PR TITLE
chore(ci): re-enable renovate for bridge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,12 @@
   "extends": [
     "@nuxtjs"
   ],
-  "ignorePaths": [
-    "**/bridge/**"
+  "packageRules": [
+    {
+      "matchPaths": ["**/bridge/**"],
+      "matchPackageNames": ["vue", "vue-router"],
+      "enabled": false
+    }
   ],
   "ignoreDeps": [
     "docus",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3644

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹 Chore

### 📚 Description

Re-enables auto-upgrade bridge deps except for vue, vue-router. It's difficult to test this but looks like it should work.
