### PR TITLE
fix(nuxt3): warn if builder can't be loaded

### DIFF
--- a/packages/nuxt3/src/core/builder.ts
+++ b/packages/nuxt3/src/core/builder.ts
@@ -55,10 +55,15 @@ function watch (nuxt: Nuxt) {
 }
 
 async function bundle (nuxt: Nuxt) {
-  const { bundle } = typeof nuxt.options.builder === 'string'
-    ? await tryImportModule(nuxt.options.builder, { paths: nuxt.options.rootDir })
-    : nuxt.options.builder
   try {
+    const { bundle } = typeof nuxt.options.builder === 'string'
+      ? await tryImportModule(nuxt.options.builder, { paths: nuxt.options.rootDir }) || {}
+      : nuxt.options.builder
+
+    if (!bundle) {
+      throw new Error(`[nuxt] Could not load \`${nuxt.options.builder}\`. Is it in your project dependencies?`)
+    }
+
     return bundle(nuxt)
   } catch (error) {
     await nuxt.callHook('build:error', error)

--- a/packages/nuxt3/src/core/builder.ts
+++ b/packages/nuxt3/src/core/builder.ts
@@ -1,6 +1,6 @@
 import chokidar from 'chokidar'
 import type { Nuxt } from '@nuxt/schema'
-import { isIgnored, tryImportModule } from '@nuxt/kit'
+import { importModule, isIgnored } from '@nuxt/kit'
 import { debounce } from 'perfect-debounce'
 import { createApp, generateApp as _generateApp } from './app'
 
@@ -57,16 +57,19 @@ function watch (nuxt: Nuxt) {
 async function bundle (nuxt: Nuxt) {
   try {
     const { bundle } = typeof nuxt.options.builder === 'string'
-      ? await tryImportModule(nuxt.options.builder, { paths: nuxt.options.rootDir }) || {}
+      ? await importModule(nuxt.options.builder, { paths: nuxt.options.rootDir })
       : nuxt.options.builder
-
-    if (!bundle) {
-      throw new Error(`[nuxt] Could not load \`${nuxt.options.builder}\`. Is it in your project dependencies?`)
-    }
 
     return bundle(nuxt)
   } catch (error) {
     await nuxt.callHook('build:error', error)
+
+    if (error.toString().includes('Cannot find module \'@nuxt/webpack-builder\'')) {
+      throw new Error([
+        'Could not load `@nuxt/webpack-builder`. You may need to add it to your project dependencies, following the steps in `https://github.com/nuxt/framework/pull/2812`.'
+      ].join('\n'))
+    }
+
     throw error
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3759

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a better error when `@nuxt/webpack-builder` can't be resolved in the project.

```
 ERROR  Cannot start nuxt:  [nuxt] Could not load @nuxt/webpack-builder. Is it in your project dependencies?        09:42:31

  at bundle (packages/nuxt3/src/core/builder.ts:64:13)
  at async build (packages/nuxt3/src/core/builder.ts:30:5)
  at async Promise.all (index 1)
  at async load (packages/nuxi/src/commands/dev.ts:53:9)
  at async Object.invoke (packages/nuxi/src/commands/dev.ts:97:5)
  at async _main (packages/nuxi/src/cli.ts:37:7)

```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

