### PR TITLE
fix(nuxt3): use `path` for uniqueness of routes when resolving

### DIFF
--- a/packages/nuxt3/src/pages/utils.ts
+++ b/packages/nuxt3/src/pages/utils.ts
@@ -40,7 +40,7 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
     })
   )).flat()
 
-  return uniqueBy(allRoutes, 'name')
+  return uniqueBy(allRoutes, 'path')
 }
 
 export function generateRoutesFromFiles (files: string[], pagesDir: string): NuxtPage[] {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -91,6 +91,16 @@ describe('pages', () => {
     expect(html).toContain('foo: foobar')
     expect(html).toContain('group: admin')
   })
+
+  it('/parent', async () => {
+    const html = await $fetch('/parent')
+    expect(html).toContain('parent/index')
+  })
+
+  it('/another-parent', async () => {
+    const html = await $fetch('/another-parent')
+    expect(html).toContain('another-parent/index')
+  })
 })
 
 describe('navigate', () => {

--- a/test/fixtures/basic/pages/another-parent.vue
+++ b/test/fixtures/basic/pages/another-parent.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    another-parent
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/another-parent/index.vue
+++ b/test/fixtures/basic/pages/another-parent/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    another-parent/index
+  </div>
+</template>

--- a/test/fixtures/basic/pages/parent.vue
+++ b/test/fixtures/basic/pages/parent.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    parent
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/parent/index.vue
+++ b/test/fixtures/basic/pages/parent/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    parent/index
+  </div>
+</template>


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Uniqueness by `name` was a mistake has multiple routes may have `name === undefined` (parents of sub routes).
Routes must be unique by their `path`.

Resolves #3892 