### PR TITLE
fix(nuxi): don't use glob

### DIFF
--- a/packages/nuxi/src/utils/fs.ts
+++ b/packages/nuxi/src/utils/fs.ts
@@ -14,7 +14,7 @@ export async function exists (path: string) {
 }
 
 export async function clearDir (path: string) {
-  await promisify(rimraf)(path)
+  await promisify(rimraf)(path, { glob: false })
   await fsp.mkdir(path, { recursive: true })
 }
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If we can't resolve `glob` from `nuxi` entrypoint, it will throw even though we're not using the feature in `clearDir`. this disables it: see https://github.com/isaacs/rimraf#options