### PR TITLE
feat(nuxt3): allow manually enabling/disabling the ad-hoc pages module

### DIFF
--- a/packages/nuxt3/src/pages/module.ts
+++ b/packages/nuxt3/src/pages/module.ts
@@ -9,15 +9,15 @@ import { TransformMacroPlugin, TransformMacroPluginOptions } from './macros'
 
 export default defineNuxtModule({
   meta: {
-    name: 'router'
+    name: 'pages'
   },
   setup (_options, nuxt) {
     const pagesDirs = nuxt.options._layers.map(
       layer => resolve(layer.config.srcDir, layer.config.dir?.pages || 'pages')
     )
 
-    // Disable module (and use universal router) if pages dir do not exists
-    if (!pagesDirs.some(dir => existsSync(dir))) {
+    // Disable module (and use universal router) if pages dir do not exists or user has disabled it
+    if (nuxt.options.pages === false || (nuxt.options.pages !== true && !pagesDirs.some(dir => existsSync(dir)))) {
       addPlugin(resolve(distDir, 'app/plugins/router'))
       return
     }

--- a/packages/schema/src/config/_adhoc.ts
+++ b/packages/schema/src/config/_adhoc.ts
@@ -35,4 +35,13 @@ export default {
     global: false,
     dirs: []
   },
+
+  /**
+   * Whether to use the vue-router integration in Nuxt 3. If you do not provide a value it will be
+   * enabled if you have a `pages/` directory in your source folder.
+   *
+   * @type {boolean}
+   * @version 3
+   */
+  pages: undefined
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2277

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows manually setting `nuxt.options.pages` to `true` or `false` to force enable or disable the ad-hoc module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

