### PR TITLE
fix(nitro): don't include current project's layer twice

### DIFF
--- a/packages/nitro/src/build.ts
+++ b/packages/nitro/src/build.ts
@@ -177,10 +177,7 @@ function startRollupWatcher (nitroContext: NitroContext) {
 async function _watch (nitroContext: NitroContext) {
   let watcher = startRollupWatcher(nitroContext)
 
-  const serverDirs = [
-    ...nitroContext._layers.map(layer => layer.serverDir),
-    nitroContext._nuxt.serverDir
-  ]
+  const serverDirs = nitroContext._layers.map(layer => layer.serverDir)
 
   nitroContext.scannedMiddleware = (
     await Promise.all(serverDirs.map(async dir => await scanMiddleware(dir,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Regression in https://github.com/nuxt/framework/pull/3717. Root package server dir was included twice here (though removed elsewhere).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

