### PR TITLE
fix(nuxt): use suspense for child pages on client-side navigation

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -26,7 +26,7 @@ export default defineComponent({
         default: (routeProps: RouterViewSlotProps) => routeProps.Component &&
             _wrapIf(Transition, routeProps.route.meta.pageTransition ?? defaultPageTransition,
               wrapInKeepAlive(routeProps.route.meta.keepalive,
-                isNested
+                isNested && nuxtApp.isHydrating
                   // Include route children in parent suspense
                   ? h(routeProps.Component, { key: generateRouteKey(props.pageKey, routeProps) } as {})
                   : h(Suspense, {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/4556

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: https://github.com/nuxt/framework/pull/4422.

This PR amends that behaviour. Initial load still includes children in the parent's suspense, but further navigation wraps child pages in suspense (which is required if not reloading the parent on further nav).

**Note**: `isHydrating` is not reactive so it doesn't trigger a rerender.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

