### PR TITLE
feat: add nuxt config option render.static.allowFromAnyOrigin

### DIFF
--- a/packages/nitro/src/context.ts
+++ b/packages/nitro/src/context.ts
@@ -62,6 +62,7 @@ export interface NitroContext {
   }
   storage: StorageOptions,
   assets: AssetOptions,
+  staticAllowFromAnyOrigin: boolean,
   _nuxt: {
     majorVersion: number
     dev: boolean
@@ -133,6 +134,7 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
       inline: !nuxtOptions.dev,
       dirs: {}
     },
+    staticAllowFromAnyOrigin: undefined,
     _nuxt: {
       majorVersion: nuxtOptions._majorVersion || 2,
       dev: nuxtOptions.dev,
@@ -207,6 +209,10 @@ export function getNitroContext (nuxtOptions: NuxtOptions, input: NitroInput): N
   // Assets
   nitroContext.assets.dirs.server = {
     dir: resolve(nitroContext._nuxt.srcDir, 'server/assets'), meta: true
+  }
+
+  if (nuxtOptions.render && nuxtOptions.render.static) {
+    nitroContext.staticAllowFromAnyOrigin = nuxtOptions.render.static.allowFromAnyOrigin
   }
 
   // console.log(nitroContext)

--- a/packages/nitro/src/rollup/plugins/static.ts
+++ b/packages/nitro/src/rollup/plugins/static.ts
@@ -8,7 +8,7 @@ import type { Plugin } from 'rollup'
 import type { NitroContext } from '../../context'
 
 export function staticAssets (context: NitroContext) {
-  const assets: Record<string, { type: string, etag: string, mtime: string, path: string }> = {}
+  const assets: Record<string, { type: string, etag: string, mtime: string, path: string, allowFromAnyOrigin?: boolean }> = {}
 
   const files = globbySync('**/*.*', { cwd: context.output.publicDir, absolute: false })
 
@@ -23,7 +23,8 @@ export function staticAssets (context: NitroContext) {
       type,
       etag,
       mtime: stat.mtime.toJSON(),
-      path: relative(context.output.serverDir, fullPath)
+      path: relative(context.output.serverDir, fullPath),
+      allowFromAnyOrigin: id.startsWith('_nuxt/') ? undefined : context.staticAllowFromAnyOrigin
     }
   }
 

--- a/packages/nitro/src/runtime/server/static.ts
+++ b/packages/nitro/src/runtime/server/static.ts
@@ -68,6 +68,13 @@ export default async function serveStatic (req, res) {
     res.setHeader('Cache-Control', `max-age=${TWO_DAYS}, immutable`)
   }
 
+  if (asset.allowFromAnyOrigin) {
+    res.setHeader('X-Frame-Options', 'ALLOWALL')
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET')
+    res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+  }
+
   const contents = await readAsset(id)
   return res.end(contents)
 }

--- a/packages/nitro/src/server/dev.ts
+++ b/packages/nitro/src/server/dev.ts
@@ -79,7 +79,16 @@ export function createDevServer (nitroContext: NitroContext) {
   // _nuxt and static
   const buildAssetsURL = joinURL(nitroContext._nuxt.baseURL, nitroContext._nuxt.buildAssetsDir)
   app.use(buildAssetsURL, serveStatic(resolve(nitroContext._nuxt.buildDir, 'dist/client')))
-  app.use(nitroContext._nuxt.baseURL, serveStatic(resolve(nitroContext._nuxt.publicDir)))
+  const renderStaticOptions = { setHeaders: undefined }
+  if (nitroContext.staticAllowFromAnyOrigin) {
+    renderStaticOptions.setHeaders = (res) => {
+      res.setHeader('X-Frame-Options', 'ALLOWALL')
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      res.setHeader('Access-Control-Allow-Methods', 'GET')
+      res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    }
+  }
+  app.use(nitroContext._nuxt.baseURL, serveStatic(resolve(nitroContext._nuxt.publicDir), renderStaticOptions))
 
   // debugging endpoint to view vfs
   app.use('/_vfs', useBase('/_vfs', handleVfs(nitroContext)))

--- a/packages/schema/src/config/render.ts
+++ b/packages/schema/src/config/render.ts
@@ -73,9 +73,7 @@ export default {
   },
 
   /**
-   * Configure the behavior of the `static/` directory.
-   *
-   * See [serve-static docs](https://github.com/expressjs/serve-static) for possible options.
+   * Configure the behavior of the `public/` directory.
    */
   static: {
     /**
@@ -89,7 +87,17 @@ export default {
      * With `prefix: true` (default): /t/favicon.ico
      * With `prefix: false`: /favicon.ico
      */
-    prefix: true
+    prefix: true,
+    /**
+     * Whether to add headers to allow access from any origin
+     *
+     * If set to true, all responses of static files from the `public/` directory will get the following headers:
+     * Access-Control-Allow-Origin *
+     * Access-Control-Allow-Methods GET
+     * Access-Control-Allow-Headers Origin, X-Requested-With, Content-Type, Accept
+     * X-Frame-Options ALLOWALL
+     */
+    allowFromAnyOrigin: false
   },
 
   /**

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,9 @@
 import { defineNuxtConfig } from 'nuxt3'
 
 export default defineNuxtConfig({
+  render: {
+    static: {
+      allowFromAnyOrigin: true
+    }
+  }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#4009 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request adds a new config option in nuxt.config.js:

```js
render: {
  static: {
    /**
     * Whether to add headers to allow access from any origin
     *
     * If set to true, all responses of static files from the `public/` directory will contain the following headers:
     * Access-Control-Allow-Origin *
     * Access-Control-Allow-Methods GET
     * Access-Control-Allow-Headers Origin, X-Requested-With, Content-Type, Accept
     * X-Frame-Options ALLOWALL
     */
    allowFromAnyOrigin: false
  },
}
```

If allowFromAnyOrigin is set to true, for development mode, a function setHeaders will be passed to serve-static to set these headers. For production mode, the public assets will be flagged and the headers will be set in the static middleware.

This allows static files from a Nuxt server to be served to clients from another domain, circumventing a CORS policy error.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.  => so far only in schema/src/config/render.ts

