### PR TITLE
chore: remove non-existent extends

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,6 @@
 import { defineNuxtConfig } from 'nuxt3'
 
 export default defineNuxtConfig({
-  extends: './base',
   modules: [
     '@nuxt/ui'
   ]


### PR DESCRIPTION
### 📚 Description

Current non-existent extends is giving an error (unable to read `config.dir.layouts`). I can fix that if we intend to support non-existent extends keys, but thought this was just a mistake.