### PR TITLE
docs: update url to new unjs/nitro repo

### DIFF
--- a/docs/content/2.guide/1.concepts/1.introduction.md
+++ b/docs/content/2.guide/1.concepts/1.introduction.md
@@ -28,7 +28,7 @@ Nuxt is composed of different [core packages](https://github.com/nuxt/framework/
 - Core Engine: [nuxt3](https://github.com/nuxt/framework/tree/main/packages/nuxt3)
 - Bundlers: [@nuxt/vite-builder](https://github.com/nuxt/framework/tree/main/packages/vite) and [@nuxt/webpack-builder](https://github.com/nuxt/framework/tree/main/packages/webpack)
 - Command line interface: [nuxi](https://github.com/nuxt/framework/tree/main/packages/nuxi)
-- Server engine: [@nuxtjs/nitro](https://github.com/unjs/nitro)
+- Server engine: [nitro](https://github.com/unjs/nitro)
 - Development kit: [@nuxt/kit](https://github.com/nuxt/framework/tree/main/packages/kit)
 - Nuxt 2 Bridge: [@nuxt/bridge](https://github.com/nuxt/framework/tree/main/packages/bridge)
 ::

--- a/docs/content/2.guide/1.concepts/1.introduction.md
+++ b/docs/content/2.guide/1.concepts/1.introduction.md
@@ -28,7 +28,7 @@ Nuxt is composed of different [core packages](https://github.com/nuxt/framework/
 - Core Engine: [nuxt3](https://github.com/nuxt/framework/tree/main/packages/nuxt3)
 - Bundlers: [@nuxt/vite-builder](https://github.com/nuxt/framework/tree/main/packages/vite) and [@nuxt/webpack-builder](https://github.com/nuxt/framework/tree/main/packages/webpack)
 - Command line interface: [nuxi](https://github.com/nuxt/framework/tree/main/packages/nuxi)
-- Server engine: [@nuxt/nitro](https://github.com/nuxt/framework/tree/main/packages/nitro)
+- Server engine: [@nuxtjs/nitro](https://github.com/unjs/nitro)
 - Development kit: [@nuxt/kit](https://github.com/nuxt/framework/tree/main/packages/kit)
 - Nuxt 2 Bridge: [@nuxt/bridge](https://github.com/nuxt/framework/tree/main/packages/bridge)
 ::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 #4323

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The page https://v3.nuxtjs.org/guide/concepts/introduction/ has "Server engine: @nuxt/nitro" linked to https://github.com/nuxt/framework/tree/main/packages/nitro which doesn't exist anymore. The repo is now available at https://github.com/unjs/nitro (thanks daniel for guiding me there)

Not sure if we should change the url text to "Server engine: unjs/nitro" as well?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

