### PR TITLE
fix(bridge, nuxt3): backward compatibility to access runtime config in client

### DIFF
--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -127,7 +127,24 @@ export function createNuxtApp (options: CreateOptions) {
       app: options.ssrContext.runtimeConfig.app
     }
   } else {
-    nuxtApp.provide('config', reactive(nuxtApp.payload.config))
+    const runtimeConfig = reactive(nuxtApp.payload.config)
+    const copatibilityConfig = new Proxy(runtimeConfig, {
+      get (target, prop) {
+        if (prop === 'public') {
+          return target.public
+        }
+        return target[prop] ?? target.public[prop]
+      },
+      set (target, prop, value) {
+        if (prop === 'public' || prop === 'app') {
+          return false // Throws TypeError
+        }
+        target[prop] = value
+        target.public[prop] = value
+        return true
+      }
+    })
+    nuxtApp.provide('config', copatibilityConfig)
   }
 
   return nuxtApp


### PR DESCRIPTION
…n client

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: https://github.com/nuxt/framework/pull/4254, https://github.com/nuxt/framework/pull/4267

This PR allows `useRuntimeConfig()` in the client-side to be used with compatible access from top-level keys to read or update public config. Data will be asynced with `.public` namespace.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

