### PR TITLE
feat(nuxt3): support auto-loading lazy and custom-resolved components

### DIFF
--- a/docs/content/3.docs/2.directory-structure/4.components.md
+++ b/docs/content/3.docs/2.directory-structure/4.components.md
@@ -47,6 +47,39 @@ If you have a component in nested directories such as:
 For clarity, we recommend that the component's file name matches its name. (So, in the example above, you could rename `Button.vue` to be `BaseFooButton.vue`.)
 ::
 
+## Dynamic components
+
+If you want to use the Vue `<component :is="someComputedComponent">` syntax, then you will need to use the `resolveComponent` helper provided by Vue.
+
+For example:
+
+```vue
+<template>
+  <component :is="clickable ? MyButton : 'div'" />
+</template>
+
+<script setup>
+const MyButton = resolveComponent('MyButton')
+</script>
+```
+
+Alternatively, though not recommended, you can register all your components globally, which will create async chunks for all your components and make them available throughout your application.
+
+```diff
+  import { defineNuxtConfig } from 'nuxt3'
+  
+  export default defineNuxtConfig({
+    components: {
++     global: true,
++     dirs: ['~/components']
+    },
+  })
+```
+
+::alert{type=info}
+The `global` option can also be set per component directory.
+::
+
 ## Dynamic Imports
 
 To dynamically import a component (also known as lazy-loading a component) all you need to do is add the `Lazy` prefix to the component's name.

--- a/packages/nuxt3/src/auto-imports/presets.ts
+++ b/packages/nuxt3/src/auto-imports/presets.ts
@@ -104,6 +104,7 @@ export const vuePreset = defineUnimportPreset({
     // Component
     'defineComponent',
     'defineAsyncComponent',
+    'resolveComponent',
     'getCurrentInstance',
     'h',
     'inject',

--- a/packages/nuxt3/src/components/templates.ts
+++ b/packages/nuxt3/src/components/templates.ts
@@ -51,6 +51,7 @@ export const componentsTypeTemplate = {
 declare module 'vue' {
   export interface GlobalComponents {
 ${options.components.map(c => `    '${c.pascalName}': typeof ${genDynamicImport(isAbsolute(c.filePath) ? relative(join(options.buildDir, 'types'), c.filePath) : c.filePath, { wrapper: false })}['${c.export}']`).join(',\n')}
+${options.components.map(c => `    'Lazy${c.pascalName}': typeof ${genDynamicImport(isAbsolute(c.filePath) ? relative(join(options.buildDir, 'types'), c.filePath) : c.filePath, { wrapper: false })}['${c.export}']`).join(',\n')}
   }
 }
 export {}

--- a/packages/schema/src/config/_adhoc.ts
+++ b/packages/schema/src/config/_adhoc.ts
@@ -9,6 +9,8 @@ export default {
    * @see [Nuxt 3](https://v3.nuxtjs.org/docs/directory-structure/components) and
    * [Nuxt 2](https://nuxtjs.org/docs/directory-structure/components/) documentation
    * @type {boolean | typeof import('../src/types/components').ComponentsOptions | typeof import('../src/types/components').ComponentsOptions['dirs']}
+   * @version 2
+   * @version 3
    */
   components: {
     $resolve: (val, get) => {
@@ -27,6 +29,7 @@ export default {
    *
    * @see [Nuxt 3 documentation](https://v3.nuxtjs.org/docs/directory-structure/composables)
    * @type {typeof import('../src/types/imports').AutoImportsOptions}
+   * @version 3
    */
   autoImports: {
     global: false,


### PR DESCRIPTION
### 🔗 Linked issue

for example, https://github.com/nuxt/framework/issues/3672 - though not marking as resolving it as we may also wish to globally register `NuxtLink`

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR:

* adds components and autoImports keys to `nuxt.config` documentation
* supports auto-loading `Lazy`-prefixed components
* adds type-hinting for `Lazy`-prefixed components
* supports custom resolving components with `resolveComponent` (to allow users to do more elaborate dynamic components without needing to set `global: true`, which can have a negative performance effect). See https://github.com/nuxt/framework/issues/3672 for example.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

