### PR TITLE
fix(nuxt3): re-enable computed metadata in useHead

### DIFF
--- a/packages/nuxt3/src/head/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt3/src/head/runtime/lib/vueuse-head.plugin.ts
@@ -17,22 +17,24 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const titleTemplate = ref<MetaObject['titleTemplate']>()
 
-  nuxtApp._useHead = (meta: MetaObject | ComputedGetter<MetaObject>) => {
-    titleTemplate.value = (unref(meta) as MetaObject).titleTemplate || titleTemplate.value
+  nuxtApp._useHead = (_meta: MetaObject | ComputedGetter<MetaObject>) => {
+    const meta = ref<MetaObject>(_meta)
+    if ('titleTemplate' in meta.value) {
+      titleTemplate.value = meta.value.titleTemplate
+    }
 
     const headObj = computed(() => {
       const overrides: MetaObject = { meta: [] }
-      const val = unref(meta) as MetaObject
-      if (titleTemplate.value && 'title' in val) {
-        overrides.title = typeof titleTemplate.value === 'function' ? titleTemplate.value(val.title) : titleTemplate.value.replace(/%s/g, val.title)
+      if (titleTemplate.value && 'title' in meta.value) {
+        overrides.title = typeof titleTemplate.value === 'function' ? titleTemplate.value(meta.value.title) : titleTemplate.value.replace(/%s/g, meta.value.title)
       }
-      if (val.charset) {
-        overrides.meta!.push({ key: 'charset', charset: val.charset })
+      if (meta.value.charset) {
+        overrides.meta!.push({ key: 'charset', charset: meta.value.charset })
       }
-      if (val.viewport) {
-        overrides.meta!.push({ name: 'viewport', content: val.viewport })
+      if (meta.value.viewport) {
+        overrides.meta!.push({ name: 'viewport', content: meta.value.viewport })
       }
-      return defu(overrides, val)
+      return defu(overrides, meta.value)
     })
     head.addHeadObjs(headObj as any)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4258

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves the regression for computed metadata (which worked before https://github.com/nuxt/framework/pull/4221).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

