### PR TITLE
fix(kit): use `route` instead of `path` in `ServerMiddleware`

### DIFF
--- a/packages/kit/src/server.ts
+++ b/packages/kit/src/server.ts
@@ -2,7 +2,7 @@ import type { Middleware } from 'h3'
 import { useNuxt } from './context'
 
 export interface ServerMiddleware {
-  path?: string,
+  route?: string,
   handler: Middleware | string
 }
 

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -22,7 +22,7 @@ export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
 export function registerViteNodeMiddleware (ctx: ViteBuildContext) {
   addServerMiddleware({
     route: '/__nuxt_vite_node__/',
-    handle: createViteNodeMiddleware(ctx)
+    handler: createViteNodeMiddleware(ctx)
   })
 }
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR will improve compatibility with Nitropack and internal usage of `addServerMiddleware` .
As Nitropack uses `route` and `handler` for middleware, I assume `path` and `handle` will be deprecated. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

