### PR TITLE
fix(kit): avoid behavior change based on NODE_ENV

### DIFF
--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -1,24 +1,34 @@
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
-import type { Nuxt, NuxtConfig } from '@nuxt/schema'
+import type { Nuxt } from '@nuxt/schema'
 import { importModule, tryImportModule, RequireModuleOptions } from '../internal/cjs'
 import type { LoadNuxtConfigOptions } from './config'
 
 export interface LoadNuxtOptions extends LoadNuxtConfigOptions {
-  rootDir: string
+  /** Load nuxt with development mode */
   dev?: boolean
-  config?: NuxtConfig
-  configFile?: string
+
+  /** Use lazy initialization of nuxt if set to false */
   ready?: boolean
+
+  /** @deprecated Use cwd option */
+  rootDir: LoadNuxtConfigOptions['cwd']
+
+  /** @deprecated use overrides option */
+  config?: LoadNuxtConfigOptions['overrides']
 }
 
 export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
-  const resolveOpts: RequireModuleOptions = { paths: opts.rootDir }
+  const resolveOpts: RequireModuleOptions = { paths: opts.cwd }
+
+  // Backward compatibility
+  opts.cwd = opts.cwd || opts.rootDir
+  opts.overrides = opts.overrides || opts.config || {}
 
   const nearestNuxtPkg = await Promise.all(['nuxt3', 'nuxt-edge', 'nuxt']
-    .map(pkg => resolvePackageJSON(pkg, { url: opts.rootDir }).catch(() => null)))
+    .map(pkg => resolvePackageJSON(pkg, { url: opts.cwd }).catch(() => null)))
     .then(r => r.filter(Boolean).sort((a, b) => b.length - a.length)[0])
   if (!nearestNuxtPkg) {
-    throw new Error(`Cannot find any nuxt version from ${opts.rootDir}`)
+    throw new Error(`Cannot find any nuxt version from ${opts.cwd}`)
   }
   const pkg = await readPackageJSON(nearestNuxtPkg)
   const majorVersion = parseInt((pkg.version || '').split('.')[0])
@@ -33,9 +43,9 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Nuxt 2
   const { loadNuxt } = await tryImportModule('nuxt-edge', resolveOpts) || await importModule('nuxt', resolveOpts)
   const nuxt = await loadNuxt({
-    rootDir: opts.rootDir,
+    rootDir: opts.cwd,
     for: opts.dev ? 'dev' : 'build',
-    configOverrides: opts.config,
+    configOverrides: opts.overrides,
     ready: opts.ready,
     envConfig: opts.dotenv // TODO: Backward format convertion
   })

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -24,6 +24,11 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   opts.cwd = opts.cwd || opts.rootDir
   opts.overrides = opts.overrides || opts.config || {}
 
+  // Apply dev as config override
+  if (opts.dev) {
+    opts.overrides.dev = true
+  }
+
   const nearestNuxtPkg = await Promise.all(['nuxt3', 'nuxt-edge', 'nuxt']
     .map(pkg => resolvePackageJSON(pkg, { url: opts.cwd }).catch(() => null)))
     .then(r => r.filter(Boolean).sort((a, b) => b.length - a.length)[0])

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -25,9 +25,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   opts.overrides = opts.overrides || opts.config || {}
 
   // Apply dev as config override
-  if (opts.dev) {
-    opts.overrides.dev = true
-  }
+  opts.overrides.dev = !!opts.dev
 
   const nearestNuxtPkg = await Promise.all(['nuxt3', 'nuxt-edge', 'nuxt']
     .map(pkg => resolvePackageJSON(pkg, { url: opts.cwd }).catch(() => null)))

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -11,18 +11,18 @@ export interface LoadNuxtOptions extends LoadNuxtConfigOptions {
   ready?: boolean
 
   /** @deprecated Use cwd option */
-  rootDir: LoadNuxtConfigOptions['cwd']
+  rootDir?: LoadNuxtConfigOptions['cwd']
 
   /** @deprecated use overrides option */
   config?: LoadNuxtConfigOptions['overrides']
 }
 
 export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
-  const resolveOpts: RequireModuleOptions = { paths: opts.cwd }
-
   // Backward compatibility
   opts.cwd = opts.cwd || opts.rootDir
   opts.overrides = opts.overrides || opts.config || {}
+
+  const resolveOpts: RequireModuleOptions = { paths: opts.cwd }
 
   // Apply dev as config override
   opts.overrides.dev = !!opts.dev

--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -49,8 +49,8 @@ export async function loadFixture () {
   })
 
   ctx.nuxt = await kit.loadNuxt({
-    rootDir: ctx.options.rootDir,
-    config: ctx.options.nuxtConfig,
+    cwd: ctx.options.rootDir,
+    overrides: ctx.options.nuxtConfig,
     configFile: ctx.options.configFile
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3262

related https://github.com/nuxt/framework/pull/3693#discussion_r828560787

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If NODE_ENV is set to anything other than `development`, `nuxi dev` will build for production! This issue was because we weren't setting `dev` override and nuxt falling back to std-env to detect it.

As to fix the root-cause, kit purely depends on C12 config types to avoid creating confusing interfaces that made this issue happen.

Options of `loadNuxt` changes (rootDir => cwd, config => overides) but preserved as backward compatibility. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

