### PR TITLE
feat(vite): replace `global` with `globalThis`

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.0.0-rc.3",
+    "@rollup/plugin-replace": "^4.0.0",
     "@vitejs/plugin-vue": "^2.3.3",
     "@vitejs/plugin-vue-jsx": "^1.3.10",
     "autoprefixer": "^10.4.7",

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -4,6 +4,7 @@ import type { Nuxt } from '@nuxt/schema'
 import type { InlineConfig, SSROptions } from 'vite'
 import { logger, isIgnored } from '@nuxt/kit'
 import type { Options } from '@vitejs/plugin-vue'
+import replace from '@rollup/plugin-replace'
 import { sanitizeFilePath } from 'mlly'
 import { getPort } from 'get-port-please'
 import { buildClient } from './client'
@@ -64,6 +65,10 @@ export async function bundle (nuxt: Nuxt) {
           }
         },
         plugins: [
+          replace({
+            ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),
+            preventAssignment: true
+          }),
           virtual(nuxt.vfs),
           DynamicBasePlugin.vite({ sourcemap: nuxt.options.sourcemap })
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,6 +1628,7 @@ __metadata:
   dependencies:
     "@nuxt/kit": ^3.0.0-rc.3
     "@nuxt/schema": ^3.0.0-rc.3
+    "@rollup/plugin-replace": ^4.0.0
     "@types/cssnano": ^5
     "@vitejs/plugin-vue": ^2.3.3
     "@vitejs/plugin-vue-jsx": ^1.3.10


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#1922, closes #4916

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR replaces references to `global` with `globalThis` for ESM compatibility, following the implementation in Nitro (e.g. https://github.com/unjs/nitro/pull/155 - which makes it safer to do this).

This is currently a draft pending more testing (e.g. for AWS Amplify).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

