### PR TITLE
docs: fix example runtime hook plugin syntax

### DIFF
--- a/docs/content/2.guide/6.going-further/2.hooks.md
+++ b/docs/content/2.guide/6.going-further/2.hooks.md
@@ -35,9 +35,11 @@ App hooks can be mainly used by [Nuxt Plugins](/guide/directory-structure/plugin
 ### Usage with Plugins
 
 ```js [plugins/test.ts]
-export defineNuxtPlugin(nuxtApp) {
-  nuxtApp.hook('page:start', () => { })
-}
+export default defineNuxtPlugin((nuxtApp) => {
+    nuxtApp.hook('page:start', () => {
+        /* your code goes here */
+     })
+})
 ```
 
 ::alert{icon=👉}


### PR DESCRIPTION

### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- The App Hooks (runtime) [Usage WIth Plugins](https://v3.nuxtjs.org/guide/going-further/hooks#usage-with-plugins) example is syntactically invalid (missing brackets etc)
- I have updated the example with one which is valid and can be copied and pasted.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

