### PR TITLE
fix(kit): ensure `useNuxt` returns nuxt instance

### DIFF
--- a/packages/kit/src/context.ts
+++ b/packages/kit/src/context.ts
@@ -4,6 +4,8 @@ import type { Nuxt } from '@nuxt/schema'
 /** Direct access to the Nuxt context - see https://github.com/unjs/unctx. */
 export const nuxtCtx = getContext<Nuxt>('nuxt')
 
+// TODO: Use use/tryUse from unctx. https://github.com/unjs/unctx/issues/6
+
 /**
  * Get access to Nuxt instance.
  *

--- a/packages/kit/src/context.ts
+++ b/packages/kit/src/context.ts
@@ -5,11 +5,36 @@ import type { Nuxt } from '@nuxt/schema'
 export const nuxtCtx = getContext<Nuxt>('nuxt')
 
 /**
- * Get access to Nuxt (if run within the Nuxt context) - see https://github.com/unjs/unctx.
+ * Get access to Nuxt instance.
+ *
+ * Throws an error if Nuxt instance is unavailable.
  *
  * @example
  * ```js
  * const nuxt = useNuxt()
  * ```
  */
-export const useNuxt = nuxtCtx.use
+export function useNuxt (): Nuxt {
+  const instance = nuxtCtx.use()
+  if (!instance) {
+    throw new Error('Nuxt instance is unavailable!')
+  }
+  return instance
+}
+
+/**
+ * Get access to Nuxt instance.
+ *
+ * Returns null if Nuxt instance is unavailable.
+ *
+ * @example
+ * ```js
+ * const nuxt = tryUseNuxt()
+ * if (nuxt) {
+ *  // Do something
+ * }
+ * ```
+ */
+export function tryUseNuxt (): Nuxt | null {
+  return nuxtCtx.use()
+}

--- a/packages/kit/src/ignore.ts
+++ b/packages/kit/src/ignore.ts
@@ -8,6 +8,8 @@ import { tryUseNuxt } from './context'
  */
 export function isIgnored (pathname: string): boolean {
   const nuxt = tryUseNuxt()
+
+  // Happens with CLI reloads
   if (!nuxt) {
     return null
   }

--- a/packages/kit/src/ignore.ts
+++ b/packages/kit/src/ignore.ts
@@ -1,13 +1,16 @@
 import { existsSync, readFileSync } from 'fs'
 import ignore from 'ignore'
 import { join, relative } from 'pathe'
-import { useNuxt } from './context'
+import { tryUseNuxt } from './context'
 
 /**
  * Return a filter function to filter an array of paths
  */
 export function isIgnored (pathname: string): boolean {
-  const nuxt = useNuxt()
+  const nuxt = tryUseNuxt()
+  if (!nuxt) {
+    return null
+  }
 
   if (!nuxt._ignore) {
     nuxt._ignore = ignore(nuxt.options.ignoreOptions)

--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -4,7 +4,7 @@ import { applyDefaults } from 'untyped'
 import { dirname } from 'pathe'
 import type { Nuxt, NuxtTemplate, NuxtModule, ModuleOptions, ModuleDefinition } from '@nuxt/schema'
 import { logger } from '../logger'
-import { useNuxt, nuxtCtx } from '../context'
+import { useNuxt, nuxtCtx, tryUseNuxt } from '../context'
 import { isNuxt2, checkNuxtCompatibility } from '../compatibility'
 import { templateUtils, compileTemplate } from '../internal/template'
 
@@ -43,7 +43,7 @@ export function defineNuxtModule<OptionsT extends ModuleOptions> (definition: Mo
   // Module format is always a simple function
   async function normalizedModule (inlineOptions: OptionsT, nuxt: Nuxt) {
     if (!nuxt) {
-      nuxt = useNuxt() || this.nuxt /* invoked by nuxt 2 */
+      nuxt = tryUseNuxt() || this.nuxt /* invoked by nuxt 2 */
     }
 
     // Avoid duplicate installs

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -2,7 +2,7 @@ import { promises as fsp, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { basename, dirname, resolve, join, normalize, isAbsolute } from 'pathe'
 import { globby } from 'globby'
-import { useNuxt } from './context'
+import { tryUseNuxt, useNuxt } from './context'
 import { tryResolveModule } from './internal/cjs'
 import { isIgnored } from './ignore'
 
@@ -103,7 +103,7 @@ export async function findPath (paths: string|string[], opts?: ResolvePathOption
  */
 export function resolveAlias (path: string, alias?: Record<string, string>): string {
   if (!alias) {
-    alias = useNuxt()?.options.alias || {}
+    alias = tryUseNuxt()?.options.alias || {}
   }
   for (const key in alias) {
     if (key === '@' && !path.startsWith('@/')) { continue } // Don't resolve @foo/bar


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Usage of `useNuxt()` was unguarded in nuxt kit about context unavailability. Introducing new `tryUseNuxt` for guarded places and directly throwing an error for `useNuxt` when context is unavailable to avoid cascading issues.

Upstream improvement: https://github.com/unjs/unctx/issues/6

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

