### PR TITLE
fix(bridge): exclude unsupported imports via `autoImports:sources`

### DIFF
--- a/packages/bridge/src/auto-imports.ts
+++ b/packages/bridge/src/auto-imports.ts
@@ -10,27 +10,25 @@ const CapiHelpers = new Set(Object.keys(CompositionApi))
 export function setupAutoImports () {
   const nuxt = useNuxt()
 
-  const bridgePresets: Preset[] = [
-    {
-      from: '@vue/composition-api',
-      imports: vuePreset.imports.filter(i => CapiHelpers.has(i as string))
-    },
-    {
-      from: '#app',
-      imports: ['useNuxt2Meta']
-    }
-  ]
+  const bridgePresets: Preset[] = [{
+    from: '@vue/composition-api',
+    imports: vuePreset.imports.filter(i => CapiHelpers.has(i as string))
+  }]
+
   nuxt.hook('autoImports:sources', (presets) => {
     const vuePreset = presets.find(p => p.from === 'vue')
     if (vuePreset) { vuePreset.disabled = true }
-  })
 
-  nuxt.hook('autoImports:extend', (imports) => {
-    for (const i of imports) {
-      if (i.from === '#app' && UnsupportedImports.has(i.name)) {
-        i.disabled = true
+    const appPreset = presets.find(p => p.from === '#app')
+    if (!appPreset) { return }
+
+    for (const [index, i] of Object.entries(appPreset.imports).reverse()) {
+      if (typeof i === 'string' && UnsupportedImports.has(i)) {
+        appPreset.imports.splice(Number(index), 1)
       }
     }
+
+    appPreset.imports.push('useNuxt2Meta')
   })
 
   nuxt.hook('modules:done', () => installModule(autoImports, { presets: bridgePresets }))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4120

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Imports from presets weren't being passed at `autoImports:extend` as this was only for dynamic imports.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

