### PR TITLE
fix(bridge): don't call nuxt app if instance is inaccessible

### DIFF
--- a/packages/nuxt3/src/meta/runtime/plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/plugin.ts
@@ -14,9 +14,9 @@ const metaMixin = {
   [metaConfig.mixinKey] () {
     const instance = getCurrentInstance()
     const options = instance?.type || /* nuxt2 */ instance?.proxy?.$options
-    const nuxtApp = useNuxtApp()
     if (!options || !('head' in options)) { return }
 
+    const nuxtApp = useNuxtApp()
     const source = typeof options.head === 'function'
       ? computed(() => options.head(nuxtApp))
       : options.head

--- a/packages/nuxt3/src/meta/runtime/plugin.ts
+++ b/packages/nuxt3/src/meta/runtime/plugin.ts
@@ -13,7 +13,9 @@ declare module 'vue' {
 const metaMixin = {
   [metaConfig.mixinKey] () {
     const instance = getCurrentInstance()
-    const options = instance?.type || /* nuxt2 */ instance?.proxy?.$options
+    if (!instance) { return }
+
+    const options = instance.type || /* nuxt2 */ instance.proxy?.$options
     if (!options || !('head' in options)) { return }
 
     const nuxtApp = useNuxtApp()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #3904

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We don't need to call `useNuxtApp` (and indeed cannot) if there is no instance.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

