### PR TITLE
docs: deprecate `buildModules` in schema

### DIFF
--- a/docs/content/3.docs/2.directory-structure/4.components.md
+++ b/docs/content/3.docs/2.directory-structure/4.components.md
@@ -160,7 +160,7 @@ That's it! Now in your project, you can import your ui library as a Nuxt module 
 
 ```js
 export default {
-  buildModules: ['awesome-ui/nuxt']
+  modules: ['awesome-ui/nuxt']
 }
 ```
 

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -271,13 +271,13 @@ export default {
    * ]
    * ```
    *
-   * @note Using `buildModules` helps to make production startup faster and also significantly
+   * @note In Nuxt 2, using `buildModules` helps to make production startup faster and also significantly
    * decreases the size of `node_modules` in production deployments. Please refer to each
    * module's documentation to see if it is recommended to use `modules` or `buildModules`.
    *
    * @type {(typeof import('../src/types/module').NuxtModule | string | [typeof import('../src/types/module').NuxtModule | string, Record<string, any>])[]}
    * @version 2
-   * @version 3
+   * @deprecated This is no longer needed in Nuxt 3 and Nuxt Bridge; all modules should be added to `modules` instead.
    */
   buildModules: [],
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3829

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There is now no concept of runtime vs build-time module, so it makes sense to deprecate `buildModules` as an option in Nuxt config for Bridge and Nuxt 3. Possible future enhancement - use schema 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

