### PR TITLE
docs: details & gotchas autoimports composables

### DIFF
--- a/docs/content/2.guide/3.directory-structure/5.composables.md
+++ b/docs/content/2.guide/3.directory-structure/5.composables.md
@@ -16,13 +16,31 @@ For example:
 
 ```bash
 composables
- | - useFoo.ts
+ | - useFoo.ts // scanned
  | - useBar
- | --- supportingFile.ts
- | --- index.ts
+ | --- supportingFile.ts // not scanned
+ | --- index.ts // scanned
 ```
 
 Only `useFoo.ts` and `useBar/index.ts` would be searched for imports - and if the latter is a default export, it would be registered as `useBar` rather than `index`.
+
+To get auto imports for `useBar/supportingFile.ts`, you have to re-export the composables you need from the `useBar/index.ts` file.
+
+```js [composables/useBar/index.ts]
+export default const useBar () {
+}
+
+// Enables auto import for this export
+export { useBaz } from './supportingFile'
+```
+
+::alert{type=warning}
+Auto import generating doesn't work with `export * from './supportingFile.ts'`, you must use named export.
+::
+
+Under the hood, Nuxt auto generates the file `.nuxt/auto-imports.d.ts` to declare the types.
+
+Be aware that you have to run `nuxt dev` or `nuxt build` in order to let Nuxt generates the types. If you create a composable without having the dev server running, typescript will throw an error `Cannot find name 'useBar'.`
 
 ## Example: (using named export)
 


### PR DESCRIPTION
I personally had several confusing moments about composables auto-imports:
* you need to run the server to get rid of the `Cannot find name 'useBar'` error.
* `export * from './sub-composable'` doesn't work, it has to be named exports.

Also, it's always nice to know what happens under the hood to debug it more easily :)

These documentation changes are the ones that could have saved me some time to understand what happens. So I hope it will help others!

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

