### PR TITLE
fix(nuxi): use rm rather than rmdir

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -39,7 +39,7 @@ export default defineNuxtCommand({
       consola.info('Removing lock-file and node_modules...')
       await Promise.all([
         fsp.rm(packageManagerLocks[packageManager]),
-        fsp.rmdir('node_modules', { recursive: true })
+        fsp.rm('node_modules', { recursive: true })
       ])
       execSync(`${packageManager} install`, { stdio: 'inherit' })
     } else {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On newer nodes, the following error is printed:

```
❯ npx nuxi upgrade --force                             
Nuxt CLI v3.0.0-27470397.9ebea90
ℹ Package Manager: yarn 3.2.0
ℹ Current nuxt version: 3.0.0-27470397.9ebea90
ℹ Removing lock-file and node_modules...

 ERROR  (node:37432) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

