### PR TITLE
fix(nuxt): check if default slot is provided before calling it

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -175,7 +175,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           // converts `""` to `null` to prevent the attribute from being added as empty (`rel=""`)
           : firstNonUndefined<string | null>(props.rel, options.externalRelAttribute, href ? DEFAULT_EXTERNAL_REL_ATTRIBUTE : '') || null
 
-        return h('a', { href, rel, target }, slots.default())
+        return h('a', { href, rel, target }, slots.default?.())
       }
     }
   }) as unknown as DefineComponent<NuxtLinkProps>

--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -3,7 +3,7 @@ import type { Component } from 'vue'
 
 const Fragment = {
   setup (_props, { slots }) {
-    return () => slots.default()
+    return () => slots.default?.()
   }
 }
 

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -135,7 +135,7 @@ export const Base = defineComponent({
 export const Title = defineComponent({
   name: 'Title',
   setup: setupForUseMeta((_, { slots }) => {
-    const title = slots.default()?.[0]?.children || null
+    const title = slots.default?.()?.[0]?.children || null
     if (process.dev && title && typeof title !== 'string') {
       console.error('<Title> can only take a string in its default slot.')
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4827

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We should generally check if default slot is provided before calling it. This applies it across several different situations throughout the Nuxt app.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

