### PR TITLE
fix(nuxt3): always generate `/` route

### DIFF
--- a/packages/nuxt3/src/core/nitro.ts
+++ b/packages/nuxt3/src/core/nitro.ts
@@ -52,7 +52,7 @@ export async function initNitro (nuxt: Nuxt) {
     prerender: {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: []
-        .concat(nuxt.options.generate.routes)
+        .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
     },
     externals: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nitro adds `/` to the routes list by default (https://github.com/unjs/nitro/blob/ba3323e07fa8429f88b8d55ae5e61d4131c584f1/src/prerender.ts#L13) but if we add a custom prerender route, this will be disabled. 

This PR makes sure that with `nuxi generate` we always crawl `/` route. Also only includes (legacy) `generate.routes` for generate command not for normal `nuxi build` as hybrid routes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

