### PR TITLE
fix(nuxt): middleware redirection error on initial load

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -123,17 +123,6 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
   })
 
-  try {
-    if (process.server) {
-      await router.push(initialURL)
-    }
-
-    await router.isReady()
-  } catch (error) {
-    // We'll catch 404s here
-    callWithNuxt(nuxtApp, throwError, [error])
-  }
-
   router.beforeEach(async (to, from) => {
     to.meta = reactive(to.meta)
     nuxtApp._processingMiddleware = true
@@ -171,6 +160,17 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       if (result || result === false) { return result }
     }
   })
+
+  try {
+    if (process.server) {
+      await router.push(initialURL)
+    }
+
+    await router.isReady()
+  } catch (error) {
+    // We'll catch 404s here
+    callWithNuxt(nuxtApp, throwError, [error])
+  }
 
   router.afterEach(async (to) => {
     delete nuxtApp._processingMiddleware


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve #4862

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Fix an issue where the router is loaded before all middleware resolution on initial load. If a middleware triggers a redirection, nuxt is trying to send 2 responses to the client. This should explain the error in the node console. It also triggers a strange behavior on the received html which show "Redirecting to " + path if the initial url does not match any .vue in the page directory.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

