### PR TITLE
fix(nuxt3)!: sync route object to currently resolved page

### DIFF
--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -7,6 +7,7 @@ import {
   RouteLocation
 } from 'vue-router'
 import { createError } from 'h3'
+import { withoutBase } from 'ufo'
 import NuxtPage from './page'
 import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig, throwError, clearError } from '#app'
 // @ts-ignore
@@ -54,7 +55,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   })
 
   // Allows suspending the route object until page navigation completes
-  const path = process.server ? nuxtApp.ssrContext.req.url : window.location.pathname
+  const path = process.server ? nuxtApp.ssrContext.req.url : withoutBase(window.location.href, window.location.origin)
   const currentRoute = shallowRef(router.resolve(path) as RouteLocation)
   router.afterEach((to, from) => {
     // We won't trigger suspense if the component is reused between routes

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -57,15 +57,14 @@ export default defineNuxtPlugin((nuxtApp) => {
   // Allows suspending the route object until page navigation completes
   const path = process.server ? nuxtApp.ssrContext.req.url : withoutBase(window.location.href, window.location.origin)
   const currentRoute = shallowRef(router.resolve(path) as RouteLocation)
+  const syncCurrentRoute = () => { currentRoute.value = router.currentRoute.value }
+  nuxtApp.hook('page:finish', syncCurrentRoute)
   router.afterEach((to, from) => {
     // We won't trigger suspense if the component is reused between routes
     // so we need to update the route manually
     if (to.matched[0]?.components?.default === from.matched[0]?.components?.default) {
-      currentRoute.value = router.currentRoute.value
+      syncCurrentRoute()
     }
-  })
-  nuxtApp.hook('page:finish', () => {
-    currentRoute.value = router.currentRoute.value
   })
   // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
   const route = {}


### PR DESCRIPTION
### 🔗 Linked issue

resolves #4086, resolves https://github.com/nuxt/framework/discussions/2459

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR does two things:

1. correctly resolves the route for use within plugins (previously `useRoute()` did not return the correct route until the plugin lifecycle had fully run)
2. creates a 'suspended' route that mirrors the behaviour of the page component - so it does not resolve to the new route until the page component resolves

I would especially welcome testing on this given the nature of the change.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

