### PR TITLE
feat(nuxt3): add `<NuxtErrorBoundary>` component for fine-grained error handling

### DIFF
--- a/docs/content/3.docs/1.usage/8.error-handling.md
+++ b/docs/content/3.docs/1.usage/8.error-handling.md
@@ -88,3 +88,32 @@ You can call this function at any point on client-side, or (on server side) dire
 * `function clearError (redirect?: string): Promise<void>`
 
 This function will clear the currently handled Nuxt error. It also takes an optional path to redirect to (for example, if you want to navigate to a 'safe' page).
+
+## Rendering errors within your app
+
+Nuxt also provides a `<NuxtErrorBoundary>` component that allows you to handle client-side errors within your app, without replacing your entire site with an error page.
+
+This component is responsible for handling errors that occur within its default slot. On client-side, it will prevent the error from bubbling up to the top level, and will render the `#error` slot instead.
+
+The `#error` slot will receive `error` and `clearError` props. (`clearError` is a method that will trigger re-rendering the default slot; you'll need to ensure that the error is fully resolved first or the error slot will just be rendered a second time.)
+
+::alert{type="info"}
+If you navigate to another route, the error will be cleared automatically.
+::
+
+### Example
+
+```vue [pages/index.vue]
+<template>
+  <!-- some content --> 
+  <NuxtErrorBoundary>
+    <!-- You use the default slot to render your content --> 
+    <template #error="{ error, clearError }">
+      You can display the error locally here.
+      <button @click="clearError">
+        This will clear the error.
+      </button>
+    </template>
+  </NuxtErrorBoundary>
+</template>
+```

--- a/examples/with-errors/app.vue
+++ b/examples/with-errors/app.vue
@@ -12,6 +12,7 @@ if ('mounted' in route.query) {
 function triggerError () {
   throw new Error('manually triggered error')
 }
+const firstRender = ref(true)
 </script>
 
 <template>
@@ -20,6 +21,9 @@ function triggerError () {
       <nav class="flex align-center gap-4 p-4">
         <NuxtLink to="/" class="n-link-base">
           Home
+        </NuxtLink>
+        <NuxtLink to="/other" class="n-link-base">
+          Other
         </NuxtLink>
         <NuxtLink to="/404" class="n-link-base">
           404
@@ -35,6 +39,20 @@ function triggerError () {
         </button>
       </nav>
     </template>
+
+    <NuxtErrorBoundary>
+      <div v-if="$route.path === '/' && firstRender">
+        <div>
+          <BoundaryTest />
+        </div>
+      </div>
+      <template #error="{ error, clearError }">
+        Here's a deliberately triggered error: {{ error }}
+        <button @click="firstRender = false; clearError()">
+          Clear error
+        </button>
+      </template>
+    </NuxtErrorBoundary>
 
     <template #footer>
       <div class="text-center p-4 op-50">

--- a/examples/with-errors/components/BoundaryTest.vue
+++ b/examples/with-errors/components/BoundaryTest.vue
@@ -1,0 +1,7 @@
+<script setup>
+throw new Error('Deliberate error in <BoundaryTest>')
+</script>
+
+<template>
+  <div>Should never see this</div>
+</template>

--- a/packages/nuxt3/src/app/components/nuxt-error-boundary.ts
+++ b/packages/nuxt3/src/app/components/nuxt-error-boundary.ts
@@ -1,0 +1,22 @@
+import { defineComponent, ref, onErrorCaptured, onBeforeUnmount } from 'vue'
+import { useNuxtApp, useRouter } from '#app'
+
+export default defineComponent({
+  setup (_props, { slots }) {
+    const error = ref(null)
+    const nuxtApp = useNuxtApp()
+
+    onErrorCaptured((err) => {
+      if (process.client && !nuxtApp.isHydrating) {
+        error.value = err
+        return false
+      }
+    })
+
+    const clearError = () => { error.value = null }
+    const unregister = useRouter().afterEach(clearError)
+    onBeforeUnmount(unregister)
+
+    return () => error.value ? slots.error?.({ error, clearError }) : slots.default?.()
+  }
+})

--- a/packages/nuxt3/src/core/nuxt.ts
+++ b/packages/nuxt3/src/core/nuxt.ts
@@ -84,6 +84,12 @@ async function initNuxt (nuxt: Nuxt) {
     filePath: resolve(nuxt.options.appDir, 'components/layout')
   })
 
+  // Add <NuxtErrorBoundary>
+  addComponent({
+    name: 'NuxtErrorBoundary',
+    filePath: resolve(nuxt.options.appDir, 'components/nuxt-error-boundary')
+  })
+
   // Add <ClientOnly>
   addComponent({
     name: 'ClientOnly',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

closes #3590

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds `<NuxtErrorBoundary>` component to simplify the creation of error interfaces. Due to the limitations of SSR, this component only renders errors on client-side. On SSR, a full page `error.vue` is rendered instead.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

