### PR TITLE
feat(nuxt3): pass rendered HTML to hook

### DIFF
--- a/docs/content/3.api/4.advanced/1.hooks.md
+++ b/docs/content/3.api/4.advanced/1.hooks.md
@@ -16,6 +16,7 @@ Hook                   | Arguments         | Description
 `app:suspense:resolve` | `appComponent`    | On [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) resolved event
 `page:start`           | `pageComponent`   | On [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) pending event
 `page:finish`          | `pageComponent`   | On [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) resolved event
+`page:rendered`        | `html`            | When SSR rendering for the whole page is done
 `meta:register`        | `metaRenderers`   | (internal)
 `vue:setup`            | -                 | (internal)
 

--- a/packages/nuxt3/src/app/nuxt.ts
+++ b/packages/nuxt3/src/app/nuxt.ts
@@ -23,6 +23,7 @@ export interface RuntimeNuxtHooks {
   'app:beforeMount': (app: App<Element>) => HookResult
   'app:mounted': (app: App<Element>) => HookResult
   'app:rendered': () => HookResult
+  'page:rendered': (html: string) => HookResult
   'app:suspense:resolve': (Component?: VNode) => HookResult
   'app:error': (err: any) => HookResult
   'app:error:cleared': (options: { redirect?: string }) => HookResult

--- a/packages/nuxt3/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt3/src/core/runtime/nitro/renderer.ts
@@ -133,6 +133,7 @@ export default eventHandler(async (event) => {
     event.res.setHeader('Content-Type', 'text/javascript;charset=UTF-8')
   } else {
     data = await renderHTML(payload, rendered, ssrContext)
+    await ssrContext.nuxt.hooks.callHook('page:rendered')(data)
     event.res.setHeader('Content-Type', 'text/html;charset=UTF-8')
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Issue: https://github.com/nuxt/framework/issues/4339
Discussion: https://github.com/nuxt/framework/discussions/4334

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt 3 doesn't have a hook that passes the rendered HTML. Having this hook is critical for having caching work on Cloudflare Workers. The change introduces a new hook called `page:rendered` with the rendered HTML as a parameter, so that third parties can save it to caches such as Cloudflare Workers and Redis. The change is minimal and doesn't introduce breaking changes. I have tested the change locally, and it works as described. I desperately need this change to be able to deploy a production site.

See Cloudflare's docs for more context: https://developers.cloudflare.com/workers/runtime-apis/cache/.

This resolves issue #4339.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

