### PR TITLE
fix(cli): close process by default after command invokation

### DIFF
--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -26,18 +26,17 @@ async function _main () {
   }
 
   // Check Node.js version in background
-  setTimeout(() => { checkEngines() }, 1000)
+  setTimeout(() => { checkEngines().catch(() => {}) }, 1000)
 
-  try {
-    // @ts-ignore default.default is hotfix for #621
-    const cmd = await commands[command as Command]() as NuxtCommand
-    if (args.h || args.help) {
-      showHelp(cmd.meta)
-    } else {
-      await cmd.invoke(args)
+  // @ts-ignore default.default is hotfix for #621
+  const cmd = await commands[command as Command]() as NuxtCommand
+  if (args.h || args.help) {
+    showHelp(cmd.meta)
+  } else {
+    const result = await cmd.invoke(args)
+    if (result !== true) {
+      process.exit(1)
     }
-  } catch (err) {
-    onFatalError(err)
   }
 }
 

--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -48,7 +48,7 @@ export function main () {
   _main()
     .then((result) => {
       if (result === 'wait') {
-        process.exit(0)
+        return
       } else if (result === 'error') {
         process.exit(1)
       }

--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -47,8 +47,10 @@ process.on('uncaughtException', err => consola.error('[uncaughtException]', err)
 export function main () {
   _main()
     .then((result) => {
-      if (result !== true) {
+      if (result === 'wait') {
         process.exit(0)
+      } else if (result === 'error') {
+        process.exit(1)
       }
     })
     .catch((error) => {

--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -47,10 +47,10 @@ process.on('uncaughtException', err => consola.error('[uncaughtException]', err)
 export function main () {
   _main()
     .then((result) => {
-      if (result === 'wait') {
-        return
-      } else if (result === 'error') {
+      if (result === 'error') {
         process.exit(1)
+      } else if (result !== 'wait') {
+        process.exit(0)
       }
     })
     .catch((error) => {

--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -34,15 +34,8 @@ async function _main () {
     showHelp(cmd.meta)
   } else {
     const result = await cmd.invoke(args)
-    if (result !== true) {
-      process.exit(1)
-    }
+    return result
   }
-}
-
-function onFatalError (err: unknown) {
-  consola.error(err)
-  process.exit(1)
 }
 
 // Wrap all console logs with consola for better DX
@@ -52,5 +45,14 @@ process.on('unhandledRejection', err => consola.error('[unhandledRejection]', er
 process.on('uncaughtException', err => consola.error('[uncaughtException]', err))
 
 export function main () {
-  _main().catch(onFatalError)
+  _main()
+    .then((result) => {
+      if (result !== true) {
+        process.exit(0)
+      }
+    })
+    .catch((error) => {
+      consola.error(error)
+      process.exit(1)
+    })
 }

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -109,6 +109,6 @@ export default defineNuxtCommand({
       await currentNuxt.hooks.callHook('listen', listener.server, listener)
     }
 
-    return true // Do not exit process
+    return 'wait'
   }
 })

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -108,5 +108,7 @@ export default defineNuxtCommand({
     if (currentNuxt) {
       await currentNuxt.hooks.callHook('listen', listener.server, listener)
     }
+
+    return true // Do not exit process
   }
 })

--- a/packages/nuxi/src/commands/index.ts
+++ b/packages/nuxi/src/commands/index.ts
@@ -30,8 +30,10 @@ export interface NuxtCommandMeta {
   [key: string]: any;
 }
 
+export type CLIInvokeResult = boolean | void
+
 export interface NuxtCommand {
-  invoke(args: Argv): Promise<void> | void
+  invoke(args: Argv): Promise<CLIInvokeResult> | CLIInvokeResult
   meta: NuxtCommandMeta
 }
 

--- a/packages/nuxi/src/commands/index.ts
+++ b/packages/nuxi/src/commands/index.ts
@@ -30,7 +30,7 @@ export interface NuxtCommandMeta {
   [key: string]: any;
 }
 
-export type CLIInvokeResult = boolean | void
+export type CLIInvokeResult = void | 'error' | 'wait'
 
 export interface NuxtCommand {
   invoke(args: Argv): Promise<CLIInvokeResult> | CLIInvokeResult

--- a/packages/nuxi/src/commands/test.ts
+++ b/packages/nuxi/src/commands/test.ts
@@ -16,6 +16,10 @@ export default defineNuxtCommand({
       dev: !!args.dev,
       watch: !!args.watch
     })
+
+    if (args.watch) {
+      return true
+    }
   }
 })
 

--- a/packages/nuxi/src/commands/test.ts
+++ b/packages/nuxi/src/commands/test.ts
@@ -18,7 +18,7 @@ export default defineNuxtCommand({
     })
 
     if (args.watch) {
-      return true
+      return 'wait'
     }
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In order to avoid hanging CLI due to open listeners, this change will force close CLI's process after invocation is done. `dev` and `test` commands opt out by returning `true` as invocation result.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

