### PR TITLE
fix(schema): add back `PublicRuntimeConfig` interface for augmentation

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -135,9 +135,17 @@ export const schemaTemplate = {
       `    [${genString(meta.configKey)}]?: typeof ${genDynamicImport(meta.importName, { wrapper: false })}.default extends NuxtModule<infer O> ? Partial<O> : Record<string, any>`
       ),
       '  }',
-      generateTypes(resolveSchema(nuxt.options.runtimeConfig),
+      generateTypes(resolveSchema(Object.fromEntries(Object.entries(nuxt.options.runtimeConfig).filter(([key]) => key !== 'public'))),
         {
           interfaceName: 'RuntimeConfig',
+          addExport: false,
+          addDefaults: false,
+          allowExtraKeys: false,
+          indentation: 2
+        }),
+      generateTypes(resolveSchema(nuxt.options.runtimeConfig.public),
+        {
+          interfaceName: 'PublicRuntimeConfig',
           addExport: false,
           addDefaults: false,
           allowExtraKeys: false,

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -14,7 +14,7 @@ export interface NuxtOptions extends ConfigSchema {
   _layers: ResolvedConfig<NuxtConfig>[]
 }
 
-type RuntimeConfigNamespace = Record<string, any >
+type RuntimeConfigNamespace = Record<string, any>
 
 export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
 

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -14,17 +14,13 @@ export interface NuxtOptions extends ConfigSchema {
   _layers: ResolvedConfig<NuxtConfig>[]
 }
 
-type RuntimeConfigNamespace = Record<string, any>
+type RuntimeConfigNamespace = Record<string, any >
 
-/** @deprecated use RuntimeConfig interface */
 export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
 
 /** @deprecated use RuntimeConfig interface */
-export interface PrivateRuntimeConfig extends PublicRuntimeConfig { }
+export interface PrivateRuntimeConfig extends RuntimeConfigNamespace { }
 
-type LegacyRuntimeConfig = PublicRuntimeConfig & Partial<PrivateRuntimeConfig>
-
-export interface RuntimeConfig extends LegacyRuntimeConfig, RuntimeConfigNamespace {
-  app: RuntimeConfigNamespace
-  public: RuntimeConfigNamespace
+export interface RuntimeConfig extends PrivateRuntimeConfig, RuntimeConfigNamespace {
+  public: PublicRuntimeConfig
 }

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -18,6 +18,7 @@ type RuntimeConfigNamespace = Record<string, any>
 
 export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
 
+// TODO: remove before release of 3.0.0
 /** @deprecated use RuntimeConfig interface */
 export interface PrivateRuntimeConfig extends RuntimeConfigNamespace { }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4550

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR restores the `PublicRuntimeConfig` interface, as a vehicle for augmenting types for runtimeConfig['public'] which otherwise can't really be done. (Otherwise each augmentation would completely override the type of `public`.)

Particularly value your input @pi0 as you touched this last.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

