### PR TITLE
fix(nuxt3): don't rely on auto-imports for `defineAsyncComponent`

### DIFF
--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -52,8 +52,8 @@ function transform (code: string, id: string, components: Component[], mode: Loa
         imports.add(genImport('#app/components/client-only', [{ name: 'createClientOnly' }]))
       }
       if (lazy) {
-        // Nuxt will auto-import `defineAsyncComponent` for us
-        imports.add(`const ${identifier}_lazy = defineAsyncComponent(${genDynamicImport(component.filePath)})`)
+        imports.add(genImport('vue', [{ name: 'defineAsyncComponent', as: '__defineAsyncComponent' }]))
+        imports.add(`const ${identifier}_lazy = __defineAsyncComponent(${genDynamicImport(component.filePath)})`)
         return isClientOnly ? `createClientOnly(${identifier}_lazy)` : `${identifier}_lazy`
       } else {
         imports.add(genImport(component.filePath, [{ name: component.export, as: identifier }]))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4445

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Issue was the _order_ of the component loader plugin vs auto-imports plugin. But it's safer not to depend on auto-imports within components loader, so added explicit import instead.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

