### PR TITLE
fix(nuxt): ensure url is not empty string

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -56,6 +56,9 @@ export interface NavigateToOptions {
 }
 
 export const navigateTo = (to: RouteLocationRaw, options: NavigateToOptions = {}): Promise<void | NavigationFailure> | RouteLocationRaw => {
+  if (!to) {
+    to = '/'
+  }
   if (isProcessingMiddleware()) {
     return to
   }
@@ -63,7 +66,7 @@ export const navigateTo = (to: RouteLocationRaw, options: NavigateToOptions = {}
   if (process.server) {
     const nuxtApp = useNuxtApp()
     if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
-      const redirectLocation = router.resolve(to).fullPath
+      const redirectLocation = router.resolve(to).fullPath || '/'
       return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext.event, redirectLocation, options.redirectCode || 301))
     }
   }

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -176,8 +176,9 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     delete nuxtApp._processingMiddleware
 
     if (process.server) {
-      if (to.fullPath !== initialURL) {
-        await callWithNuxt(nuxtApp, navigateTo, [to.fullPath])
+      const currentURL = to.fullPath || '/'
+      if (currentURL !== initialURL) {
+        await callWithNuxt(nuxtApp, navigateTo, [currentURL])
       }
     }
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#4778

Reproduction: https://stackblitz.com/edit/nuxt-starter-mc3z36

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


We detect redirection happens when after router middleware, initialURL is mismatching current route's fullPath. While initialURL from req.url is `/`, `fullPath` is an empty string due to a vue-router bug. Additionally, I've added `''` to `'/'` fallback for `navigateTo` to ensure this issue won't happen in other places when calling `router.resolve` 

Other than workaround for upstream issue, this PR tries to improve path compare to avoid unnecessary navigations.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

