### PR TITLE
fix(nuxi): call listen on each nuxt restart

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -61,6 +61,7 @@ export default defineNuxtCommand({
         }
         currentNuxt = await loadNuxt({ rootDir, dev: true, ready: false })
         await currentNuxt.ready()
+        await currentNuxt.hooks.callHook('listen', listener.server, listener)
         await Promise.all([
           writeTypes(currentNuxt).catch(console.error),
           buildNuxt(currentNuxt)
@@ -105,9 +106,6 @@ export default defineNuxtCommand({
     })
 
     await load(false)
-    if (currentNuxt) {
-      await currentNuxt.hooks.callHook('listen', listener.server, listener)
-    }
 
     return 'wait'
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3835

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a tricky one. Current behaviour is that the `listen` hook only runs once, and it's called by `nuxi`. Even when Nuxt restarts, the same listener persists, so on one level, it makes sense to call it once.

However, modules and other nuxt context re-initialises so it probably makes sense to re-call this hook on each reinitialisation of nuxt.

We might also consider adding functionality to allow users to hook into the Nitro dev server, which might mean this PR is unneeded.

Context: https://github.com/nuxt/framework/pull/2772

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

