### PR TITLE
feat(schema): expose `RouterOptions` and `RouterConfigOptions`

### DIFF
--- a/docs/content/3.docs/2.directory-structure/10.pages.md
+++ b/docs/content/3.docs/2.directory-structure/10.pages.md
@@ -274,10 +274,10 @@ It is possible to set default [vue-router options](https://router.vuejs.org/api/
 This is the recommaned way to specify router options.
 
 ```js [app/router.options.ts]
-import type { RouterOptions } from 'vue-router'
+import type { RouterOptions } from '@nuxt/schema'
 
 // https://router.vuejs.org/api/#routeroptions
-export default <Partial<RouterOptions>>{
+export default <RouterOptions>{
 }
 ```
 

--- a/docs/content/3.docs/2.directory-structure/10.pages.md
+++ b/docs/content/3.docs/2.directory-structure/10.pages.md
@@ -283,7 +283,13 @@ export default <Partial<RouterOptions>>{
 
 ### Using `nuxt.config`
 
-**Note:** Only JSON serializable options shall be passed. Non serializable options including `parseQuery`, `scrollBehavior` and `stringifyQuery` should be set using `app/router.options` file.
+**Note:** Only JSON serializable options are configurable:
+
+- `linkActiveClass`
+- `linkExactActiveClass`
+- `end`
+- `sensitive`
+- `strict`
 
 ```js [nuxt.config]
 export default defineNuxtConfig({

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -9,7 +9,7 @@ export default {
    * For more control, you can use `app/router.optionts.ts` file.
    *
    * @see [documentation](https://router.vuejs.org/api/#routeroptions)
-   * @type {Pick<import('vue-router').RouterOptions, 'linkActiveClass' | 'linkExactActiveClass' | 'end' | 'sensitive' | 'strict'>}
+   * @type {import('../src/types/router').RouterConfigOptions}
    *
    * @version 3
    */

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -9,7 +9,7 @@ export default {
    * For more control, you can use `app/router.optionts.ts` file.
    *
    * @see [documentation](https://router.vuejs.org/api/#routeroptions)
-   * @type {import('vue-router').RouterOptions}
+   * @type {Pick<import('vue-router').RouterOptions, 'linkActiveClass' | 'linkExactActiveClass' | 'end' | 'sensitive' | 'strict'>}
    *
    * @version 3
    */

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -10,7 +10,7 @@ export * from './types/imports'
 export * from './types/meta'
 export * from './types/module'
 export * from './types/nuxt'
-export * from './types/pages'
+export * from './types/router'
 
 // Schema
 export { default as NuxtConfigSchema } from './config/index'

--- a/packages/schema/src/types/pages.ts
+++ b/packages/schema/src/types/pages.ts
@@ -1,2 +1,0 @@
-// TODO: Lost!
-export interface NuxtRoute { }

--- a/packages/schema/src/types/router.ts
+++ b/packages/schema/src/types/router.ts
@@ -1,0 +1,9 @@
+import type { RouterOptions as _RouterOptions  } from 'vue-router'
+
+
+export type RouterOptions = Exclude<_RouterOptions, 'history' | 'routes'>
+
+/**
+ * Only JSON serializable router options are configurable from nuxt config
+ */
+export type RouterConfigOptions = Pick<RouterOptions, 'linkActiveClass' | 'linkExactActiveClass' | 'end' | 'sensitive' | 'strict'>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Expose proper types from schema for router options in `app/router.options.ts` (`RouterOptions`) and possible values of `router.options` in `nuxt.config` (`RouterConfigOptions`)

Instead of `pick`, we could exclude function options but this seems safer to only pick allowed ones.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

