### PR TITLE
docs(migration): update to use new `runtimeConfig`

### DIFF
--- a/docs/content/migration/8.runtime-config.md
+++ b/docs/content/migration/8.runtime-config.md
@@ -25,7 +25,7 @@ import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
   runtimeConfig: {
-    secretKey: '', // variable that can only be accessed on server-side
+    secretKey: '', // variable that can only be accessed on the server side
     public: {
       BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org' // variable that can also be accessed on the client-side
     }

--- a/docs/content/migration/8.runtime-config.md
+++ b/docs/content/migration/8.runtime-config.md
@@ -13,7 +13,7 @@ When referencing these variables within your components, you will have to use th
 
 ## Migration
 
-1. Add any environment variables you use in your app to your `publicRuntimeConfig` or `privateRuntimeConfig`.
+1. Add any environment variables you use in your app to `runtimeConfig` in `nuxt.config.ts`.
 1. Migrate `process.env` to `useRuntimeConfig` throughout the Vue part of your app.
 
 ## Example
@@ -25,9 +25,9 @@ import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
   runtimeConfig: {
-    secretKey: '', // variables that can only be accessed on server-side
+    secretKey: '', // variable that can only be accessed on server-side
     public: {
-      BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org'
+      BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org' // variable that can also be accessed on the client-side
     }
   },
 })

--- a/docs/content/migration/8.runtime-config.md
+++ b/docs/content/migration/8.runtime-config.md
@@ -13,7 +13,7 @@ When referencing these variables within your components, you will have to use th
 
 ## Migration
 
-1. Add any environment variables you use in your app to `runtimeConfig` in `nuxt.config.ts`.
+1. Add any environment variables that you use in your app to the `runtimeConfig` property of the `nuxt.config` file.
 1. Migrate `process.env` to `useRuntimeConfig` throughout the Vue part of your app.
 
 ## Example

--- a/docs/content/migration/8.runtime-config.md
+++ b/docs/content/migration/8.runtime-config.md
@@ -27,7 +27,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     secretKey: '', // variable that can only be accessed on the server side
     public: {
-      BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org' // variable that can also be accessed on the client-side
+      BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org' // variable that can also be accessed on the client side
     }
   },
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The migration guide still mentioned the deprecated `publicRuntimeConfig` and `privateRuntimeConfig`, this is changed to the new `runtimeConfig`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

