### PR TITLE
fix(vite-node): wrong entry been resolved in stub mode

### DIFF
--- a/packages/vite/src/runtime/server.mjs
+++ b/packages/vite/src/runtime/server.mjs
@@ -50,6 +50,8 @@ async function writeManifest () {
 let render
 
 export default async (ssrContext) => {
+  // Workaround for stub mode
+  // https://github.com/nuxt/framework/pull/3983
   process.server = true
   render = render || (await runner.executeFile(entry)).default
   const result = await render(ssrContext)

--- a/packages/vite/src/runtime/server.mjs
+++ b/packages/vite/src/runtime/server.mjs
@@ -50,6 +50,7 @@ async function writeManifest () {
 let render
 
 export default async (ssrContext) => {
+  process.server = true
   render = render || (await runner.executeFile(entry)).default
   const result = await render(ssrContext)
   await writeManifest()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Fixes https://github.com/nuxt/framework/pull/3974#issuecomment-1084166442

`process.server` was `undefined` so it resolved to the client entry and caused loaded app is an function instead of a server-rendered app. 

This only happens on the stub mode of development, but not the production build.
TBH I am not sure why it's happening and if this is the correct fix.

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

