### PR TITLE
fix(schema): use entire object for `app` properties

### DIFF
--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -726,9 +726,9 @@ export default {
       ...get('privateRuntimeConfig'),
       public: get('publicRuntimeConfig'),
       app: {
-        baseURL: get('app.baseURL'),
-        buildAssetsDir: get('app.buildAssetsDir'),
-        cdnURL: get('app.cdnURL'),
+        baseURL: get('app').baseURL,
+        buildAssetsDir: get('app').buildAssetsDir,
+        cdnURL: get('app').cdnURL,
       }
     })
   },

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -192,7 +192,7 @@ export default {
      * @version 2
      */
     publicPath: {
-      $resolve: (val, get) => val ? withTrailingSlash(normalizeURL(val)) : get('app.buildAssetsDir')
+      $resolve: (val, get) => val ? withTrailingSlash(normalizeURL(val)) : get('app').buildAssetsDir
     },
 
     /**

--- a/packages/schema/src/config/generate.ts
+++ b/packages/schema/src/config/generate.ts
@@ -160,7 +160,7 @@ export default {
      * The full path to the directory underneath `/_nuxt/` where static assets
      * (payload, state and manifest files) will live.
      */
-    base: { $resolve: (val, get) => val || joinURL(get('app.buildAssetsDir'), get('generate.dir')) },
+    base: { $resolve: (val, get) => val || joinURL(get('app').buildAssetsDir, get('generate.dir')) },
     /** The full path to the versioned directory where static assets for the current buidl are located. */
     versionBase: { $resolve: (val, get) => val || joinURL(get('generate.base'), get('generate.version')) },
     /** A unique string to uniquely identify payload versions (defaults to the current timestamp).  */

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -33,7 +33,7 @@ export default {
    * @version 2
    */
   base: {
-    $resolve: (val, get) => val ? withTrailingSlash(normalizeURL(val)) : get('app.baseURL')
+    $resolve: (val, get) => val ? withTrailingSlash(normalizeURL(val)) : get('app').baseURL
   },
 
   /** @private */


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4112

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR resolves an issue accessing the default value of `app.buildAssetsURL`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

