### PR TITLE
chores(docs): prevent link rendering by Docus

### DIFF
--- a/docs/content/3.api/2.components/5.nuxt-error-boundary.md
+++ b/docs/content/3.api/2.components/5.nuxt-error-boundary.md
@@ -4,7 +4,7 @@ Nuxt provides the `<NuxtErrorBoundary>` component to handle client-side errors h
 
 ## Events
 
-- **@error**: Event emitted when the default slot of the component throws an error.
+- **`@error`**: Event emitted when the default slot of the component throws an error.
 
   ```vue
   <template>


### PR DESCRIPTION
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use back ticks to prevent Docus from rendering a link to Github based on `@` character.

