### PR TITLE
fix(vite): optimise `vue` by default

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -53,7 +53,8 @@ export async function bundle (nuxt: Nuxt) {
         optimizeDeps: {
           entries: [
             resolve(nuxt.options.appDir, 'entry.ts')
-          ]
+          ],
+          include: ['vue']
         },
         css: resolveCSSOptions(nuxt),
         build: {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Current new builds are failing with white screen & hydration error (but only on the first run of Nuxt). This is because vite doesn't know to optimize vue so the vue imported by `@nuxt/ui-templates/templates/welcome.vue` is a different vue from the one used in the rest of the app. After the first run, vue is optimized and you have to delete `node_modules/.vite` to trigger error again.

Reproducible https://stackblitz.com/edit/github-ndg68p?file=package.json&terminal=dev