### PR TITLE
fix(nuxt3)!: add default cookie path to `/`

### DIFF
--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -4,7 +4,7 @@ import { parse, serialize, CookieParseOptions, CookieSerializeOptions } from 'co
 import { appendHeader } from 'h3'
 import type { NuxtApp } from '@nuxt/schema'
 import destr from 'destr'
-import { useNuxtApp, useRuntimeConfig } from '#app'
+import { useNuxtApp } from '#app'
 
 type _CookieOptions = Omit<CookieSerializeOptions & CookieParseOptions, 'decode' | 'encode'>
 

--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -17,13 +17,13 @@ export interface CookieOptions<T=any> extends _CookieOptions {
 export interface CookieRef<T> extends Ref<T> {}
 
 const CookieDefaults: CookieOptions<any> = {
+  path: '/',
   decode: val => destr(decodeURIComponent(val)),
   encode: val => encodeURIComponent(typeof val === 'string' ? val : JSON.stringify(val))
 }
 
 export function useCookie <T=string> (name: string, _opts?: CookieOptions<T>): CookieRef<T> {
-  const baseURL = useRuntimeConfig().app.baseURL
-  const opts = { ...CookieDefaults, path: baseURL, ..._opts }
+  const opts = { ...CookieDefaults, ..._opts }
   const cookies = readRawCookies(opts)
 
   const cookie = ref(cookies[name] ?? opts.default?.())

--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -4,7 +4,7 @@ import { parse, serialize, CookieParseOptions, CookieSerializeOptions } from 'co
 import { appendHeader } from 'h3'
 import type { NuxtApp } from '@nuxt/schema'
 import destr from 'destr'
-import { useNuxtApp } from '#app'
+import { useNuxtApp, useRuntimeConfig } from '#app'
 
 type _CookieOptions = Omit<CookieSerializeOptions & CookieParseOptions, 'decode' | 'encode'>
 
@@ -22,7 +22,8 @@ const CookieDefaults: CookieOptions<any> = {
 }
 
 export function useCookie <T=string> (name: string, _opts?: CookieOptions<T>): CookieRef<T> {
-  const opts = { ...CookieDefaults, ..._opts }
+  const baseURL = useRuntimeConfig().app.baseURL
+  const opts = { ...CookieDefaults, path: baseURL, ..._opts }
   const cookies = readRawCookies(opts)
 
   const cookie = ref(cookies[name] ?? opts.default?.())


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4018

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This defaults cookie path to app's baseURL (though we could instead set it to `/` by default if there's a reason)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

