### PR TITLE
fix(webpack): support absolute urls in webpack css url/import

### DIFF
--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -163,10 +163,16 @@ export default {
       },
       css: {
         importLoaders: 0,
+        url: {
+          filter: (url: string, resourcePath: string) => !url.startsWith('/'),
+        },
         esModule: false
       },
       cssModules: {
         importLoaders: 0,
+        url: {
+          filter: (url: string, resourcePath: string) => !url.startsWith('/'),
+        },
         esModule: false,
         modules: {
           localIdentName: '[local]_[hash:base64:5]'


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Whilst working on https://github.com/nuxt/framework/issues/3437, I discovered the following syntax is invalid in webpack:

```vue
<style>
.app {
  background-image: url('/logo.svg');
}
</style>
```

But we want this to be preserved (i.e. not included in build assets).

[**Documentation**](https://webpack.js.org/loaders/css-loader/#url)