### PR TITLE
fix(vite): improve warmup

### DIFF
--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -1,19 +1,25 @@
 import { logger } from '@nuxt/kit'
 import type { ViteDevServer } from 'vite'
 
-export async function warmupViteServer (server: ViteDevServer, entries: string[]) {
+export async function warmupViteServer (
+  server: ViteDevServer,
+  entries: string[]
+) {
   const warmedUrls = new Set<String>()
 
   const warmup = async (url: string) => {
-    if (warmedUrls.has(url)) { return undefined }
+    if (warmedUrls.has(url)) {
+      return
+    }
     warmedUrls.add(url)
     try {
       await server.transformRequest(url)
     } catch (e) {
       logger.debug('Warmup for %s failed with: %s', url, e)
     }
-    const deps = Array.from(server.moduleGraph.urlToModuleMap.get(url)?.importedModules || [])
-    await Promise.all(deps.map(m => warmup(m.url)))
+    const mod = await server.moduleGraph.getModuleByUrl(url)
+    const deps = Array.from(mod?.importedModules || [])
+    await Promise.all(deps.map(m => warmup(m.url.replace('/@id/__x00__', '\0'))))
   }
 
   await Promise.all(entries.map(entry => warmup(entry)))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The original warm-up will only warm up the entry module, due to two issues:

- `server.moduleGraph.urlToModuleMap.get(url)` does not hit because we are warm-up with unresolved URLs, while `urlToModuleMap` stores resolved absolute URL. Use `getModuleByUrl(url)` will let Vite handles the normalization and matching.
- Since the introduction of VFS for internal modules, the URL gets appended with `/@id/__x00__` for browser compatibility, while the plugin still expects the id starts with `\0`, causing the `transformRequest` to return `undefined` and failed to identify it's dependencies (that means, all Vue components and user code)

This PR improves the warm-up logic, and also fixes the FOUC problem of `vite-node` and #3968
