### PR TITLE
feat(test-utils): test in development mode

### DIFF
--- a/examples/with-test/tests/basic.test.ts
+++ b/examples/with-test/tests/basic.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'url'
 import { describe, expect, it } from 'vitest'
-import { setup, $fetch } from '@nuxt/test-utils'
+import { setup, $fetch, isDev } from '@nuxt/test-utils'
 
 describe('example', async () => {
   await setup({
@@ -11,4 +11,10 @@ describe('example', async () => {
   it('Renders Hello Nuxt', async () => {
     expect(await $fetch('/')).toMatch('Hello Nuxt!')
   })
+
+  if (isDev()) {
+    it('[dev] ensure vite client script is added', async () => {
+      expect(await $fetch('/')).toMatch('/_nuxt/@vite/client"')
+    })
+  }
 })

--- a/packages/nuxi/src/commands/test.ts
+++ b/packages/nuxi/src/commands/test.ts
@@ -4,7 +4,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'test',
-    usage: 'npx nuxi test',
+    usage: 'npx nuxi test [--dev] [--watch] [rootDir]',
     description: 'Run tests'
   },
   async invoke (args) {
@@ -12,7 +12,9 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
     const { runTests } = await importTestUtils()
     await runTests({
-      rootDir
+      rootDir,
+      dev: !!args.dev,
+      watch: !!args.watch
     })
   }
 })

--- a/packages/test-utils/build.config.ts
+++ b/packages/test-utils/build.config.ts
@@ -10,6 +10,7 @@ export default defineBuildConfig({
   externals: [
     'vitest',
     'playwright',
-    'playwright-core'
+    'playwright-core',
+    'listhen'
   ]
 })

--- a/packages/test-utils/src/context.ts
+++ b/packages/test-utils/src/context.ts
@@ -10,6 +10,7 @@ export function createTestContext (options: Partial<TestOptions>): TestContext {
     fixture: 'fixture',
     configFile: 'nuxt.config',
     setupTimeout: 60000,
+    dev: !!JSON.parse(process.env.NUXT_TEST_DEV || 'true'),
     logLevel: 1,
     server: options.browser,
     build: options.browser || options.server,
@@ -34,4 +35,9 @@ export function useTestContext (): TestContext {
 export function setTestContext (context: TestContext): TestContext {
   currentContext = context
   return currentContext
+}
+
+export function isDev () {
+  const ctx = useTestContext()
+  return ctx.options.dev
 }

--- a/packages/test-utils/src/context.ts
+++ b/packages/test-utils/src/context.ts
@@ -10,7 +10,7 @@ export function createTestContext (options: Partial<TestOptions>): TestContext {
     fixture: 'fixture',
     configFile: 'nuxt.config',
     setupTimeout: 60000,
-    dev: !!JSON.parse(process.env.NUXT_TEST_DEV || 'true'),
+    dev: !!JSON.parse(process.env.NUXT_TEST_DEV || 'false'),
     logLevel: 1,
     server: options.browser,
     build: options.browser || options.server,

--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -50,6 +50,7 @@ export async function loadFixture () {
 
   ctx.nuxt = await kit.loadNuxt({
     cwd: ctx.options.rootDir,
+    dev: ctx.options.dev,
     overrides: ctx.options.nuxtConfig,
     configFile: ctx.options.configFile
   })

--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -1,5 +1,7 @@
 export interface RunTestOptions {
   rootDir: string,
+  dev?: boolean,
+  watch?: boolean
   runner?: 'vitest'
 }
 
@@ -13,13 +15,19 @@ export async function runTests (opts: RunTestOptions) {
   if (opts.runner !== 'vitest') {
     throw new Error(`Unsupported runner: ${opts.runner}. Currently only vitest runner is supported.`)
   }
+
+  if (opts.dev) {
+    // Set default dev option for @nuxt/test-utils
+    process.env.NUXT_TEST_DEV = 'true'
+  }
+
   const { startVitest } = await import('vitest/dist/node.js')
   const succeeded = await startVitest(
     [] /* argv */,
     // Vitest options
     {
       root: opts.rootDir,
-      run: true
+      run: !opts.watch
     },
     // Vite options
     {

--- a/packages/test-utils/src/server.ts
+++ b/packages/test-utils/src/server.ts
@@ -10,7 +10,7 @@ export async function startServer () {
   const port = await getRandomPort()
   ctx.url = 'http://localhost:' + port
   if (ctx.options.dev) {
-    await ctx.nuxt.server.listen(port)
+    ctx.listener = await ctx.nuxt.server.listen(port)
     await waitForPort(port, { retries: 8 })
     for (let i = 0; i < 50; i++) {
       await new Promise(resolve => setTimeout(resolve, 100))
@@ -39,6 +39,9 @@ export async function stopServer () {
   const ctx = useTestContext()
   if (ctx.serverProcess) {
     await ctx.serverProcess.kill()
+  }
+  if (ctx.listener) {
+    await ctx.listener.close()
   }
 }
 

--- a/packages/test-utils/src/server.ts
+++ b/packages/test-utils/src/server.ts
@@ -24,7 +24,7 @@ export async function startServer () {
     ctx.serverProcess = execa('node', [
       resolve(ctx.nuxt.options.nitro.output.dir, 'server/index.mjs')
     ], {
-      stdout: 'inherit',
+      stdio: 'inherit',
       env: {
         ...process.env,
         PORT: String(port),

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -12,6 +12,7 @@ export interface TestOptions {
   buildDir: string
   nuxtConfig: NuxtConfig
   build: boolean
+  dev: boolean
   setupTimeout: number
   waitFor: number
   browser: boolean

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -1,6 +1,7 @@
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { ExecaChildProcess } from 'execa'
 import type { Browser, LaunchOptions } from 'playwright'
+import type { Listener } from 'listhen'
 
 export type TestRunner = 'vitest' | 'jest'
 
@@ -31,6 +32,7 @@ export interface TestContext {
   browser?: Browser
   url?: string
   serverProcess?: ExecaChildProcess
+  listener?: Listener
 }
 
 export interface TestHooks {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Rework of #3693

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow testing nuxt build in development mode:

- Add new `dev` option to test utils
- Support `--dev` and `--watch` to `nuxi test`
- Add new `isDev()` utility from `@nuxt/test-utils` to check if testing in development environment
- Directly use nitro server listener
- (prod) Inherit stdio for process

To be improved: Wating for loading is via a loop to fetch and check payload. We could improve state management (hooks are unreliable for this since both nitro and vite need to be done) (~> #730)

Try: `yarn nuxi test examples/with-test --dev`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

