### PR TITLE
fix(vite): transform virtual templates

### DIFF
--- a/packages/vite/src/plugins/virtual.ts
+++ b/packages/vite/src/plugins/virtual.ts
@@ -1,7 +1,7 @@
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import type { Plugin } from 'rollup'
 
-const PREFIX = '\0virtual:'
+const PREFIX = 'virtual:'
 
 export default function virtual (vfs: Record<string, string>): Plugin {
   const extensions = ['', '.ts', '.vue', '.mjs', '.cjs', '.js', '.json']


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #454, resolves #2635

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Starting the prefix with `\0` seems to short-circuit the vite/rollup transform process, meaning future transform plugins weren't being run. This change means we can process virtual files in the same way we can the rest of source materials for the build.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

