### PR TITLE
docs: add note that `.env` is not read in production

### DIFF
--- a/docs/content/2.guide/2.features/10.runtime-config.md
+++ b/docs/content/2.guide/2.features/10.runtime-config.md
@@ -33,9 +33,15 @@ console.log(runtimeConfig.public.apiBase)
 ### Environment Variables
 
 The most common way to provide configuration is by using [Environment Variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa).
+
+
+::alert{type=info}
 Nuxt CLI has built-in [dotenv](https://github.com/motdotla/dotenv) support.
 
 In addition to any process environment variables, if you have a `.env` file in your project root directory, it will be automatically loaded into `process.env` and accessible within your `nuxt.config` file and modules.
+
+However, **after your project is built**, you are responsible for setting environment variables when you run the server - your `.env` file will not be read at this point.
+::
 
 Runtime config values are automatically replaced by matching environment variables at runtime. For this to work, you _must_ have a fallback value (which can just be an empty string) defined in your `nuxt.config`.
 

--- a/docs/content/2.guide/2.features/10.runtime-config.md
+++ b/docs/content/2.guide/2.features/10.runtime-config.md
@@ -34,7 +34,6 @@ console.log(runtimeConfig.public.apiBase)
 
 The most common way to provide configuration is by using [Environment Variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa).
 
-
 ::alert{type=info}
 Nuxt CLI has built-in [dotenv](https://github.com/motdotla/dotenv) support.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/4682#discussioncomment-2662151

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Small note that `.env` is not read in production

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

