### PR TITLE
feat(nuxt3): extends support for server/ directory

### DIFF
--- a/examples/config-extends/base/server/api/base.ts
+++ b/examples/config-extends/base/server/api/base.ts
@@ -1,0 +1,1 @@
+export default () => 'base'

--- a/examples/config-extends/server/api/hello.ts
+++ b/examples/config-extends/server/api/hello.ts
@@ -1,0 +1,1 @@
+export default () => 'hello'

--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -83,7 +83,10 @@ export interface NitroContext {
   _internal: {
     runtimeDir: string
     hooks: Hookable<NitroHooks>
-  }
+  },
+  _extends: Array<{
+    serverDir: string
+  }>
 }
 
 type DeepPartial<T> = T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> | T[P] } : T
@@ -154,7 +157,10 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
     _internal: {
       runtimeDir,
       hooks: createHooks<NitroHooks>()
-    }
+    },
+    _extends: nuxtOptions._extends.map(layer => ({
+      serverDir: resolve(layer.config.srcDir, (layer.config.dir as any)?.server || 'server')
+    }))
   }
 
   defaults.preset = input.preset || process.env.NITRO_PRESET || detectTarget() || 'server'

--- a/packages/nuxt3/src/core/nitro-legacy.ts
+++ b/packages/nuxt3/src/core/nitro-legacy.ts
@@ -77,7 +77,15 @@ export function initNitro (nuxt: Nuxt) {
   })
 
   nuxt.hook('build:before', async () => {
-    nitroDevContext.scannedMiddleware = await scanMiddleware(nitroDevContext._nuxt.serverDir)
+    const serverDirs = [
+      ...nitroDevContext._extends.map(layer => layer.serverDir),
+      nitroDevContext._nuxt.serverDir
+    ]
+
+    nitroDevContext.scannedMiddleware = (
+      await Promise.all(serverDirs.map(async dir => await scanMiddleware(dir)))
+    ).flat().sort((a, b) => b.route.localeCompare(a.route))
+
     await writeTypes(nitroDevContext)
   })
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following up #3222 (`extends` support progress) this PR allows extending `server/` directory for extended config layers

### TO DO
- [x] Extends support for `server` directory
- [ ] Improve code to have less redundant logic ?
- [ ] Extends support for `serverMiddleware` config key in layers => maybe later ? /cc @pi0 
