### PR TITLE
feat(nuxt3): allow overriding root component using `app.root.vue`

### DIFF
--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -63,8 +63,11 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
     app.mainComponent = tryResolveModule('@nuxt/ui-templates/templates/welcome.vue')
   }
 
-  // Default root component
-  app.rootComponent = resolve(nuxt.options.appDir, 'components/nuxt-root.vue')
+  // Resolve root component
+  if (!app.rootComponent) {
+    app.rootComponent = await findPath(['~/app.root', resolve(nuxt.options.appDir, 'components/nuxt-root.vue')])
+  }
+  console.log('Root', app.rootComponent)
 
   // Resolve error component
   if (!app.errorComponent) {

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -67,7 +67,6 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   if (!app.rootComponent) {
     app.rootComponent = await findPath(['~/app.root', resolve(nuxt.options.appDir, 'components/nuxt-root.vue')])
   }
-  console.log('Root', app.rootComponent)
 
   // Resolve error component
   if (!app.errorComponent) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow overriding Vue root component (builtin: https://github.com/nuxt/framework/blob/main/packages/nuxt3/src/app/components/nuxt-root.vue) for fine-grained control over Suspense behavior.

**Note:** This is advanced functionality and experimental, use with caution! (meaning might be dropped in the final version of Nuxt 3)

#### Future improvements:

Similar to Nuxt 2, we  might find a better way to allow overriding any built-in component for debugging and making Nuxt completely hackable making edge cases possible (example [nuxt-community/nuxt7](https://github.com/nuxt-community/nuxt7): It uses a completely different router and app handling still leveraging the power of Nuxt!)

Also, we could extract setup logic out of built-in `<NuxtRoot>` as a composable. Making it easier to override component, yet using Nuxt logic.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

