### PR TITLE
chore: avoid workspace resolution for `@nuxt/test-utils`

### DIFF
--- a/examples/with-test/package.json
+++ b/examples/with-test/package.json
@@ -7,7 +7,6 @@
     "start": "nuxi preview"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "latest",
     "nuxt3": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "jiti": "^1.13.0",
     "nitropack-dev": "link:../nitropack",
     "nuxt3": "workspace:./packages/nuxt3",
-    "@nuxt/test-utils": "workspace:./packages/test-utils",
     "vite": "^2.8.6",
     "unbuild": "^0.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3194,7 +3194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/test-utils@workspace:./packages/test-utils, @nuxt/test-utils@workspace:packages/test-utils":
+"@nuxt/test-utils@workspace:packages/test-utils":
   version: 0.0.0-use.local
   resolution: "@nuxt/test-utils@workspace:packages/test-utils"
   dependencies:
@@ -10561,7 +10561,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-with-test@workspace:examples/with-test"
   dependencies:
-    "@nuxt/test-utils": latest
     nuxt3: latest
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
fixes issue with yarn when releasing edge (renaming not supported)

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

