### PR TITLE
fix(nuxt3): improve component loading behaviour

### DIFF
--- a/packages/nuxt3/src/components/loader.ts
+++ b/packages/nuxt3/src/components/loader.ts
@@ -4,6 +4,7 @@ import { parseQuery, parseURL } from 'ufo'
 import { Component } from '@nuxt/schema'
 import { genImport } from 'knitwork'
 import MagicString from 'magic-string'
+import { pascalCase } from 'scule'
 
 interface LoaderOptions {
   getComponents(): Component[]
@@ -24,8 +25,9 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => ({
   }
 }))
 
-function findComponent (components: Component[], name:string) {
-  return components.find(({ pascalName, kebabName }) => [pascalName, kebabName].includes(name))
+function findComponent (components: Component[], name: string) {
+  const id = pascalCase(name)
+  return components.find(component => id === component.pascalName)
 }
 
 function transform (code: string, id: string, components: Component[]) {

--- a/packages/nuxt3/src/components/loader.ts
+++ b/packages/nuxt3/src/components/loader.ts
@@ -30,7 +30,7 @@ function findComponent (components: Component[], name:string) {
 
 function transform (code: string, id: string, components: Component[]) {
   let num = 0
-  let imports = ''
+  const imports = new Set<string>()
   const map = new Map<Component, string>()
   const s = new MagicString(code)
 
@@ -40,15 +40,15 @@ function transform (code: string, id: string, components: Component[]) {
     if (component) {
       const identifier = map.get(component) || `__nuxt_component_${num++}`
       map.set(component, identifier)
-      imports += genImport(component.filePath, [{ name: component.export, as: identifier }])
+      imports.add(genImport(component.filePath, [{ name: component.export, as: identifier }]))
       return ` ${identifier}`
     }
     // no matched
     return full
   })
 
-  if (imports) {
-    s.prepend(imports + '\n')
+  if (imports.size) {
+    s.prepend([...imports, ''].join('\n'))
   }
 
   if (s.hasChanged()) {

--- a/packages/nuxt3/src/components/loader.ts
+++ b/packages/nuxt3/src/components/loader.ts
@@ -26,7 +26,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => ({
 }))
 
 function findComponent (components: Component[], name: string) {
-  const id = pascalCase(name)
+  const id = pascalCase(name).replace(/["']/g, '')
   return components.find(component => id === component.pascalName)
 }
 

--- a/packages/nuxt3/src/components/scan.ts
+++ b/packages/nuxt3/src/components/scan.ts
@@ -3,12 +3,7 @@ import { globby } from 'globby'
 import { pascalCase, splitByCase } from 'scule'
 import type { Component, ComponentsDir } from '@nuxt/schema'
 import { isIgnored } from '@nuxt/kit'
-
-// vue@2 src/shared/util.js
-// TODO: update to vue3?
-function hyphenate (str: string): string {
-  return str.replace(/\B([A-Z])/g, '-$1').toLowerCase()
-}
+import { hyphenate } from '@vue/shared'
 
 /**
  * Scan the components inside different components folders


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3678, resolves https://github.com/nuxt/framework/issues/3739

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

* Vue can call resolveComponent more than once when kebab + pascal case are both used in template. This deduplicates imports with a Set.
* We also convert to pascal case when resolving as there is an edge case with numbers and the following are all valid ways of referring to the same component in Vue: `<Oscars2022>`, `<oscars-2022>` and `<oscars2022>`
* I also spotted an opportunity to use the helper function from Vue 3 rather than a copy of it.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

