### PR TITLE
fix(nuxt3): improve types of `uniqueBy` utility

### DIFF
--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -106,14 +106,13 @@ function getNameFromPath (path: string) {
   return kebabCase(basename(path).replace(extname(path), '')).replace(/["']/g, '')
 }
 
-function uniqueBy (arr: any[], uniqueKey: string) {
-  const seen = new Set<string>()
+function uniqueBy <T, K extends keyof T> (arr: T[], key: K) {
   const res = []
-  for (const i of arr) {
-    const key = i[uniqueKey]
-    if (seen.has(key)) { continue }
-    res.push(i)
-    seen.add(key)
+  const seen = new Set<T[K]>()
+  for (const item of arr) {
+    if (seen.has(item[key])) { continue }
+    seen.add(item[key])
+    res.push(item)
   }
   return res
 }

--- a/packages/nuxt3/src/core/app.ts
+++ b/packages/nuxt3/src/core/app.ts
@@ -107,7 +107,7 @@ function getNameFromPath (path: string) {
 }
 
 function uniqueBy <T, K extends keyof T> (arr: T[], key: K) {
-  const res = []
+  const res: T[] = []
   const seen = new Set<T[K]>()
   for (const item of arr) {
     if (seen.has(item[key])) { continue }

--- a/packages/nuxt3/src/pages/utils.ts
+++ b/packages/nuxt3/src/pages/utils.ts
@@ -273,7 +273,7 @@ export function getImportName (name: string) {
 }
 
 function uniqueBy <T, K extends keyof T> (arr: T[], key: K) {
-  const res = []
+  const res: T[] = []
   const seen = new Set<T[K]>()
   for (const item of arr) {
     if (seen.has(item[key])) { continue }

--- a/packages/nuxt3/src/pages/utils.ts
+++ b/packages/nuxt3/src/pages/utils.ts
@@ -272,14 +272,12 @@ export function getImportName (name: string) {
   return pascalCase(name).replace(/[^\w]/g, '')
 }
 
-function uniqueBy (arr: any[], key: string) {
+function uniqueBy <T, K extends keyof T> (arr: T[], key: K) {
   const res = []
-  const keys = new Set<string>()
+  const seen = new Set<T[K]>()
   for (const item of arr) {
-    if (keys.has(item[key])) {
-      continue
-    }
-    keys.add(item[key])
+    if (seen.has(item[key])) { continue }
+    seen.add(item[key])
     res.push(item)
   }
   return res


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

Improves types for the `uniqueBy` utility function, enabling autocompletion on second parameter `key` 😎

![image](https://user-images.githubusercontent.com/25272043/160115581-c8ec780c-38c1-4db0-b814-d993c3e6a8b8.png)


@pi0 This utility being used at two places in the same package (**nuxt3**), I'll let you refactor it to only define it once somewhere :)

