### PR TITLE
fix(nuxt3): fix layout suspense loading

### DIFF
--- a/packages/nuxt3/src/core/templates.ts
+++ b/packages/nuxt3/src/core/templates.ts
@@ -160,7 +160,7 @@ export const layoutTemplate: NuxtTemplate = {
   filename: 'layouts.mjs',
   getContents ({ app }) {
     const layoutsObject = genObjectFromRawEntries(Object.values(app.layouts).map(({ name, file }) => {
-      return [name, `defineAsyncComponent({ suspensible: false, loader: ${genDynamicImport(file)} })`]
+      return [name, `defineAsyncComponent(${genDynamicImport(file)})`]
     }))
     return [
       'import { defineAsyncComponent } from \'vue\'',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/2664, resolves https://github.com/nuxt/framework/issues/3168

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves two significant layout-related bugs. By setting `suspensible` to false, layout children weren't blocking rendering of the app, which meant that `isHydrating` was false by the time these functions ran.

There is still [an upstream bug related to nested suspenses on route changes](https://github.com/vuejs/router/issues/626#issuecomment-1048609550), but it has a different cause.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

