### PR TITLE
docs: corrected typo in nuxt v3 documentation

### DIFF
--- a/docs/content/bridge/1.overview.md
+++ b/docs/content/bridge/1.overview.md
@@ -159,7 +159,7 @@ Nuxt 3 natively supports TypeScript and ECMAScript Modules. Please check [Native
 - Remove `@nuxt/content` (1.x). A rewrite for Nuxt 3 is planned (2.x)
 - Remove `nuxt-vite`: Bridge enables same functionality
 - Remove `@nuxt/typescript-build`: Bridge enables same functionality
-- Remove `@nuxt/typescript-runtime` and `nuxt-ts`: Nuxt 2 has built-in runtime support
+- Remove `@nuxt/typescript-runtime` and `nuxt-ts`: Nuxt 3 has built-in runtime support
 - Remove `@nuxt/nitro`: Bridge injects same functionality
 - Remove `@vue/composition-api` from your dependencies ([migration guide](/bridge/bridge-composition-api)).
 - Remove `@nuxtjs/composition-api` from your dependencies (and from your modules in `nuxt.config`) ([migration guide](/bridge/bridge-composition-api)).


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Corrects a typo in the Nuxt 3 docs where "Nuxt 2" is referenced instead of "Nuxt 3"

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
