### PR TITLE
feat(nuxt3): add `titleTemplate` (and viewport/charset shorthand)

### DIFF
--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -70,7 +70,7 @@ export default {
 
 You can use `definePageMeta` along with `useHead` to set metadata based on the current route.
 
-For example, to include the page title alongside your app name, first define your page title:
+For example, you can first set the current page title (this is extracted at build time via a macro, so it can't be set dynamically):
 
 ```vue{}[pages/some-page.vue]
 <script setup>
@@ -80,14 +80,14 @@ definePageMeta({
 </script>
 ```
 
-And then in your layout file:
+And then in your layout file you might use the route metadata you've previously set:
 
 ```vue{}[layouts/default.vue]
 <script setup>
 const route = useRoute()
 
 useHead({
-  title: computed(() => `App Name - ${route.meta.title}`)
+  meta: [{ name: 'og:title', content: `App Name - ${route.meta.title}` }]
 })
 </script>
 ```

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -4,7 +4,7 @@ You can customize the meta tags for your site through several different ways:
 
 ## `useHead` Composable
 
-Within your `setup` function, you can call `useHead` with an object of meta properties with keys corresponding to meta tags: `title`, `base`, `script`, `style`, `meta` and `link`, as well as `htmlAttrs` and `bodyAttrs`. Alternatively, you can pass a function returning the object for reactive metadata.
+Within your `setup` function, you can call `useHead` with an object of meta properties with keys corresponding to meta tags: `title`, `titleTemplate`, `base`, `script`, `style`, `meta` and `link`, as well as `htmlAttrs` and `bodyAttrs`. There are also two shorthand properties, `charset` and `viewport`, which set the corresponding meta tags. Alternatively, you can pass a function returning the object for reactive metadata.
 
 For example:
 
@@ -12,8 +12,10 @@ For example:
 export default {
   setup () {
     useHead({
+      titleTemplate: 'My App - %s', // or, title => `My App - ${title}`
+      viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
       meta: [
-        { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1' }
+        { name: 'description', content: 'My amazing site.' }
       ],
       bodyAttrs: {
         class: 'test'

--- a/docs/content/migration/4.meta.md
+++ b/docs/content/migration/4.meta.md
@@ -11,7 +11,7 @@ Nuxt 3 provides several different ways to manage your meta tags.
 2. Through the `useHead` [composable](/guide/features/head-management)
 3. Through [global meta components](/guide/features/head-management)
 
-You can customize `title`, `base`, `script`, `style`, `meta`, `link`, `htmlAttrs` and `bodyAttrs`.
+You can customize `title`, `titleTemplate`, `base`, `script`, `style`, `meta`, `link`, `htmlAttrs` and `bodyAttrs`.
 
 ::alert{icon=📦}
 Nuxt currently uses [`vueuse/head`](https://github.com/vueuse/head) to manage your meta tags, but implementation details may change.

--- a/examples/composables/use-head/app.vue
+++ b/examples/composables/use-head/app.vue
@@ -27,6 +27,7 @@
 export default {
   setup () {
     useHead({
+      titleTemplate: '%s - useHead example',
       bodyAttrs: {
         class: 'test'
       }

--- a/packages/nuxt3/src/head/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/head/runtime/lib/vueuse-head.plugin.ts
@@ -1,5 +1,6 @@
 import { createHead, renderHeadToString } from '@vueuse/head'
-import { ref, watchEffect, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { computed, ref, unref, watchEffect, onBeforeUnmount, getCurrentInstance, ComputedGetter } from 'vue'
+import defu from 'defu'
 import type { MetaObject } from '..'
 import { defineNuxtPlugin } from '#app'
 
@@ -14,9 +15,26 @@ export default defineNuxtPlugin((nuxtApp) => {
     headReady = true
   })
 
-  nuxtApp._useHead = (meta: MetaObject) => {
-    const headObj = ref(meta as any)
-    head.addHeadObjs(headObj)
+  const titleTemplate = ref<MetaObject['titleTemplate']>()
+
+  nuxtApp._useHead = (meta: MetaObject | ComputedGetter<MetaObject>) => {
+    titleTemplate.value = (unref(meta) as MetaObject).titleTemplate || titleTemplate.value
+
+    const headObj = computed(() => {
+      const overrides: MetaObject = { meta: [] }
+      const val = unref(meta) as MetaObject
+      if (titleTemplate.value && 'title' in val) {
+        overrides.title = typeof titleTemplate.value === 'function' ? titleTemplate.value(val.title) : titleTemplate.value.replace(/%s/g, val.title)
+      }
+      if (val.charset) {
+        overrides.meta!.push({ charset: val.charset })
+      }
+      if (val.viewport) {
+        overrides.meta!.push({ name: 'viewport', content: val.viewport })
+      }
+      return defu(overrides, val)
+    })
+    head.addHeadObjs(headObj as any)
 
     if (process.server) { return }
 

--- a/packages/schema/src/types/meta.ts
+++ b/packages/schema/src/types/meta.ts
@@ -21,4 +21,6 @@ export interface MetaObject extends Record<string, any> {
   style?: Array<Record<string, any>>
   /** Each item in the array maps to a newly-created `<script>` element, where object properties map to attributes. */
   script?: Array<Record<string, any>>
+
+  titleTemplate?: string | ((title: string) => string)
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -37,7 +37,7 @@ describe('pages', () => {
     // should render text
     expect(html).toContain('Hello Nuxt 3!')
     // should render <Head> components
-    expect(html).toContain('<title>Basic fixture</title>')
+    expect(html).toContain('<title>Basic fixture - Fixture</title>')
     // should inject runtime config
     expect(html).toContain('RuntimeConfig | testConfig: 123')
     // composables auto import
@@ -119,7 +119,7 @@ describe('pages', () => {
 describe('head tags', () => {
   it('should render tags', async () => {
     const html = await $fetch('/head')
-    expect(html).toContain('<title>Using a dynamic component</title>')
+    expect(html).toContain('<title>Using a dynamic component - Fixture</title>')
     expect(html).not.toContain('<meta name="description" content="first">')
     expect(html).toContain('<meta name="description" content="overriding with an inline useHead call">')
     expect(html).toMatch(/<html[^>]*class="html-attrs-test"/)

--- a/test/fixtures/basic/plugins/my-plugin.ts
+++ b/test/fixtures/basic/plugins/my-plugin.ts
@@ -1,4 +1,7 @@
 export default defineNuxtPlugin(() => {
+  useHead({
+    titleTemplate: '%s - Fixture'
+  })
   return {
     provide: {
       myPlugin: () => 'Injected by my-plugin'


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/3522, https://github.com/nuxt/framework/discussions/1768

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds `titleTemplate` support to Nuxt 3, as well as enabling `viewport` and `charset` shorthands (which were type-hinted to users but hitherto ineffective).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

