### PR TITLE
fix(nuxt): add `app:documentTemplate` to replace old `nitro:document`…

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -88,9 +88,9 @@ const defaultAppTemplate = `
 export const appViewTemplate = {
   filename: 'views/document.template.mjs',
   write: true,
-  async getContents (ctx: TemplateContext) {
+  async getContents ({ nuxt }: TemplateContext) {
     const context = { contents: defaultAppTemplate }
-    await ctx.nuxt.hooks.callHook('app:documentTemplate', context)
+    await nuxt.hooks.callHook('app:documentTemplate', context)
 
     // eslint-disable-next-line no-template-curly-in-string
     return `export default (params) => \`${context.contents.replace(/{{ (\w+) }}/g, '${params.$1}')}\``

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -70,23 +70,30 @@ export const serverPluginTemplate = {
   }
 }
 
+const defaultAppTemplate = `
+<!DOCTYPE html>
+<html {{ HTML_ATTRS }}>
+
+<head {{ HEAD_ATTRS }}>
+  {{ HEAD }}
+</head>
+
+<body {{ BODY_ATTRS }}>{{ BODY_PREPEND }}
+  {{ APP }}
+</body>
+
+</html>
+`.trim()
+
 export const appViewTemplate = {
   filename: 'views/document.template.mjs',
   write: true,
-  getContents () {
-    return `export default (params) => \`<!DOCTYPE html>
-<html \${params.HTML_ATTRS}>
+  async getContents (ctx: TemplateContext) {
+    const context = { contents: defaultAppTemplate }
+    await ctx.nuxt.hooks.callHook('app:documentTemplate', context)
 
-<head \${params.HEAD_ATTRS}>
-  \${params.HEAD}
-</head>
-
-<body \${params.BODY_ATTRS}>\${params.BODY_PREPEND}
-  \${params.APP}
-</body>
-
-</html>\`
-`
+    // eslint-disable-next-line no-template-curly-in-string
+    return `export default (params) => \`${context.contents.replace(/{{ (\w+) }}/g, '${params.$1}')}\``
   }
 }
 

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -69,6 +69,7 @@ export interface NuxtHooks {
   'app:resolve': (app: NuxtApp) => HookResult
   'app:templates': (app: NuxtApp) => HookResult
   'app:templatesGenerated': (app: NuxtApp) => HookResult
+  'app:documentTemplate': ({ contents: string }) => HookResult
   'builder:generateApp': () => HookResult
   'pages:extend': (pages: NuxtPage[]) => HookResult
   'pages:middleware:extend': (middleware: NuxtMiddleware[]) => HookResult


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds back the ability to manipulate the document template removed in https://github.com/nuxt/framework/pull/4187 as part of nitropack migration.

`nitro:document` is currently used in `@nuxtjs/color-mode` and this kind of functionality could be useful in other modules too. (This could also be resolved with another way to manipulate what is rendered in `ssr: false`.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

