### PR TITLE
fix(bridge,nitro,nuxi,nuxt3,vite): ensure debounced/async handlers run in order

### DIFF
--- a/packages/bridge/src/vite/server.ts
+++ b/packages/bridge/src/vite/server.ts
@@ -118,7 +118,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     consola.info(`Server built in ${time}ms`)
     await onBuild()
   }
-  const doBuild = pDebounce(pDebounce.promise(_doBuild), 1)
+  const doBuild = pDebounce(pDebounce.promise(_doBuild), 300)
 
   // Initial build
   await _doBuild()

--- a/packages/bridge/src/vite/server.ts
+++ b/packages/bridge/src/vite/server.ts
@@ -118,7 +118,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     consola.info(`Server built in ${time}ms`)
     await onBuild()
   }
-  const doBuild = pDebounce(_doBuild, 300)
+  const doBuild = pDebounce(pDebounce.promise(_doBuild), 1)
 
   // Initial build
   await _doBuild()

--- a/packages/nitro/src/server/dev.ts
+++ b/packages/nitro/src/server/dev.ts
@@ -128,7 +128,7 @@ export function createDevServer (nitroContext: NitroContext) {
   let watcher: FSWatcher
   function watch () {
     if (watcher) { return }
-    const dReload = debounce(debounce.promise(() => reload().catch(console.warn)), 1, { before: true })
+    const dReload = debounce(debounce.promise(() => reload().catch(console.warn)), 200, { before: true })
     watcher = chokidar.watch([
       resolve(nitroContext.output.serverDir, pattern),
       resolve(nitroContext._nuxt.buildDir, 'dist/server', pattern)

--- a/packages/nitro/src/server/dev.ts
+++ b/packages/nitro/src/server/dev.ts
@@ -128,7 +128,7 @@ export function createDevServer (nitroContext: NitroContext) {
   let watcher: FSWatcher
   function watch () {
     if (watcher) { return }
-    const dReload = debounce(() => reload().catch(console.warn), 200, { before: true })
+    const dReload = debounce(debounce.promise(() => reload().catch(console.warn)), 1, { before: true })
     watcher = chokidar.watch([
       resolve(nitroContext.output.serverDir, pattern),
       resolve(nitroContext._nuxt.buildDir, 'dist/server', pattern)

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -3,6 +3,7 @@ import chokidar from 'chokidar'
 import debounce from 'p-debounce'
 import type { Nuxt } from '@nuxt/schema'
 import consola from 'consola'
+import { withTrailingSlash } from 'ufo'
 import { createServer, createLoadingHandler } from '../utils/server'
 import { showBanner } from '../utils/banner'
 import { writeTypes } from '../utils/prepare'
@@ -46,12 +47,13 @@ export default defineNuxtCommand({
         if (currentNuxt) {
           await currentNuxt.close()
         }
-        const newNuxt = await loadNuxt({ rootDir, dev: true, ready: false })
-        await clearDir(newNuxt.options.buildDir)
-        currentNuxt = newNuxt
+        currentNuxt = await loadNuxt({ rootDir, dev: true, ready: false })
+        await clearDir(currentNuxt.options.buildDir)
         await currentNuxt.ready()
-        writeTypes(currentNuxt).catch(console.error)
-        await buildNuxt(currentNuxt)
+        await Promise.all([
+          writeTypes(currentNuxt).catch(console.error),
+          buildNuxt(currentNuxt)
+        ])
         server.setApp(currentNuxt.server.app)
         if (isRestart && args.clear !== false) {
           showBanner()
@@ -67,12 +69,12 @@ export default defineNuxtCommand({
 
     // Watch for config changes
     // TODO: Watcher service, modules, and requireTree
-    const dLoad = debounce(load, 250)
+    const dLoad = debounce(debounce.promise(load), 250)
     const watcher = chokidar.watch([rootDir], { ignoreInitial: true, depth: 1 })
     watcher.on('all', (event, file) => {
       if (!currentNuxt) { return }
-      if (file.startsWith(currentNuxt.options.buildDir)) { return }
-      if (file.match(/(nuxt\.config\.(js|ts|mjs|cjs)|\.nuxtignore)$/)) {
+      if (file.startsWith(withTrailingSlash(currentNuxt.options.buildDir))) { return }
+      if (file.match(/(nuxt\.config\.(js|ts|mjs|cjs)|\.nuxtignore|\.env|\.nuxtrc)$/)) {
         dLoad(true, `${relative(rootDir, file)} updated`)
       }
 

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -154,7 +154,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       logger.success(`Vite server built in ${time}ms`)
       await onBuild()
     }
-    const doBuild = pDebounce(pDebounce.promise(_doBuild), 1)
+    const doBuild = pDebounce(pDebounce.promise(_doBuild), 100)
 
     // Initial build
     await _doBuild()

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -154,7 +154,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       logger.success(`Vite server built in ${time}ms`)
       await onBuild()
     }
-    const doBuild = pDebounce(_doBuild, 100)
+    const doBuild = pDebounce(pDebounce.promise(_doBuild), 1)
 
     // Initial build
     await _doBuild()


### PR DESCRIPTION
### 🔗 Linked issue

resolves #3654

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Across the nuxt codebase, this PR uses `debounce` + `debounce.promise` to prevent initialising a new handler before the old one has finished running (which should prevent double access to files, for example, or multiple callbacks pushing the same plugin to `app.plugins`, as in the issue linked above).

At the same time, we drop the timeout from (for example) 300 to 1. This leads to a significant increase in DX as it feels much faster.

This PR also:

* fixes a bug with nuxi dev where any path starting with `.nuxt` was not triggering a reload (such as `.nuxtignore`)
* adds `.env` and `.nuxtrc` files to trigger a full nuxt reload

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

