### PR TITLE
fix(nuxi): respect `NUXT_PORT` and `NUXT_HOST` vars in dev mode

### DIFF
--- a/docs/content/3.docs/1.usage/8.cli.md
+++ b/docs/content/3.docs/1.usage/8.cli.md
@@ -35,6 +35,8 @@ Option        | Default          | Description
 `--ssl-cert` |`null` | Specify a certificate for https.
 `--ssl-key` |`null` | Specify the key for the https certificate.
 
+The port and host can also be set via NUXT_PORT, PORT, NUXT_HOST or HOST environment variables.
+
 This command sets `process.env.NODE_ENV` to `development`. To override, define `NODE_ENV` in a `.env` file or as command-line argument.
 
 ## Build

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -23,8 +23,8 @@ export default defineNuxtCommand({
     const listener = await server.listen({
       clipboard: args.clipboard,
       open: args.open || args.o,
-      port: args.port || args.p,
-      hostname: args.host || args.h,
+      port: args.port || args.p || process.env.NUXT_PORT,
+      hostname: args.host || args.h || process.env.NUXT_HOST,
       https: Boolean(args.https),
       certificate: (args['ssl-cert'] && args['ssl-key']) && {
         cert: args['ssl-cert'],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/3958

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Although not strictly a bug, it can be confusing for users for dev + server to have different env variables affecting port + host.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

