### PR TITLE
fix(nuxt3): normalize watched paths

### DIFF
--- a/packages/nuxt3/src/core/builder.ts
+++ b/packages/nuxt3/src/core/builder.ts
@@ -2,6 +2,7 @@ import chokidar from 'chokidar'
 import type { Nuxt } from '@nuxt/schema'
 import { importModule, isIgnored } from '@nuxt/kit'
 import { debounce } from 'perfect-debounce'
+import { normalize } from 'pathe'
 import { createApp, generateApp as _generateApp } from './app'
 
 export async function build (nuxt: Nuxt) {
@@ -48,7 +49,7 @@ function watch (nuxt: Nuxt) {
     ]
   })
 
-  const watchHook = debounce((event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir', path: string) => nuxt.callHook('builder:watch', event, path))
+  const watchHook = debounce((event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir', path: string) => nuxt.callHook('builder:watch', event, normalize(path)))
   watcher.on('all', watchHook)
   nuxt.hook('close', () => watcher.close())
   return watcher


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4030

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Yet another issue triggered by `\` vs `/`. Source issue is here:

https://github.com/nuxt/framework/blob/dda0cebc761c00042ad82bb4c2a47b679581755a/packages/nuxt3/src/pages/module.ts#L40-L43

But I've fixed by normalising upstream (before we call nuxt hook), to help avoid similar issues in future.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

