### PR TITLE
fix(nuxt): normalise window location for universal router

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -1,9 +1,9 @@
 import { reactive, h } from 'vue'
-import { parseURL, parseQuery } from 'ufo'
+import { parseURL, parseQuery, withoutBase } from 'ufo'
 import { createError } from 'h3'
 import { defineNuxtPlugin } from '..'
 import { callWithNuxt } from '../nuxt'
-import { clearError, navigateTo, throwError } from '#app'
+import { clearError, navigateTo, throwError, useRuntimeConfig } from '#app'
 
 interface Route {
     /** Percentage encoded pathname section of the URL. */
@@ -85,8 +85,14 @@ interface Router {
   removeRoute: (name: string) => void
 }
 
+function createCurrentLocation (base: string, location: Location): string {
+  const { pathname, search, hash } = location
+  return withoutBase(pathname, base) + search + hash
+}
+
 export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
-  const initialURL = process.client ? window.location.href : nuxtApp.ssrContext.url
+  const { baseURL } = useRuntimeConfig().app
+  const initialURL = process.client ? createCurrentLocation(baseURL, window.location) : nuxtApp.ssrContext.url
   const routes = []
 
   const hooks: { [key in keyof RouterHooks]: RouterHooks[key][] } = {

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -91,7 +91,7 @@ function createCurrentLocation (base: string, location: Location): string {
 }
 
 export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
-  const { baseURL } = useRuntimeConfig().app
+  const baseURL = useRuntimeConfig().app.baseURL
   const initialURL = process.client ? createCurrentLocation(baseURL, window.location) : nuxtApp.ssrContext.url
   const routes = []
 

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -85,14 +85,10 @@ interface Router {
   removeRoute: (name: string) => void
 }
 
-function createCurrentLocation (base: string, location: Location): string {
-  const { pathname, search, hash } = location
-  return withoutBase(pathname, base) + search + hash
-}
-
 export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
-  const baseURL = useRuntimeConfig().app.baseURL
-  const initialURL = process.client ? createCurrentLocation(baseURL, window.location) : nuxtApp.ssrContext.url
+  const initialURL = process.client
+    ? withoutBase(window.location.pathname, useRuntimeConfig().app.baseURL) + window.location.search + window.location.hash
+    : nuxtApp.ssrContext.url
   const routes = []
 
   const hooks: { [key in keyof RouterHooks]: RouterHooks[key][] } = {

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -54,7 +54,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   nuxtApp.vueApp.component('NuxtNestedPage', NuxtPage)
   nuxtApp.vueApp.component('NuxtChild', NuxtPage)
 
-  const { baseURL } = useRuntimeConfig().app
+  const baseURL = useRuntimeConfig().app.baseURL
   const routerHistory = process.client
     ? createWebHistory(baseURL)
     : createMemoryHistory(baseURL)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

currently `route.fullPath` is `/` on server and `http://localhost:3000/` on client. This implements same behaviour as on router, which also fixes an issue where baseURL wasn't being correctly handled with universal router:

https://github.com/nuxt/framework/blob/ebc27ce997c80f5c30fc56ad82b02785fdf482bc/packages/nuxt/src/pages/runtime/router.ts#L30-L49

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

