### PR TITLE
docs: remove unnecessary `return` in example

### DIFF
--- a/docs/content/3.docs/2.directory-structure/7.middleware.md
+++ b/docs/content/3.docs/2.directory-structure/7.middleware.md
@@ -27,9 +27,9 @@ Route middleware are navigation guards that receive the current route and the ne
 ```js
 export default defineNuxtRouteMiddleware((to, from) => {
   if (to.params.id === '1') {
-    return abortNavigation()
+    abortNavigation()
   }
-  return navigateTo('/')
+  navigateTo('/')
 })
 ```
 


### PR DESCRIPTION
No need to return `abortNavigation` and `navigateTo` in `defineNuxtRouteMiddleware`

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

Docs

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

No need to return `abortNavigation` and `navigateTo` in `defineNuxtRouteMiddleware`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

