### PR TITLE
fix(bridge): don't double-install plugins when using compat `vueApp.use`

### DIFF
--- a/docs/content/1.getting-started/3.bridge.md
+++ b/docs/content/1.getting-started/3.bridge.md
@@ -194,6 +194,10 @@ export default defineNuxtPlugin(nuxtApp => {
 If you want to use the new Nuxt composables (such as `useNuxtApp` or `useRuntimeConfig`) within your plugins, you will need to use the `defineNuxtPlugin` helper for those plugins.
 ::
 
+::alert{type=warning}
+Although a compatibility interface is provided via `nuxtApp.vueApp` you should avoid registering plugins, directives, mixins or components this way without adding your own logic to ensure they are not installed more than once, or this may cause a memory leak.
+::
+
 ## New `useMeta` (optional)
 
 Nuxt Bridge provides a new Nuxt 3 meta API that can be accessed with a new `useMeta` composable.

--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -19,22 +19,29 @@ function proxiedState (state) {
   })
 }
 
+const runOnceWith = (obj, fn) => {
+  if (!obj || !['function', 'object'].includes(typeof obj)) {
+    return fn()
+  }
+  if (obj.__nuxt_installed) { return }
+  obj.__nuxt_installed = true
+  return fn()
+}
+
 export default async (ctx, inject) => {
   const nuxtApp = {
     vueApp: {
-      component: Vue.component.bind(Vue),
+      component: (id, definition) => runOnceWith(definition, () => Vue.component(id, definition)),
       config: {
         globalProperties: {}
       },
-      directive: Vue.directive.bind(Vue),
-      mixin: Vue.mixin.bind(Vue),
+      directive: (id, definition) => runOnceWith(definition, () => Vue.directive(id, definition)),
+      mixin: mixin => runOnceWith(mixin, () => Vue.mixin(mixin)),
       mount: () => { },
       provide: inject,
       unmount: () => { },
       use (vuePlugin) {
-        if (vuePlugin.__nuxt_installed) { return }
-        vuePlugin.__nuxt_installed = true
-        vuePlugin.install(this)
+        runOnceWith(vuePlugin, () => vuePlugin.install(this))
       },
       version: Vue.version
     },

--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -32,6 +32,8 @@ export default async (ctx, inject) => {
       provide: inject,
       unmount: () => { },
       use (vuePlugin) {
+        if (vuePlugin.__nuxt_installed) { return }
+        vuePlugin.__nuxt_installed = true
         vuePlugin.install(this)
       },
       version: Vue.version


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2037
resolves https://github.com/nuxt/framework/issues/3431

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds some protections against double installing plugins, components, etc. - and also a warning to avoid this usage in bridge without adding protection.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

