### PR TITLE
docs: add note that layout root cannot be `<slot />`

### DIFF
--- a/docs/content/2.guide/3.directory-structure/6.layouts.md
+++ b/docs/content/2.guide/3.directory-structure/6.layouts.md
@@ -13,7 +13,7 @@ Layouts are placed in the `layouts/` directory and will be automatically loaded 
 If you only have a single layout in your application, we recommend to use [app.vue](/guide/directory-structure/app) instead.
 
 ::alert{type=warning}
-Unlike other components, your layouts must have a single root element to allow Nuxt to apply transitions between layout changes.
+Unlike other components, your layouts must have a single root element to allow Nuxt to apply transitions between layout changes - and this root element cannot be a `<slot />`.
 ::
 
 ## Example: Enabling layouts with `app.vue`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3344

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

See issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

