### PR TITLE
feat(nuxt3):  `watch` option for `useAsyncData` to auto refresh

### DIFF
--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -18,6 +18,7 @@ const {
   pending: Ref<boolean>,
   refresh: (force?: boolean) => Promise<void>,
   error?: any
+  watch: WatchSource[]
 } = useAsyncData(
   key: string,
   handler: (ctx?: NuxtApp) => Promise<Object>,
@@ -35,6 +36,7 @@ const {
   * _server_: whether to fetch the data on server-side (defaults to `true`)
   * _transform_: a function that can be used to alter `handler` function result after resolving
   * _pick_: only pick specified keys in this array from `handler` function result
+  * _watch_: watch reactive sources to auto refrash
 
 Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the route before the data has been fetched. Consider using `lazy: true` and implementing a loading state instead for a snappier user experience.
 

--- a/examples/use-async-data/app.vue
+++ b/examples/use-async-data/app.vue
@@ -1,5 +1,6 @@
 <script setup>
-const { data, refresh, pending } = await useAsyncData('/api/hello', () => $fetch('/api/hello'))
+const ctr = ref(0)
+const { data, refresh, pending } = await useAsyncData('/api/hello', () => $fetch(`/api/hello/${ctr.value}`), { watch: [ctr] })
 </script>
 
 <template>
@@ -8,6 +9,9 @@ const { data, refresh, pending } = await useAsyncData('/api/hello', () => $fetch
     <div>
       <NButton :disabled="pending" @click="refresh">
         Refresh Data
+      </NButton>
+      <NButton :disabled="pending" @click="ctr++">
+        +
       </NButton>
     </div>
     <template #tips>

--- a/examples/use-async-data/server/api/hello.js
+++ b/examples/use-async-data/server/api/hello.js
@@ -1,1 +1,1 @@
-export default () => `Hello world! (Generated at ${new Date().toGMTString()})`
+export default req => `Hello world (${req.url.substr(1)}) (Generated at ${new Date().toGMTString()})`

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -137,9 +137,12 @@ export function useAsyncData<
       asyncData.refresh()
     }
     if (options.watch) {
-      watch(options.watch, () => {
+      const unwatch = watch(options.watch, () => {
         asyncData.refresh()
       })
+      if (instance) {
+        onUnmounted(() => unwatch())
+      }
     }
   }
 

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -1,5 +1,5 @@
-import { onBeforeMount, onServerPrefetch, onUnmounted, ref, getCurrentInstance } from 'vue'
-import type { Ref } from 'vue'
+import { onBeforeMount, onServerPrefetch, onUnmounted, ref, getCurrentInstance, watch } from 'vue'
+import type { Ref, WatchSource } from 'vue'
 import { NuxtApp, useNuxtApp } from '#app'
 
 export type _Transform<Input = any, Output = any> = (input: Input) => Output
@@ -7,6 +7,8 @@ export type _Transform<Input = any, Output = any> = (input: Input) => Output
 export type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? Pick<T, K[number]> : T
 export type KeysOf<T> = Array<keyof T extends string ? keyof T : string>
 export type KeyOfRes<Transform extends _Transform> = KeysOf<ReturnType<Transform>>
+
+type MultiWatchSources = (WatchSource<unknown> | object)[];
 
 export interface AsyncDataOptions<
   DataT,
@@ -18,6 +20,7 @@ export interface AsyncDataOptions<
   default?: () => DataT
   transform?: Transform
   pick?: PickKeys
+  watch?: MultiWatchSources
 }
 
 export interface _AsyncData<DataT> {
@@ -132,6 +135,11 @@ export function useAsyncData<
     } else {
       // 4. Navigation (lazy: false) - or plugin usage: await fetch
       asyncData.refresh()
+    }
+    if (options.watch) {
+      watch(options.watch, () => {
+        asyncData.refresh()
+      })
     }
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new `watch` option to `useAsyncData` that triggers refrash on reactivity detection. In next steps, we shall improve it using watchEffect to discover more dependencies of handler. 

Watcher is only enabled on client-side when `options.watch` is set and stop when instance (if any) unmounts.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

