### PR TITLE
docs: make titleTemplate function form example clearer

### DIFF
--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -13,7 +13,7 @@ For example:
 ```vue
 <script setup>
 useHead({
-  titleTemplate: 'My App - %s', // or, title => `My App - ${title}`
+  titleTemplate: 'My App - %s', // or, titleTemplate: (title) => `My App - ${title}`
   viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
   charset: 'utf-8',
   meta: [

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -13,7 +13,9 @@ For example:
 ```vue
 <script setup>
 useHead({
-  titleTemplate: 'My App - %s', // or, titleTemplate: (title) => `My App - ${title}`
+  titleTemplate: 'My App - %s',
+  // or, instead:
+  // titleTemplate: (title) => `My App - ${title}`,
   viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
   charset: 'utf-8',
   meta: [


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

I was confused when trying the second "function form" of the `titleTemplate` as follows:

```vue
useHead({
  title => `My App - ${title}`
})
```

Which obviously make no sense, but it took a while to get head (Pun intended!) around the current documentation.
Maybe my change makes it clearer for others?

