### PR TITLE
feat(nuxt)!: use paylod cache for initial data fetching by default

### DIFF
--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -40,7 +40,7 @@ const {
   * _transform_: a function that can be used to alter `handler` function result after resolving
   * _pick_: only pick specified keys in this array from `handler` function result
   * _watch_: watch reactive sources to auto refresh
-  * _cache_: When set to `false`, will skip payload cache for initial fetch. (defaults to `true`)
+  * _initialCache_: When set to `false`, will skip payload cache for initial fetch. (defaults to `true`)
 
 Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the route before the data has been fetched. Consider using `lazy: true` and implementing a loading state instead for a snappier user experience.
 
@@ -115,7 +115,6 @@ const {
 Available options:
 
 * `key`: Provide a custom key
-* `cache`: Either a [RequestCache](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) strategy or `false` to skip initial paylod cache from asyncData.
 * Options from [ohmyfetch](https://github.com/unjs/ohmyfetch)
   * `method`: Request method
   * `params`: Query params

--- a/docs/content/3.docs/1.usage/1.data-fetching.md
+++ b/docs/content/3.docs/1.usage/1.data-fetching.md
@@ -16,12 +16,12 @@ Within your pages, components and plugins you can use `useAsyncData` to get acce
 const {
   data: Ref<DataT>,
   pending: Ref<boolean>,
-  refresh: (force?: boolean) => Promise<void>,
+  refresh: () => Promise<void>,
   error?: any
 } = useAsyncData(
   key: string,
   handler: (ctx?: NuxtApp) => Promise<Object>,
-  options?: { 
+  options?: {
     lazy: boolean,
     server: boolean,
     watch: WatchSource[]
@@ -40,6 +40,7 @@ const {
   * _transform_: a function that can be used to alter `handler` function result after resolving
   * _pick_: only pick specified keys in this array from `handler` function result
   * _watch_: watch reactive sources to auto refresh
+  * _cache_: When set to `false`, will skip payload cache for initial fetch. (defaults to `true`)
 
 Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the route before the data has been fetched. Consider using `lazy: true` and implementing a loading state instead for a snappier user experience.
 
@@ -114,6 +115,7 @@ const {
 Available options:
 
 * `key`: Provide a custom key
+* `cache`: Either a [RequestCache](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) strategy or `false` to skip initial paylod cache from asyncData.
 * Options from [ohmyfetch](https://github.com/unjs/ohmyfetch)
   * `method`: Request method
   * `params`: Query params

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -31,7 +31,7 @@ export interface RefreshOptions {
 export interface _AsyncData<DataT> {
   data: Ref<DataT>
   pending: Ref<boolean>
-  refrash: (opts?: RefreshOptions) => Promise<void>
+  refresh: (opts?: RefreshOptions) => Promise<void>
   error?: any
 }
 
@@ -87,7 +87,7 @@ export function useAsyncData<
     error: ref(nuxt.payload._errors[key] ?? null)
   } as AsyncData<DataT>
 
-  asyncData.refrash = (opts = {}) => {
+  asyncData.refresh = (opts = {}) => {
     // Avoid fetching same key more than once at a time
     if (nuxt._asyncDataPromises[key]) {
       return nuxt._asyncDataPromises[key]
@@ -125,7 +125,7 @@ export function useAsyncData<
     return nuxt._asyncDataPromises[key]
   }
 
-  const initialFetch = () => asyncData.refrash({ _initial: true })
+  const initialFetch = () => asyncData.refresh({ _initial: true })
 
   const fetchOnServer = options.server !== false && nuxt.payload.serverRendered
 

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -153,7 +153,7 @@ export function useAsyncData<
     }
     const off = nuxt.hook('app:data:refresh', (keys) => {
       if (!keys || keys.includes(key)) {
-        return initialFetch()
+        return asyncData.refresh()
       }
     })
     if (instance) {

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -24,14 +24,14 @@ export interface AsyncDataOptions<
   cache?: boolean
 }
 
-export interface RefrashOptions {
+export interface RefreshOptions {
   _initial?: boolean
 }
 
 export interface _AsyncData<DataT> {
   data: Ref<DataT>
   pending: Ref<boolean>
-  refrash: (opts?: RefrashOptions) => Promise<void>
+  refrash: (opts?: RefreshOptions) => Promise<void>
   error?: any
 }
 

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -21,12 +21,17 @@ export interface AsyncDataOptions<
   transform?: Transform
   pick?: PickKeys
   watch?: MultiWatchSources
+  cache?: boolean
+}
+
+export interface RefrashOptions {
+  _initial?: boolean
 }
 
 export interface _AsyncData<DataT> {
   data: Ref<DataT>
   pending: Ref<boolean>
-  refresh: (force?: boolean) => Promise<void>
+  refrash: (opts?: RefrashOptions) => Promise<void>
   error?: any
 }
 
@@ -58,6 +63,7 @@ export function useAsyncData<
     console.warn('[useAsyncData] `defer` has been renamed to `lazy`. Support for `defer` will be removed in RC.')
   }
   options.lazy = options.lazy ?? (options as any).defer ?? false
+  options.cache = options.cache ?? true
 
   // Setup nuxt instance payload
   const nuxt = useNuxtApp()
@@ -81,10 +87,14 @@ export function useAsyncData<
     error: ref(nuxt.payload._errors[key] ?? null)
   } as AsyncData<DataT>
 
-  asyncData.refresh = (force?: boolean) => {
+  asyncData.refrash = (opts = {}) => {
     // Avoid fetching same key more than once at a time
-    if (nuxt._asyncDataPromises[key] && !force) {
+    if (nuxt._asyncDataPromises[key]) {
       return nuxt._asyncDataPromises[key]
+    }
+    // Avoid fetching same key that is already fetched
+    if (opts._initial && options.cache && nuxt.payload.data[key] !== undefined) {
+      return nuxt.payload.data[key]
     }
     asyncData.pending.value = true
     // TODO: Cancel previous promise
@@ -115,11 +125,13 @@ export function useAsyncData<
     return nuxt._asyncDataPromises[key]
   }
 
+  const initialFetch = () => asyncData.refrash({ _initial: true })
+
   const fetchOnServer = options.server !== false && nuxt.payload.serverRendered
 
   // Server side
   if (process.server && fetchOnServer) {
-    const promise = asyncData.refresh()
+    const promise = initialFetch()
     onServerPrefetch(() => promise)
   }
 
@@ -131,17 +143,17 @@ export function useAsyncData<
     } else if (instance && (nuxt.isHydrating || options.lazy)) {
       // 2. Initial load (server: false): fetch on mounted
       // 3. Navigation (lazy: true): fetch on mounted
-      instance._nuxtOnBeforeMountCbs.push(asyncData.refresh)
+      instance._nuxtOnBeforeMountCbs.push(initialFetch)
     } else {
       // 4. Navigation (lazy: false) - or plugin usage: await fetch
-      asyncData.refresh()
+      initialFetch()
     }
     if (options.watch) {
-      watch(options.watch, () => asyncData.refresh())
+      watch(options.watch, () => initialFetch())
     }
     const off = nuxt.hook('app:data:refresh', (keys) => {
       if (!keys || keys.includes(key)) {
-        return asyncData.refresh()
+        return initialFetch()
       }
     })
     if (instance) {

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -149,7 +149,7 @@ export function useAsyncData<
       initialFetch()
     }
     if (options.watch) {
-      watch(options.watch, () => initialFetch())
+      watch(options.watch, () => asyncData.refresh())
     }
     const off = nuxt.hook('app:data:refresh', (keys) => {
       if (!keys || keys.includes(key)) {

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -21,7 +21,7 @@ export interface AsyncDataOptions<
   transform?: Transform
   pick?: PickKeys
   watch?: MultiWatchSources
-  cache?: boolean
+  initialCache?: boolean
 }
 
 export interface RefreshOptions {
@@ -63,7 +63,7 @@ export function useAsyncData<
     console.warn('[useAsyncData] `defer` has been renamed to `lazy`. Support for `defer` will be removed in RC.')
   }
   options.lazy = options.lazy ?? (options as any).defer ?? false
-  options.cache = options.cache ?? true
+  options.initialCache = options.initialCache ?? true
 
   // Setup nuxt instance payload
   const nuxt = useNuxtApp()
@@ -93,7 +93,7 @@ export function useAsyncData<
       return nuxt._asyncDataPromises[key]
     }
     // Avoid fetching same key that is already fetched
-    if (opts._initial && options.cache && nuxt.payload.data[key] !== undefined) {
+    if (opts._initial && options.initialCache && nuxt.payload.data[key] !== undefined) {
       return nuxt.payload.data[key]
     }
     asyncData.pending.value = true

--- a/packages/nuxt3/src/app/composables/fetch.ts
+++ b/packages/nuxt3/src/app/composables/fetch.ts
@@ -12,10 +12,9 @@ export interface UseFetchOptions<
   Transform extends _Transform<DataT, any> = _Transform<DataT, DataT>,
   PickKeys extends KeyOfRes<Transform> = KeyOfRes<Transform>
 > extends
-  Omit<AsyncDataOptions<DataT, Transform, PickKeys>, 'cache'>,
-  Omit<FetchOptions, 'cache'>
+  AsyncDataOptions<DataT, Transform, PickKeys>,
+  FetchOptions
   {
-  cache?: boolean | RequestCache,
   key?: string
  }
 
@@ -45,7 +44,6 @@ export function useFetch<
 
   const _asyncDataOptions: AsyncDataOptions<any> = {
     ...opts,
-    cache: requestCacheToCacheOption(opts.cache),
     watch: [
       _request,
       ...(opts.watch || [])
@@ -57,22 +55,6 @@ export function useFetch<
   }, _asyncDataOptions)
 
   return asyncData
-}
-
-// Maps request cache option to useAsyncData cache strategy
-// https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
-function requestCacheToCacheOption (input: undefined | boolean | RequestCache): AsyncDataOptions<any>['cache'] {
-  // Async data possible options
-  const t = typeof input
-  if (t === 'boolean' || t === 'undefined') {
-    return input as boolean | undefined
-  }
-  // Map values
-  if (input === 'force-cache') {
-    return true
-  }
-  // Use default behavior for rest
-  return undefined
 }
 
 export function useLazyFetch<

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+await useFetch('http://icanhazip.com', { key: 'test' })
+await useFetch('http://icanhazip.com', { key: 'test', server: false, initialCache: false })
 </script>
 
 <template>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-await useFetch('http://icanhazip.com', { key: 'test' })
-await useFetch('http://icanhazip.com', { key: 'test', server: false, initialCache: false })
 </script>
 
 <template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Both `useFetch` and `useAsyncData` avoid fetching twice at the same time when a promise is running but skip any value in payload cache for **initial refrash**. A simple way to reproduce behavior:

```vue
<script setup lang="ts">
await useFetch('http://icanhazip.com', { key: 'test' })
await useFetch('http://icanhazip.com', { key: 'test', server: false })
</script>
```

The script above, causes another client-side fetching on initialization, despite the fact that we already have the same key in payload cache. There are other situations where this happens as well, including fetching in multiple components when a race-condition can happen for fast fetches.

This PR changes the default behavior to **use payload cache for initial fetch** when exists. Running the above example, will not cause another client-side request anymore. To avoid this new behavior, a new `{ initialCache: false }` options can be provide (* see notes).

Any subsequent call of `refrash` either automated with watchers or manually triggered by user, will still cause fetching and updating payload cache.



Slightly breaking changes:
- `refresh(_force)` option is dropped. It wasn't making sense to have it and it was limiting future compatibility with refresh options. It should be either `refresh()` or `refresh({})` (there are no public options yet)
- A code relying on the buggy behavior with double fetch might be broken. `{ initialCache: false }` can be used as a workaround.

---


(*) `useFetch`'s `cache` option can be either a [Request Cache strategy](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) or boolean. Value will be mapped to boolean for internal `useAsyncData ` options. 

In the future, we can extend `cache` option with different new strategies. Ideally consistent with Request Cache API.

**Update**: Using explicit `initialCache` for time being to avoid possibly usage conflict in the future development of cache support. (https://github.com/nuxt/framework/pull/3985/commits/d6436a183fd4f521e662a3f56a2a3569aad6f63a)


