### PR TITLE
feat: allow disabling sourcemap generation

### DIFF
--- a/packages/nuxt/src/auto-imports/module.ts
+++ b/packages/nuxt/src/auto-imports/module.ts
@@ -74,8 +74,8 @@ export default defineNuxtModule<Partial<AutoImportsOptions>>({
       })
     } else {
       // Transform to inject imports in production mode
-      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.dev }))
-      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.dev }))
+      addVitePlugin(TransformPlugin.vite({ ctx, options, sourceMap: nuxt.options.dev }))
+      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourceMap: nuxt.options.dev }))
     }
 
     const regenerateAutoImports = async () => {

--- a/packages/nuxt/src/auto-imports/module.ts
+++ b/packages/nuxt/src/auto-imports/module.ts
@@ -74,8 +74,8 @@ export default defineNuxtModule<Partial<AutoImportsOptions>>({
       })
     } else {
       // Transform to inject imports in production mode
-      addVitePlugin(TransformPlugin.vite({ ctx, options }))
-      addWebpackPlugin(TransformPlugin.webpack({ ctx, options }))
+      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.dev }))
+      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.dev }))
     }
 
     const regenerateAutoImports = async () => {

--- a/packages/nuxt/src/auto-imports/module.ts
+++ b/packages/nuxt/src/auto-imports/module.ts
@@ -74,8 +74,8 @@ export default defineNuxtModule<Partial<AutoImportsOptions>>({
       })
     } else {
       // Transform to inject imports in production mode
-      addVitePlugin(TransformPlugin.vite({ ctx, options, sourceMap: nuxt.options.dev }))
-      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourceMap: nuxt.options.dev }))
+      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.sourcemap }))
+      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.sourcemap }))
     }
 
     const regenerateAutoImports = async () => {

--- a/packages/nuxt/src/auto-imports/transform.ts
+++ b/packages/nuxt/src/auto-imports/transform.ts
@@ -4,7 +4,7 @@ import { parseQuery, parseURL } from 'ufo'
 import { Unimport } from 'unimport'
 import { AutoImportsOptions } from '@nuxt/schema'
 
-export const TransformPlugin = createUnplugin(({ ctx, options, sourceMap }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourceMap?: boolean }) => {
+export const TransformPlugin = createUnplugin(({ ctx, options, sourcemap }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourcemap?: boolean }) => {
   return {
     name: 'nuxt:auto-imports-transform',
     enforce: 'post',
@@ -39,7 +39,7 @@ export const TransformPlugin = createUnplugin(({ ctx, options, sourceMap }: {ctx
       }
       return {
         code,
-        map: sourceMap && s.generateMap({ source: id, includeContent: true })
+        map: sourcemap && s.generateMap({ source: id, includeContent: true })
       }
     }
   }

--- a/packages/nuxt/src/auto-imports/transform.ts
+++ b/packages/nuxt/src/auto-imports/transform.ts
@@ -4,7 +4,7 @@ import { parseQuery, parseURL } from 'ufo'
 import { Unimport } from 'unimport'
 import { AutoImportsOptions } from '@nuxt/schema'
 
-export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourceMap?: boolean }) => {
+export const TransformPlugin = createUnplugin(({ ctx, options, sourceMap }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourceMap?: boolean }) => {
   return {
     name: 'nuxt:auto-imports-transform',
     enforce: 'post',
@@ -39,7 +39,7 @@ export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport,
       }
       return {
         code,
-        map: options.sourceMap && s.generateMap({ source: id, includeContent: true })
+        map: sourceMap && s.generateMap({ source: id, includeContent: true })
       }
     }
   }

--- a/packages/nuxt/src/auto-imports/transform.ts
+++ b/packages/nuxt/src/auto-imports/transform.ts
@@ -4,7 +4,7 @@ import { parseQuery, parseURL } from 'ufo'
 import { Unimport } from 'unimport'
 import { AutoImportsOptions } from '@nuxt/schema'
 
-export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourcemap?: boolean }) => {
+export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourceMap?: boolean }) => {
   return {
     name: 'nuxt:auto-imports-transform',
     enforce: 'post',
@@ -39,7 +39,7 @@ export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport,
       }
       return {
         code,
-        map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
+        map: options.sourceMap && s.generateMap({ source: id, includeContent: true })
       }
     }
   }

