### PR TITLE
fix(vite): resolve '#_config' in base plugin

### DIFF
--- a/packages/vite/src/plugins/dynamic-base.ts
+++ b/packages/vite/src/plugins/dynamic-base.ts
@@ -40,6 +40,7 @@ export const DynamicBasePlugin = createUnplugin(function (options: DynamicBasePl
       if (id.startsWith('/__NUXT_BASE__')) {
         return id.replace('/__NUXT_BASE__', '')
       }
+      if (id === '#_config') { return '#_config' }
       return null
     },
     enforce: 'post',

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -62,7 +62,6 @@ export async function buildServer (ctx: ViteBuildContext) {
           preferConst: true,
           format: 'module'
         },
-        external: ['#config'],
         onwarn (warning, rollupWarn) {
           if (!['UNUSED_EXTERNAL_IMPORT'].includes(warning.code)) {
             rollupWarn(warning)

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -82,7 +82,7 @@ export async function bundle (nuxt: Nuxt) {
             ]
           }
         }
-      },
+      } as ViteOptions,
       nuxt.options.vite
     )
   }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Regression from https://github.com/nuxt/framework/pull/3757. Prints out the following harmless warning:

```bash
 WARN  [SSR] Error transforming virtual:/playground/.nuxt/paths.mjs: Failed to resolve import "#_config" from "virtual:/playground/.nuxt/paths.mjs". Does the file exist?

  at formatError (node_modules/vite/dist/node/chunks/dep-9c153816.js:38098:46)
  at TransformContext.error (node_modules/vite/dist/node/chunks/dep-9c153816.js:38094:19)
  at normalizeUrl (node_modules/vite/dist/node/chunks/dep-9c153816.js:69819:26)
  at processTicksAndRejections (internal/process/task_queues.js:95:5)
  at async TransformContext.transform (node_modules/vite/dist/node/chunks/dep-9c153816.js:69959:57)
  at async Object.transform (node_modules/vite/dist/node/chunks/dep-9c153816.js:38334:30)
  at async doTransform (node_modules/vite/dist/node/chunks/dep-9c153816.js:53030:29)
```

This PR resolves the alias so no errors are printed.