### PR TITLE
fix(nuxt): use function to generate prerender routes

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -51,9 +51,11 @@ export async function initNitro (nuxt: Nuxt) {
     ],
     prerender: {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
-      routes: []
-        .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
+      routes: typeof nuxt.options.generate.routes === 'function'
+        ? await nuxt.options.generate.routes()
+        : []
+            .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
+            .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
     },
     sourcemap: nuxt.options.sourcemap,
     externals: {
@@ -172,8 +174,8 @@ export async function initNitro (nuxt: Nuxt) {
 }
 
 async function resolveHandlers (nuxt: Nuxt) {
-  const handlers: NitroEventHandler[] = [...nuxt.options.serverHandlers]
-  const devHandlers: NitroDevEventHandler[] = [...nuxt.options.devServerHandlers]
+  const handlers: NitroEventHandler[] = [...(nuxt.options.serverHandlers || [])]
+  const devHandlers: NitroDevEventHandler[] = [...(nuxt.options.devServerHandlers || [])]
 
   // Map legacy serverMiddleware to handlers
   for (let m of nuxt.options.serverMiddleware) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the ability to use a function in the `generate.routes` Nuxt configuration. It was already documented in the code but was not actually working, so I made a small fix to make it work.

Resolves #4885.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

