### PR TITLE
fix(nuxt3): force nitro dev preset in dev mode

### DIFF
--- a/packages/nuxt3/src/core/nitro.ts
+++ b/packages/nuxt3/src/core/nitro.ts
@@ -90,6 +90,10 @@ export async function initNitro (nuxt: Nuxt) {
     }
   })
 
+  if (nuxt.options.dev) {
+    nitroConfig.preset = 'nitro-dev'
+  }
+
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4398

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

At the moment, there's only one dev preset: `nitro-dev`. So it seems it might be a better dx to force it in dev mode, letting users do:

```js
nitro: {
  preset: 'cloudflare'
  // rather than
  preset: process.env.NODE_ENV === 'production' ? 'cloudflare' : 'nitro-dev'
}
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

