### PR TITLE
feat(nuxi): load `.env` when previewing builds

### DIFF
--- a/docs/content/3.docs/1.usage/8.cli.md
+++ b/docs/content/3.docs/1.usage/8.cli.md
@@ -67,6 +67,10 @@ Option        | Default          | Description
 
 This command sets `process.env.NODE_ENV` to `production`. To override, define `NODE_ENV` in a `.env` file or as command-line argument.
 
+::alert{type=info}
+For convenience, in preview mode, your `.env.production` or `.env` file will be loaded into `process.env`. (However, in production you will need to ensure your environment variables are set yourself.)
+::
+
 ## Info
 
 ```{bash}

--- a/docs/content/3.docs/1.usage/8.cli.md
+++ b/docs/content/3.docs/1.usage/8.cli.md
@@ -68,7 +68,7 @@ Option        | Default          | Description
 This command sets `process.env.NODE_ENV` to `production`. To override, define `NODE_ENV` in a `.env` file or as command-line argument.
 
 ::alert{type=info}
-For convenience, in preview mode, your `.env.production` or `.env` file will be loaded into `process.env`. (However, in production you will need to ensure your environment variables are set yourself.)
+For convenience, in preview mode, your `.env` file will be loaded into `process.env`. (However, in production you will need to ensure your environment variables are set yourself.)
 ::
 
 ## Info

--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -24,6 +24,7 @@
     "@types/mri": "^1.1.1",
     "@types/rimraf": "^3",
     "@types/semver": "^7",
+    "c12": "^0.2.4",
     "chokidar": "^3.5.3",
     "clear": "^0.1.0",
     "clipboardy": "^3.0.0",

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -35,12 +35,9 @@ export default defineNuxtCommand({
       process.exit(1)
     }
 
-    for (const env of ['.env.production', '.env']) {
-      if (existsSync(resolve(rootDir, env))) {
-        consola.info(`Loading \`${env}\` for preview...`)
-        process.env = await loadDotenv({ cwd: rootDir, fileName: env, env: process.env })
-        break
-      }
+    if (existsSync(resolve(rootDir, '.env'))) {
+      consola.info('Loading `.env` for preview...')
+      process.env = await loadDotenv({ cwd: rootDir, fileName: '.env', env: process.env })
     }
 
     consola.info('Starting preview command:', nitroJSON.commands.preview)

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -1,6 +1,7 @@
 import { existsSync, promises as fsp } from 'fs'
 import { dirname, relative } from 'path'
 import { execa } from 'execa'
+import { loadDotenv } from 'c12'
 import { resolve } from 'pathe'
 import consola from 'consola'
 
@@ -32,6 +33,14 @@ export default defineNuxtCommand({
     if (!nitroJSON.commands.preview) {
       consola.error('Preview is not supported for this build.')
       process.exit(1)
+    }
+
+    for (const env of ['.env.production', '.env']) {
+      if (existsSync(resolve(rootDir, env))) {
+        consola.info(`Loading \`${env}\` for preview...`)
+        process.env = await loadDotenv({ cwd: rootDir, fileName: env, env: process.env })
+        break
+      }
     }
 
     consola.info('Starting preview command:', nitroJSON.commands.preview)

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -36,7 +36,7 @@ export default defineNuxtCommand({
     }
 
     if (existsSync(resolve(rootDir, '.env'))) {
-      consola.info('Loading `.env` for preview...')
+      consola.info('Loading `.env`. This will not be loaded when running the server in production.')
       process.env = await loadDotenv({ cwd: rootDir, fileName: '.env', env: process.env })
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15369,6 +15369,7 @@ __metadata:
     "@types/mri": ^1.1.1
     "@types/rimraf": ^3
     "@types/semver": ^7
+    c12: ^0.2.4
     chokidar: ^3.5.3
     clear: ^0.1.0
     clipboardy: ^3.0.0


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/3621

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This loads `.env` in `nuxi preview`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

