### PR TITLE
fix(nuxi): don't kill analyze command

### DIFF
--- a/packages/nuxi/src/commands/analyze.ts
+++ b/packages/nuxi/src/commands/analyze.ts
@@ -65,5 +65,7 @@ export default defineNuxtCommand({
 </html>`)
 
     await listen(app)
+
+    return 'wait'
   }
 })


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
We need to return 'wait` in order for Nuxt to not kill the analyze command starting a server.


