### PR TITLE
Docs: "Experimental" text was missing

### DIFF
--- a/docs/content/1.getting-started/2.migration.md
+++ b/docs/content/1.getting-started/2.migration.md
@@ -25,4 +25,4 @@ Auto Imports             | ❌             | ✅               | ✅
 Webpack                  | 4              | 4                | 5
 Vite                     | ⚠️ Partial     | 🚧 Partial       | 🚧 Experimental
 Nuxi CLI                 | ❌ Old         | ✅ nuxi          | ✅ nuxi
-Static sites             | ✅             | ✅               | 🚧
+Static sites             | ✅             | ✅               | 🚧 Experimental


### PR DESCRIPTION
The last icon from "Static sites" and "Nuxt 3" the "Experimental" text was missing

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the docs of migration a text was missing. When I read it, the "experimental" features was not clear so I just add the text of "Experimental" to make it clear. Like it is 2 line above.


