### PR TITLE
fix(webpack): add `exportOnlyLocals: true` for css modules options in server build.

### DIFF
--- a/packages/webpack/src/presets/style.ts
+++ b/packages/webpack/src/presets/style.ts
@@ -99,7 +99,7 @@ function createCssLoadersRule (ctx: WebpackConfigContext, cssLoaderOptions) {
     if (ctx.isServer) {
       // https://webpack.js.org/loaders/css-loader/#exportonlylocals
       if (cssLoader.options.modules) {
-        cssLoader.options.modules.exportOnlyLocals = true
+        cssLoader.options.modules.exportOnlyLocals = cssLoader.options.modules.exportOnlyLocals ?? true
       }
       return [cssLoader]
     }

--- a/packages/webpack/src/presets/style.ts
+++ b/packages/webpack/src/presets/style.ts
@@ -97,6 +97,10 @@ function createCssLoadersRule (ctx: WebpackConfigContext, cssLoaderOptions) {
 
   if (options.webpack.extractCSS) {
     if (ctx.isServer) {
+      // https://webpack.js.org/loaders/css-loader/#exportonlylocals
+      if (cssLoader.options.modules) {
+        cssLoader.options.modules.exportOnlyLocals = true
+      }
       return [cssLoader]
     }
 


### PR DESCRIPTION


<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As css-loader documentation says, for css modules pre-rendering with `mini-css-extract-plugin` we should use `modules.exportOnlyLocals: true` in server build.  

https://webpack.js.org/loaders/css-loader/#exportonlylocals

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

