### PR TITLE
docs: add missing parentheses in  the `alias` example

### DIFF
--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -519,9 +519,9 @@ export default {
    * ```js
    * export default {
    *   alias: {
-   *     'images': fileURLToPath(new URL('./assets/images', import.meta.url),
-   *     'style': fileURLToPath(new URL('./assets/style', import.meta.url),
-   *     'data': fileURLToPath(new URL('./assets/other/data', import.meta.url)
+   *     'images': fileURLToPath(new URL('./assets/images', import.meta.url)),
+   *     'style': fileURLToPath(new URL('./assets/style', import.meta.url)),
+   *     'data': fileURLToPath(new URL('./assets/other/data', import.meta.url))
    *   }
    * }
    * ```

--- a/packages/schema/src/config/server.ts
+++ b/packages/schema/src/config/server.ts
@@ -9,8 +9,8 @@ export default {
    * export default {
    *   server: {
    *     https: {
-   *       key: fs.readFileSync(fileURLToPath(new URL('./server.key', import.meta.url)),
-   *       cert: fs.readFileSync(fileURLToPath(new URL('./server.crt', import.meta.url))
+   *       key: fs.readFileSync(fileURLToPath(new URL('./server.key', import.meta.url))),
+   *       cert: fs.readFileSync(fileURLToPath(new URL('./server.crt', import.meta.url)))
    *     }
    *   }
    * }

--- a/packages/schema/src/config/server.ts
+++ b/packages/schema/src/config/server.ts
@@ -9,8 +9,8 @@ export default {
    * export default {
    *   server: {
    *     https: {
-   *       key: fs.readFileSync(fileURLToPath(new URL('./server.key', import.meta.url))),
-   *       cert: fs.readFileSync(fileURLToPath(new URL('./server.crt', import.meta.url)))
+   *       key: fs.readFileSync(fileURLToPath(new URL('./server.key', import.meta.url)),
+   *       cert: fs.readFileSync(fileURLToPath(new URL('./server.crt', import.meta.url))
    *     }
    *   }
    * }


### PR DESCRIPTION
### 🔗 Linked issue

resolve #4987

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description
Correction of parentheses for auto-generated documentation.

### 📝 Checklist

- [x] I have linked an issue or discussion.