--- a/packages/nuxt/src/auto-imports/transform.ts
+++ b/packages/nuxt/src/auto-imports/transform.ts
@@ -4,7 +4,7 @@ import { parseQuery, parseURL } from 'ufo'
 import { Unimport } from 'unimport'
 import { AutoImportsOptions } from '@nuxt/schema'
 
-export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport, options: Partial<AutoImportsOptions> }) => {
+export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport, options: Partial<AutoImportsOptions>, sourcemap?: boolean }) => {
   return {
     name: 'nuxt:auto-imports-transform',
     enforce: 'post',
@@ -39,7 +39,7 @@ export const TransformPlugin = createUnplugin(({ ctx, options }: {ctx: Unimport,
       }
       return {
         code,
-        map: s.generateMap({ source: id, includeContent: true })
+        map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
       }
     }
   }

--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -9,7 +9,7 @@ import { pascalCase } from 'scule'
 interface LoaderOptions {
   getComponents(): Component[]
   mode: 'server' | 'client'
-  sourceMap?: boolean
+  sourcemap?: boolean
 }
 
 export const loaderPlugin = createUnplugin((options: LoaderOptions) => ({
@@ -60,7 +60,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => ({
     if (s.hasChanged()) {
       return {
         code: s.toString(),
-        map: options.sourceMap && s.generateMap({ source: id, includeContent: true })
+        map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
       }
     }
   }

--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -9,7 +9,7 @@ import { pascalCase } from 'scule'
 interface LoaderOptions {
   getComponents(): Component[]
   mode: 'server' | 'client'
-  sourcemap?: boolean
+  sourceMap?: boolean
 }
 
 export const loaderPlugin = createUnplugin((options: LoaderOptions) => ({
@@ -60,7 +60,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => ({
     if (s.hasChanged()) {
       return {
         code: s.toString(),
-        map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
+        map: options.sourceMap && s.generateMap({ source: id, includeContent: true })
       }
     }
   }

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -132,6 +132,7 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       config.plugins = config.plugins || []
       config.plugins.push(loaderPlugin.vite({
+        sourcemap: nuxt.options.dev,
         getComponents,
         mode: isClient ? 'client' : 'server'
       }))
@@ -140,6 +141,7 @@ export default defineNuxtModule<ComponentsOptions>({
       configs.forEach((config) => {
         config.plugins = config.plugins || []
         config.plugins.push(loaderPlugin.webpack({
+          sourcemap: nuxt.options.dev,
           getComponents,
           mode: config.name === 'client' ? 'client' : 'server'
         }))

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -132,7 +132,7 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       config.plugins = config.plugins || []
       config.plugins.push(loaderPlugin.vite({
-        sourceMap: nuxt.options.dev,
+        sourcemap: nuxt.options.sourcemap,
         getComponents,
         mode: isClient ? 'client' : 'server'
       }))
@@ -141,7 +141,7 @@ export default defineNuxtModule<ComponentsOptions>({
       configs.forEach((config) => {
         config.plugins = config.plugins || []
         config.plugins.push(loaderPlugin.webpack({
-          sourceMap: nuxt.options.dev,
+          sourcemap: nuxt.options.sourcemap,
           getComponents,
           mode: config.name === 'client' ? 'client' : 'server'
         }))

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -132,7 +132,7 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       config.plugins = config.plugins || []
       config.plugins.push(loaderPlugin.vite({
-        sourcemap: nuxt.options.dev,
+        sourceMap: nuxt.options.dev,
         getComponents,
         mode: isClient ? 'client' : 'server'
       }))
@@ -141,7 +141,7 @@ export default defineNuxtModule<ComponentsOptions>({
       configs.forEach((config) => {
         config.plugins = config.plugins || []
         config.plugins.push(loaderPlugin.webpack({
-          sourcemap: nuxt.options.dev,
+          sourceMap: nuxt.options.dev,
           getComponents,
           mode: config.name === 'client' ? 'client' : 'server'
         }))

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -55,6 +55,7 @@ export async function initNitro (nuxt: Nuxt) {
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
     },
+    sourceMap: nuxt.options.dev,
     externals: {
       inline: [
         ...(nuxt.options.dev ? [] : ['vue', '@vue/', '@nuxt/', nuxt.options.buildDir]),

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -55,7 +55,7 @@ export async function initNitro (nuxt: Nuxt) {
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
     },
-    sourceMap: nuxt.options.dev,
+    sourcemap: nuxt.options.sourcemap,
     externals: {
       inline: [
         ...(nuxt.options.dev ? [] : ['vue', '@vue/', '@nuxt/', nuxt.options.buildDir]),

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -63,8 +63,8 @@ async function initNuxt (nuxt: Nuxt) {
   addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Add unctx transform
-  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: nuxt.options.dev }))
-  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: nuxt.options.dev }))
+  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourceMap: nuxt.options.dev }))
+  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourceMap: nuxt.options.dev }))
 
   // Init user modules
   await nuxt.callHook('modules:before', { nuxt } as ModuleContainer)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -63,8 +63,8 @@ async function initNuxt (nuxt: Nuxt) {
   addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Add unctx transform
-  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourceMap: nuxt.options.dev }))
-  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourceMap: nuxt.options.dev }))
+  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: nuxt.options.sourcemap }))
+  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: nuxt.options.sourcemap }))
 
   // Init user modules
   await nuxt.callHook('modules:before', { nuxt } as ModuleContainer)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -63,8 +63,8 @@ async function initNuxt (nuxt: Nuxt) {
   addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Add unctx transform
-  addVitePlugin(UnctxTransformPlugin(nuxt).vite())
-  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack())
+  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: nuxt.options.dev }))
+  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: nuxt.options.dev }))
 
   // Init user modules
   await nuxt.callHook('modules:before', { nuxt } as ModuleContainer)

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -12,7 +12,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
   nuxt.hook('app:resolve', (_app) => { app = _app })
   nuxt.hook('pages:middleware:extend', (_middlewares) => { middleware = _middlewares })
 
