### PR TITLE
fix(nuxt3): handle prematurely ended `res` object

### DIFF
--- a/packages/nuxt3/src/app/composables/cookie.ts
+++ b/packages/nuxt3/src/app/composables/cookie.ts
@@ -65,7 +65,7 @@ function writeClientCookie (name: string, value: any, opts: CookieSerializeOptio
 }
 
 function writeServerCookie (event: CompatibilityEvent, name: string, value: any, opts: CookieSerializeOptions = {}) {
-  if (event) {
+  if (event && !event.res.writableEnded) {
     // TODO: Try to smart join with existing Set-Cookie headers
     appendHeader(event, 'Set-Cookie', serializeCookie(name, value, opts))
   }

--- a/packages/nuxt3/src/app/plugins/router.ts
+++ b/packages/nuxt3/src/app/plugins/router.ts
@@ -220,7 +220,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
   if (process.server) {
     nuxtApp.hooks.hookOnce('app:created', async () => {
       await router.push(nuxtApp.ssrContext.url)
-      if (route.fullPath !== nuxtApp.ssrContext.url) {
+      if (route.fullPath !== nuxtApp.ssrContext.url && !nuxtApp.ssrContext.res.writableEnded) {
         nuxtApp.ssrContext.res.setHeader('Location', route.fullPath)
         nuxtApp.ssrContext.res.statusCode = 301
         nuxtApp.ssrContext.res.end()

--- a/packages/nuxt3/src/pages/runtime/router.ts
+++ b/packages/nuxt3/src/pages/runtime/router.ts
@@ -168,7 +168,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       router.push(nuxtApp.ssrContext.url)
 
       router.afterEach((to) => {
-        if (to.fullPath !== nuxtApp.ssrContext.url) {
+        if (to.fullPath !== nuxtApp.ssrContext.url && !nuxtApp.ssrContext.res.writableEnded) {
           nuxtApp.ssrContext.res.setHeader('Location', to.fullPath)
           nuxtApp.ssrContext.res.statusCode = 301
           nuxtApp.ssrContext.res.end()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

related: #4244

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's possible before these points for the request to have been ended (such as in a previous `app:rendered` or in a router middleware).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

