### PR TITLE
fix(nuxi): don't strip file extensions from dirs in `tsconfig`

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -1,4 +1,4 @@
-import { promises as fsp, statSync } from 'node:fs'
+import { promises as fsp } from 'node:fs'
 import { isAbsolute, join, relative, resolve } from 'pathe'
 import { Nuxt, TSReference } from '@nuxt/schema'
 import defu from 'defu'

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -1,4 +1,4 @@
-import { promises as fsp } from 'node:fs'
+import { promises as fsp, statSync } from 'node:fs'
 import { isAbsolute, join, relative, resolve } from 'pathe'
 import { Nuxt, TSReference } from '@nuxt/schema'
 import defu from 'defu'
@@ -43,18 +43,17 @@ export const writeTypes = async (nuxt: Nuxt) => {
     if (excludedAlias.some(re => re.test(alias))) {
       continue
     }
-    const path = aliases[alias].replace(/(?<=\w)\.\w+$/g, '') /* remove extension */
-    const relativePath = isAbsolute(path)
-      ? relative(nuxt.options.rootDir, path) || '.'
-      : path
-    tsConfig.compilerOptions.paths[alias] = [relativePath]
+    const relativePath = isAbsolute(aliases[alias])
+      ? relative(nuxt.options.rootDir, aliases[alias]) || '.'
+      : aliases[alias]
 
-    try {
-      const { isDirectory } = await fsp.stat(resolve(nuxt.options.rootDir, relativePath))
-      if (isDirectory) {
-        tsConfig.compilerOptions.paths[`${alias}/*`] = [`${relativePath}/*`]
-      }
-    } catch { }
+    const stats = await fsp.stat(resolve(nuxt.options.rootDir, relativePath)).catch(() => null /* file does not exist */)
+    if (stats?.isDirectory()) {
+      tsConfig.compilerOptions.paths[alias] = [relativePath]
+      tsConfig.compilerOptions.paths[`${alias}/*`] = [`${relativePath}/*`]
+    } else {
+      tsConfig.compilerOptions.paths[alias] = [relativePath.replace(/(?<=\w)\.\w+$/g, '')] /* remove extension */
+    }
   }
 
   const references: TSReference[] = [


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4572

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were stripping anything extension-like from a path, which also covered directories like `app.com`. This PR strips file extensions only if it's not a directory.

When we bump minimum node version to 14.17 then we could also use `throwIfNoEntry: false`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

