### PR TITLE
fix(nuxt3): set pending to false when using cached data

### DIFF
--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -81,9 +81,11 @@ export function useAsyncData<
     }
   }
 
+  const useInitialCache = () => options.initialCache && nuxt.payload.data[key] !== undefined
+
   const asyncData = {
     data: ref(nuxt.payload.data[key] ?? options.default()),
-    pending: ref(!options.initialCache || nuxt.payload.data[key] === undefined),
+    pending: ref(!useInitialCache()),
     error: ref(nuxt.payload._errors[key] ?? null)
   } as AsyncData<DataT>
 
@@ -93,7 +95,7 @@ export function useAsyncData<
       return nuxt._asyncDataPromises[key]
     }
     // Avoid fetching same key that is already fetched
-    if (opts._initial && options.initialCache && nuxt.payload.data[key] !== undefined) {
+    if (opts._initial && useInitialCache()) {
       return nuxt.payload.data[key]
     }
     asyncData.pending.value = true

--- a/packages/nuxt3/src/app/composables/asyncData.ts
+++ b/packages/nuxt3/src/app/composables/asyncData.ts
@@ -83,7 +83,7 @@ export function useAsyncData<
 
   const asyncData = {
     data: ref(nuxt.payload.data[key] ?? options.default()),
-    pending: ref(true),
+    pending: ref(!options.initialCache || nuxt.payload.data[key] === undefined),
     error: ref(nuxt.payload._errors[key] ?? null)
   } as AsyncData<DataT>
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/4053
resolves https://github.com/nuxt/framework/issues/4027

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We never run the refresh if we already have data present, meaning previously `pending` was getting stuck in the true position.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