-  return createUnplugin(() => ({
+  return createUnplugin((options: { sourcemap?: boolean } = {}) => ({
     name: 'unctx:transfrom',
     enforce: 'post',
     transformInclude (id) {
@@ -23,7 +23,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
       if (result) {
         return {
           code: result.code,
-          map: result.magicString.generateMap({ source: id, includeContent: true })
+          map: options.sourcemap && result.magicString.generateMap({ source: id, includeContent: true })
         }
       }
     }

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -12,7 +12,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
   nuxt.hook('app:resolve', (_app) => { app = _app })
   nuxt.hook('pages:middleware:extend', (_middlewares) => { middleware = _middlewares })
 
-  return createUnplugin((options: { sourceMap?: boolean } = {}) => ({
+  return createUnplugin((options: { sourcemap?: boolean } = {}) => ({
     name: 'unctx:transfrom',
     enforce: 'post',
     transformInclude (id) {
@@ -23,7 +23,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
       if (result) {
         return {
           code: result.code,
-          map: options.sourceMap && result.magicString.generateMap({ source: id, includeContent: true })
+          map: options.sourcemap && result.magicString.generateMap({ source: id, includeContent: true })
         }
       }
     }

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -12,7 +12,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
   nuxt.hook('app:resolve', (_app) => { app = _app })
   nuxt.hook('pages:middleware:extend', (_middlewares) => { middleware = _middlewares })
 
-  return createUnplugin((options: { sourcemap?: boolean } = {}) => ({
+  return createUnplugin((options: { sourceMap?: boolean } = {}) => ({
     name: 'unctx:transfrom',
     enforce: 'post',
     transformInclude (id) {
@@ -23,7 +23,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
       if (result) {
         return {
           code: result.code,
-          map: options.sourcemap && result.magicString.generateMap({ source: id, includeContent: true })
+          map: options.sourceMap && result.magicString.generateMap({ source: id, includeContent: true })
         }
       }
     }

--- a/packages/nuxt/src/pages/macros.ts
+++ b/packages/nuxt/src/pages/macros.ts
@@ -7,6 +7,7 @@ import MagicString from 'magic-string'
 export interface TransformMacroPluginOptions {
   macros: Record<string, string>
   dev?: boolean
+  sourcemap?: boolean
 }
 
 export const TransformMacroPlugin = createUnplugin((options: TransformMacroPluginOptions) => {
@@ -24,7 +25,7 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
 
       function result () {
         if (s.hasChanged()) {
-          return { code: s.toString(), map: s.generateMap({ source: id, includeContent: true }) }
+          return { code: s.toString(), map: options.sourcemap && s.generateMap({ source: id, includeContent: true }) }
         }
       }
 

--- a/packages/nuxt/src/pages/macros.ts
+++ b/packages/nuxt/src/pages/macros.ts
@@ -7,7 +7,7 @@ import MagicString from 'magic-string'
 export interface TransformMacroPluginOptions {
   macros: Record<string, string>
   dev?: boolean
-  sourcemap?: boolean
+  sourceMap?: boolean
 }
 
 export const TransformMacroPlugin = createUnplugin((options: TransformMacroPluginOptions) => {
@@ -25,7 +25,7 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
 
       function result () {
         if (s.hasChanged()) {
-          return { code: s.toString(), map: options.sourcemap && s.generateMap({ source: id, includeContent: true }) }
+          return { code: s.toString(), map: options.sourceMap && s.generateMap({ source: id, includeContent: true }) }
         }
       }
 

--- a/packages/nuxt/src/pages/macros.ts
+++ b/packages/nuxt/src/pages/macros.ts
@@ -7,7 +7,7 @@ import MagicString from 'magic-string'
 export interface TransformMacroPluginOptions {
   macros: Record<string, string>
   dev?: boolean
-  sourceMap?: boolean
+  sourcemap?: boolean
 }
 
 export const TransformMacroPlugin = createUnplugin((options: TransformMacroPluginOptions) => {
@@ -25,7 +25,7 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
 
       function result () {
         if (s.hasChanged()) {
-          return { code: s.toString(), map: options.sourceMap && s.generateMap({ source: id, includeContent: true }) }
+          return { code: s.toString(), map: options.sourcemap && s.generateMap({ source: id, includeContent: true }) }
         }
       }
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -57,7 +57,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
       dev: nuxt.options.dev,
-      sourceMap: nuxt.options.dev,
+      sourcemap: nuxt.options.sourcemap,
       macros: {
         definePageMeta: 'meta'
       }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -57,6 +57,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
       dev: nuxt.options.dev,
+      sourcemap: nuxt.options.dev,
       macros: {
         definePageMeta: 'meta'
       }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -57,7 +57,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
       dev: nuxt.options.dev,
-      sourcemap: nuxt.options.dev,
+      sourceMap: nuxt.options.dev,
       macros: {
         definePageMeta: 'meta'
       }

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -23,6 +23,15 @@ export default {
     },
   },
   /**
+   * Whether to generate sourcemaps.
+   *
+   * By default, this option is enabled in development.
+   * @version 3
+   */
+  sourcemap: {
+    $resolve: (val, get) => val ?? get('dev')
+  },
+  /**
    * Shared build configuration.
    * @version 2
    * @version 3
@@ -132,7 +141,7 @@ export default {
      * @version 2
      */
     cssSourceMap: {
-      $resolve: (val, get) => val ?? get('dev')
+      $resolve: (val, get) => val ?? get('sourcemap') ?? get('dev')
     },
 
     /**
@@ -242,8 +251,8 @@ export default {
         ]
         for (const name of styleLoaders) {
           const loader = val[name]
-          if (loader && loader.sourceMap === undefined) {
-            loader.sourceMap = Boolean(get('build.cssSourceMap'))
+          if (loader && loader.sourcemap === undefined) {
+            loader.sourcemap = Boolean(get('build.cssSourceMap'))
           }
         }
         return val
@@ -315,7 +324,7 @@ export default {
      *
      * @see [terser-webpack-plugin documentation](https://github.com/webpack-contrib/terser-webpack-plugin)
      *
-     * @note Enabling sourceMap will leave `//# sourceMappingURL` linking comment at
+     * @note Enabling sourcemap will leave `//# sourcemappingURL` linking comment at
      * the end of each output file if webpack `config.devtool` is set to `source-map`.
      * @version 2
      */
@@ -493,7 +502,7 @@ export default {
           return postcssOptions
         }
       },
-      sourceMap: undefined,
+      sourcemap: undefined,
       implementation: undefined,
       order: ''
     },

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -25,12 +25,9 @@ export default {
   /**
    * Whether to generate sourcemaps.
    *
-   * By default, this option is enabled in development.
    * @version 3
    */
-  sourcemap: {
-    $resolve: (val, get) => val ?? get('dev')
-  },
+  sourcemap: true,
   /**
    * Shared build configuration.
    * @version 2

--- a/packages/vite/src/plugins/dynamic-base.ts
+++ b/packages/vite/src/plugins/dynamic-base.ts
@@ -5,7 +5,7 @@ import MagicString from 'magic-string'
 
 interface DynamicBasePluginOptions {
   globalPublicPath?: string
-  sourceMap?: boolean
+  sourcemap?: boolean
 }
 
 export const RelativeAssetPlugin = function (): Plugin {
@@ -98,7 +98,7 @@ export const DynamicBasePlugin = createUnplugin(function (options: DynamicBasePl
       if (s.hasChanged()) {
         return {
           code: s.toString(),
-          map: options.sourceMap && s.generateMap({ source: id, includeContent: true })
+          map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
         }
       }
     }

--- a/packages/vite/src/plugins/dynamic-base.ts
+++ b/packages/vite/src/plugins/dynamic-base.ts
@@ -5,7 +5,7 @@ import MagicString from 'magic-string'
 
 interface DynamicBasePluginOptions {
   globalPublicPath?: string
-  sourcemap?: boolean
+  sourceMap?: boolean
 }
 
 export const RelativeAssetPlugin = function (): Plugin {
@@ -98,7 +98,7 @@ export const DynamicBasePlugin = createUnplugin(function (options: DynamicBasePl
       if (s.hasChanged()) {
         return {
           code: s.toString(),
-          map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
+          map: options.sourceMap && s.generateMap({ source: id, includeContent: true })
         }
       }
     }

--- a/packages/vite/src/plugins/dynamic-base.ts
+++ b/packages/vite/src/plugins/dynamic-base.ts
@@ -5,6 +5,7 @@ import MagicString from 'magic-string'
 
 interface DynamicBasePluginOptions {
   globalPublicPath?: string
+  sourcemap?: boolean
 }
 
 export const RelativeAssetPlugin = function (): Plugin {
@@ -97,7 +98,7 @@ export const DynamicBasePlugin = createUnplugin(function (options: DynamicBasePl
       if (s.hasChanged()) {
         return {
           code: s.toString(),
-          map: s.generateMap({ source: id, includeContent: true })
+          map: options.sourcemap && s.generateMap({ source: id, includeContent: true })
         }
       }
     }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -65,7 +65,7 @@ export async function bundle (nuxt: Nuxt) {
         },
         plugins: [
           virtual(nuxt.vfs),
-          DynamicBasePlugin.vite()
+          DynamicBasePlugin.vite({ sourcemap: nuxt.options.dev })
         ],
         vue: {
           reactivityTransform: nuxt.options.experimental.reactivityTransform

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -65,7 +65,7 @@ export async function bundle (nuxt: Nuxt) {
         },
         plugins: [
           virtual(nuxt.vfs),
-          DynamicBasePlugin.vite({ sourcemap: nuxt.options.dev })
+          DynamicBasePlugin.vite({ sourceMap: nuxt.options.dev })
         ],
         vue: {
           reactivityTransform: nuxt.options.experimental.reactivityTransform

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -65,7 +65,7 @@ export async function bundle (nuxt: Nuxt) {
         },
         plugins: [
           virtual(nuxt.vfs),
-          DynamicBasePlugin.vite({ sourceMap: nuxt.options.dev })
+          DynamicBasePlugin.vite({ sourcemap: nuxt.options.sourcemap })
         ],
         vue: {
           reactivityTransform: nuxt.options.experimental.reactivityTransform

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -34,7 +34,7 @@ export async function bundle (nuxt: Nuxt) {
   // Configure compilers
   const compilers = webpackConfigs.map((config) => {
     config.plugins.push(DynamicBasePlugin.webpack({
-      sourceMap: nuxt.options.dev,
+      sourcemap: nuxt.options.sourcemap,
       globalPublicPath: '__webpack_public_path__'
     }))
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -34,7 +34,7 @@ export async function bundle (nuxt: Nuxt) {
   // Configure compilers
   const compilers = webpackConfigs.map((config) => {
     config.plugins.push(DynamicBasePlugin.webpack({
-      sourcemap: nuxt.options.dev,
+      sourceMap: nuxt.options.dev,
       globalPublicPath: '__webpack_public_path__'
     }))
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -34,6 +34,7 @@ export async function bundle (nuxt: Nuxt) {
   // Configure compilers
   const compilers = webpackConfigs.map((config) => {
     config.plugins.push(DynamicBasePlugin.webpack({
+      sourcemap: nuxt.options.dev,
       globalPublicPath: '__webpack_public_path__'
     }))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR disables sourcemap generation for our various transform plugins when building. (I would also be open to adding a `build.sourceMap` option that allows configuring sourcemap generation.)

I've seen one or two reports of memory issues when building, and have previously resolved this with turning off magic string sourcemaps. For context:

* https://github.com/nuxt/bridge/issues/151
* https://github.com/rollup/plugins/issues/1064
* https://github.com/Rich-Harris/magic-string/issues/195

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

