### PR TITLE
fix(bridge): resolve vue from `.nuxt`, not `node_modules`

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -60,12 +60,9 @@ export function setupAppBridge (_options: any) {
   })
 
   // Alias vue to have identical vue3 exports
-  addWebpackPlugin(VueCompat.webpack({
-    src: resolve(distDir, 'runtime/vue2-bridge.mjs')
-  }))
-  addVitePlugin(VueCompat.vite({
-    src: resolve(distDir, 'runtime/vue2-bridge.mjs')
-  }))
+  const { dst: vueCompat } = addTemplate({ src: resolve(distDir, 'runtime/vue2-bridge.mjs') })
+  addWebpackPlugin(VueCompat.webpack({ src: vueCompat }))
+  addVitePlugin(VueCompat.vite({ src: vueCompat }))
 
   nuxt.hook('prepare:types', ({ tsConfig, references }) => {
     // Type 'vue' module with composition API exports


### PR DESCRIPTION
### 🔗 Linked issue

resolves #4094

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously with npm (but not yarn or pnpm) vue@3 was being resolved by the import in `vue2-bridge` (see https://github.com/nuxt/framework/pull/3886), because vue@3 was being installed, nested under `@nuxt/bridge` in `node_modules`. This PR instead moves that template to `.nuxt` so we can benefit from resolving `vue` from the user's root (that is, vue@2).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

