### PR TITLE
fix(vite): clean up dynamic paths

### DIFF
--- a/packages/vite/src/plugins/dynamic-base.ts
+++ b/packages/vite/src/plugins/dynamic-base.ts
@@ -33,6 +33,12 @@ export const RelativeAssetPlugin = function (): Plugin {
             .replace(assetRE, r => r.replace(/\/__NUXT_BASE__/g, assetBase))
             .replace(/\/__NUXT_BASE__/g, publicBase)
         }
+        if (asset.type === 'chunk' && typeof asset.code === 'string') {
+          asset.code = asset.code
+            .replace(/`\$\{(_?_?publicAssetsURL|buildAssetsURL|)\(\)\}([^`]*)`/g, '$1(`$2`)')
+            .replace(/"\/__NUXT_BASE__\/([^"]*)"\.replace\("\/__NUXT_BASE__", ""\)/g, '"$1"')
+            .replace(/'\/__NUXT_BASE__\/([^']*)'\.replace\("\/__NUXT_BASE__", ""\)/g, '"$1"')
+        }
       }
     }
   }

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -13,6 +13,7 @@ import { prepareDevServerEntry } from './vite-node'
 import { isCSS, isDirectory, readDirRecursively } from './utils'
 import { bundleRequest } from './dev-bundler'
 import { writeManifest } from './manifest'
+import { RelativeAssetPlugin } from './plugins/dynamic-base'
 
 export async function buildServer (ctx: ViteBuildContext) {
   const _resolve = id => resolveModule(id, { paths: ctx.nuxt.options.modulesDir })
@@ -74,6 +75,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     },
     plugins: [
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'server'),
+      RelativeAssetPlugin(),
       vuePlugin(ctx.config.vue),
       viteJsxPlugin()
     ]


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This tidies up the following generated code:

```diff
- const logo = buildAssetsURL("/__NUXT_BASE__/logo.148d9522.svg".replace("/__NUXT_BASE__", ""));
+ const logo = buildAssetsURL("logo.148d9522.svg");
- const _imports_1 = `${publicAssetsURL()}public.svg`;
+ const _imports_1 = publicAssetsURL(`public.svg`);
```

(We can't do this in the transform step as vite does a straight replacement of the asset id after this point.)