### PR TITLE
fix(nuxt3): avoid `#_config` app import in dev mode

### DIFF
--- a/packages/nuxt3/src/core/templates.ts
+++ b/packages/nuxt3/src/core/templates.ts
@@ -179,7 +179,7 @@ export const publicPathTemplate: NuxtTemplate = {
   getContents ({ nuxt }) {
     return [
       'import { joinURL } from \'ufo\'',
-      'import config from \'#_config\'',
+      !nuxt.options.dev && 'import config from \'#_config\'',
 
       nuxt.options.dev
         ? `const appConfig = ${JSON.stringify(nuxt.options.app)}`
@@ -194,6 +194,6 @@ export const publicPathTemplate: NuxtTemplate = {
       '  const publicBase = appConfig.cdnURL || appConfig.baseURL',
       '  return path.length ? joinURL(publicBase, ...path) : publicBase',
       '}'
-    ].join('\n')
+    ].filter(Boolean).join('\n')
   }
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is an oversight from https://github.com/nuxt/framework/pull/3757 - we are not using this import.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

