### PR TITLE
fix(nuxt): mark config head as non-reactive

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { addPlugin, addTemplate, defineNuxtModule, isNuxt3 } from '@nuxt/kit'
+import { addPlugin, addTemplate, defineNuxtModule } from '@nuxt/kit'
 import defu from 'defu'
 import { distDir } from '../dirs'
 import type { MetaObject } from './runtime'

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -31,7 +31,7 @@ export default defineNuxtModule({
     // Add global meta configuration
     addTemplate({
       filename: 'meta.config.mjs',
-      getContents: () => 'export default ' + JSON.stringify({ globalMeta, mixinKey: isNuxt3() ? 'created' : 'setup' })
+      getContents: () => 'export default ' + JSON.stringify({ globalMeta })
     })
 
     // Add generic plugin

--- a/packages/nuxt/src/head/runtime/plugin.ts
+++ b/packages/nuxt/src/head/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { computed, getCurrentInstance } from 'vue'
+import { computed, getCurrentInstance, markRaw } from 'vue'
 import * as Components from './components'
 import { useHead } from './composables'
 import { defineNuxtPlugin, useNuxtApp } from '#app'
@@ -11,11 +11,11 @@ declare module 'vue' {
 }
 
 const metaMixin = {
-  [metaConfig.mixinKey] () {
+  created () {
     const instance = getCurrentInstance()
     if (!instance) { return }
 
-    const options = instance.type || /* nuxt2 */ instance.proxy?.$options
+    const options = instance.type
     if (!options || !('head' in options)) { return }
 
     const nuxtApp = useNuxtApp()
@@ -28,7 +28,7 @@ const metaMixin = {
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
-  useHead(metaConfig.globalMeta)
+  useHead(markRaw(metaConfig.globalMeta))
 
   nuxtApp.vueApp.mixin(metaMixin)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4426, resolves https://github.com/nuxt/framework/issues/4630

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In general using reactive objects outside of a Vue context is dangerous. This PR marks the nuxt configuration head inserted by Nuxt as non-reactive, which avoids a memory leak, as well as tidying up a bit of leftover bridge compatibility.

There seems ample space here for future improvement as well, including:

 * identifying if there's something in `vueuse/head` implementation (or in our practice of reffing up the head values)
 * detecting if `useHead` is being called outside of a vue context (that is, in a plugin) and marking entries as non-reactive if they aren't already refs/reactive.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

