### PR TITLE
fix(schema): decrease recursion on DeepPartial

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -8,7 +8,7 @@ export default {
    * See https://vitejs.dev/config for more information.
    * Please note that not all vite options are supported in Nuxt.
    *
-   * @type {typeof import('vite').InlineConfig}
+   * @type {typeof import('vite').UserConfig}
    * @version 3
    */
   vite: {

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,7 +1,7 @@
 import { ConfigSchema } from '../../schema/config'
 import type { ResolvedConfig } from 'c12'
 
-type DeepPartial<T> = T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> | T[P] } : T
+type DeepPartial<T> = T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 
 /** User configuration in `nuxt.config` file */
 export interface NuxtConfig extends DeepPartial<ConfigSchema> {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4655

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This slightly improves performance of the recursive `DeepPartial` type. I'm not sure why we had the union here, but removing it does improve the performance of `defineNuxtConfig`.

We could also allow an escape hatch from `DeepPartial` with a complementary utility type - might be worth considering if this happens again. `UserConfig` here is already partial, and doesn't _need_ to be processed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

