### PR TITLE
fix(nuxt3)!: preserve runtime-config structure for client-side

### DIFF
--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -120,8 +120,12 @@ export function createNuxtApp (options: CreateOptions) {
 
   // Expose runtime config
   if (process.server) {
-    nuxtApp.provide('config', options.ssrContext.runtimeConfig.private)
-    nuxtApp.payload.config = options.ssrContext.runtimeConfig.public
+    nuxtApp.provide('config', options.ssrContext.runtimeConfig)
+    // Client's runtime-config
+    nuxtApp.payload.config = {
+      public: options.ssrContext.runtimeConfig.public,
+      app: options.ssrContext.runtimeConfig.app
+    }
   } else {
     nuxtApp.provide('config', reactive(nuxtApp.payload.config))
   }

--- a/packages/nuxt3/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt3/src/core/runtime/nitro/renderer.ts
@@ -32,7 +32,7 @@ const getSPARenderer = cachedResult(async () => {
     ssrContext.nuxt = {
       serverRendered: false,
       config: {
-        ...config.public,
+        public: config.public,
         app: config.app
       }
     }
@@ -84,13 +84,12 @@ export default eventHandler(async (event) => {
   }
 
   // Initialize ssr context
-  const config = useRuntimeConfig()
   const ssrContext = {
     url,
     event,
     req: event.req,
     res: event.res,
-    runtimeConfig: { private: config, public: { ...config.public, app: config.app } },
+    runtimeConfig: useRuntimeConfig(),
     noSSR: event.req.headers['x-nuxt-no-ssr'],
 
     error: ssrError,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With changes of #4254, we introduced `.public` to the runtime config but it was being flattened when using `useRuntimeConfig` on the client-side. This makes `useRuntimeConfig` returned interface identical between client-side and server-side.

Previously (client-sie code)

```js
// nuxt.config
publicRuntimeConfig: {
 test: 123
}
```

```js
// usage
useRuntimeConfig().test
```

Using new `runtimeConfig`:

```js
// nuxt.config
runtimeConfig: {
 public: {
   test: 123
 }
}
```

```js
// usage
useRuntimeConfig().public.test
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

