### PR TITLE
fix(nuxt): fix router redirection on aliased page

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -182,8 +182,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   nuxtApp.hooks.hookOnce('app:created', async () => {
     try {
+      const initialRoute = router.resolve(initialURL)
+      delete initialRoute.name
       await router.replace({
-        ...router.resolve(initialURL),
+        ...initialRoute,
         force: true
       })
     } catch (error) {

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -184,7 +184,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     try {
       await router.replace({
         ...router.resolve(initialURL),
-        name: undefined,
+        name: undefined, // #4920, #$4982
         force: true
       })
     } catch (error) {

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -185,7 +185,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       const initialRoute = router.resolve(initialURL)
       delete initialRoute.name
       await router.replace({
-        ...initialRoute,
+        ...router.resolve(initialURL),
+        name: undefined,
         force: true
       })
     } catch (error) {

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -182,8 +182,6 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   nuxtApp.hooks.hookOnce('app:created', async () => {
     try {
-      const initialRoute = router.resolve(initialURL)
-      delete initialRoute.name
       await router.replace({
         ...router.resolve(initialURL),
         name: undefined,


### PR DESCRIPTION
resolve #4920 

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#4920 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using the force option on router replace make vue router use the name key in priority to match and retrieve the router location object resulting in a redirection such as the one described in the linked issue. We should just remove the name key from the object passed to router.replace when using force: true
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

