### PR TITLE
fix(bridge): transpile `@nuxt/bridge-edge`

### DIFF
--- a/packages/bridge/src/transpile.ts
+++ b/packages/bridge/src/transpile.ts
@@ -5,6 +5,8 @@ export const setupTranspile = () => {
   const nuxt = useNuxt()
 
   nuxt.hook('modules:done', () => {
-    addModuleTranspiles()
+    addModuleTranspiles({
+      additionalModules: ['@nuxt/bridge-edge']
+    })
   })
 }

--- a/packages/bridge/src/vite/server.ts
+++ b/packages/bridge/src/vite/server.ts
@@ -50,7 +50,6 @@ export async function buildServer (ctx: ViteBuildContext) {
         /\.(es|esm|esm-browser|esm-bundler).js$/,
         '#app',
         /@nuxt\/nitro\/(dist|src)/,
-        '@nuxt/bridge-edge',
         ...ctx.nuxt.options.build.transpile.filter(i => typeof i === 'string')
       ]
     },

--- a/packages/bridge/src/vite/server.ts
+++ b/packages/bridge/src/vite/server.ts
@@ -50,6 +50,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         /\.(es|esm|esm-browser|esm-bundler).js$/,
         '#app',
         /@nuxt\/nitro\/(dist|src)/,
+        '@nuxt/bridge-edge',
         ...ctx.nuxt.options.build.transpile.filter(i => typeof i === 'string')
       ]
     },

--- a/packages/nuxt3/src/core/modules.ts
+++ b/packages/nuxt3/src/core/modules.ts
@@ -4,6 +4,7 @@ export const addModuleTranspiles = () => {
   const nuxt = useNuxt()
 
   const modules = [
+    '@nuxt/bridge-edge',
     ...nuxt.options.buildModules,
     ...nuxt.options.modules,
     ...nuxt.options._modules

--- a/packages/nuxt3/src/core/modules.ts
+++ b/packages/nuxt3/src/core/modules.ts
@@ -1,10 +1,14 @@
 import { useNuxt } from '@nuxt/kit'
 
-export const addModuleTranspiles = () => {
+interface AddModuleTranspilesOptions {
+  additionalModules?: string[]
+}
+
+export const addModuleTranspiles = (opts: AddModuleTranspilesOptions = {}) => {
   const nuxt = useNuxt()
 
   const modules = [
-    '@nuxt/bridge-edge',
+    ...opts.additionalModules || [],
     ...nuxt.options.buildModules,
     ...nuxt.options.modules,
     ...nuxt.options._modules

--- a/packages/nuxt3/src/core/modules.ts
+++ b/packages/nuxt3/src/core/modules.ts
@@ -1,6 +1,6 @@
 import { useNuxt } from '@nuxt/kit'
 
-interface AddModuleTranspilesOptions {
+export interface AddModuleTranspilesOptions {
   additionalModules?: string[]
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #3221

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Having looked at this, #3221 is not actually a shortcoming in `externality`. It's more that `@nuxt/bridge` (which is what we add to the transpile array) is a stub that re-exports `@nuxt/bridge-edge`. pnpm doesn't nest this under `@nuxt/bridge` so there's nothing to match against.

So this PR isn't a workaround as such, but probably the correct solution.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

