### PR TITLE
fix(nuxt): respect baseurl when redirecting (and universal router)

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,6 +1,7 @@
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, NavigationFailure } from 'vue-router'
 import { sendRedirect } from 'h3'
-import { useNuxtApp } from '#app'
+import { joinURL } from 'ufo'
+import { useNuxtApp, useRuntimeConfig } from '#app'
 
 export const useRouter = () => {
   return useNuxtApp()?.$router as Router
@@ -66,7 +67,7 @@ export const navigateTo = (to: RouteLocationRaw, options: NavigateToOptions = {}
   if (process.server) {
     const nuxtApp = useNuxtApp()
     if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
-      const redirectLocation = router.resolve(to).fullPath || '/'
+      const redirectLocation = joinURL(useRuntimeConfig().app.baseURL, router.resolve(to).fullPath || '/')
       return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext.event, redirectLocation, options.redirectCode || 301))
     }
   }

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -1,5 +1,5 @@
 import { reactive, h } from 'vue'
-import { parseURL, parseQuery, withoutBase, isEqual } from 'ufo'
+import { parseURL, parseQuery, withoutBase, isEqual, joinURL } from 'ufo'
 import { createError } from 'h3'
 import { defineNuxtPlugin } from '..'
 import { callWithNuxt } from '../nuxt'
@@ -102,6 +102,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
     hooks[hook].push(guard)
     return () => hooks[hook].splice(hooks[hook].indexOf(guard), 1)
   }
+  const baseURL = useRuntimeConfig().app.baseURL
 
   const route: Route = reactive(getRouteFromPath(initialURL))
   async function handleNavigation (url: string, replace?: boolean): Promise<void> {
@@ -124,7 +125,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
       // Perform navigation
       Object.assign(route, to)
       if (process.client) {
-        window.history[replace ? 'replaceState' : 'pushState']({}, '', url)
+        window.history[replace ? 'replaceState' : 'pushState']({}, '', joinURL(baseURL, url))
         if (!nuxtApp.isHydrating) {
           // Clear any existing errors
           await callWithNuxt(nuxtApp, clearError)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -148,12 +148,9 @@ describe('head tags', () => {
 
 describe('navigate', () => {
   it('should redirect to index with navigateTo', async () => {
-    const html = await $fetch('/navigate-to/')
+    const { headers } = await fetch('/navigate-to/', { redirect: 'manual' })
 
-    // Snapshot
-    // expect(html).toMatchInlineSnapshot()
-
-    expect(html).toContain('Hello Nuxt 3!')
+    expect(headers.get('location')).toEqual('/')
   })
 })
 
@@ -366,6 +363,15 @@ describe('dynamic paths', () => {
       // TODO: webpack does not yet support dynamic static paths
       expect(url.startsWith('/foo/_other/') || url === '/foo/public.svg' || (process.env.TEST_WITH_WEBPACK && url === '/public.svg')).toBeTruthy()
     }
+  })
+
+  it('should use baseURL when redirecting', async () => {
+    process.env.NUXT_APP_BUILD_ASSETS_DIR = '/_other/'
+    process.env.NUXT_APP_BASE_URL = '/foo/'
+    await startServer()
+    const { headers } = await fetch('/foo/navigate-to/', { redirect: 'manual' })
+
+    expect(headers.get('location')).toEqual('/foo/')
   })
 
   it('should allow setting CDN URL', async () => {

--- a/test/fixtures/basic/pages/navigate-to.vue
+++ b/test/fixtures/basic/pages/navigate-to.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script setup>
-navigateTo('/', { replace: true })
+await navigateTo('/', { replace: true })
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4932

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR:
* uses baseURL when pushing with universal router (fixing an unreported error)
* uses baseURL when sending a redirect

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

