### PR TITLE
fix(nuxt): don't debounce watcher, and include layers

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -13,11 +13,11 @@ export async function build (nuxt: Nuxt) {
   if (nuxt.options.dev) {
     watch(nuxt)
     nuxt.hook('builder:watch', async (event, path) => {
-      if (event !== 'change' && /app|error|plugins/i.test(path)) {
-        if (path.match(/app/i)) {
+      if (event !== 'change' && /(^|\/)(app|error|plugins)\b/i.test(path)) {
+        if (path.match(/(^|\/)app\b/i)) {
           app.mainComponent = null
         }
-        if (path.match(/error/i)) {
+        if (path.match(/(^|\/)error\b/i)) {
           app.errorComponent = null
         }
         await generateApp()
@@ -38,7 +38,7 @@ export async function build (nuxt: Nuxt) {
 }
 
 function watch (nuxt: Nuxt) {
-  const watcher = chokidar.watch(nuxt.options.srcDir, {
+  const watcher = chokidar.watch([nuxt.options.srcDir, ...nuxt.options._layers.map(i => i.cwd)], {
     ...nuxt.options.watchers.chokidar,
     cwd: nuxt.options.srcDir,
     ignoreInitial: true,
@@ -49,8 +49,7 @@ function watch (nuxt: Nuxt) {
     ]
   })
 
-  const watchHook = debounce((event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir', path: string) => nuxt.callHook('builder:watch', event, normalize(path)))
-  watcher.on('all', watchHook)
+  watcher.on('all', (event, path) => nuxt.callHook('builder:watch', event, normalize(path)))
   nuxt.hook('close', () => watcher.close())
   return watcher
 }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -37,7 +37,7 @@ export default defineNuxtModule({
         nuxt.options.dir.middleware
       ].filter(Boolean)
 
-      const pathPattern = new RegExp(`^(${dirs.map(escapeRE).join('|')})/`)
+      const pathPattern = new RegExp(`(^|\\/)(${dirs.map(escapeRE).join('|')})/`)
       if (event !== 'change' && path.match(pathPattern)) {
         await nuxt.callHook('builder:generateApp')
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4522

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some circumstances the watcher was swallowing 'add' events, causing https://github.com/nuxt/framework/issues/4522 (not just on Windows), because it was debouncing an add + change event into a single change event. This PR removes the debouncing on the watcher, as we already have a debouncer on the `generateApp` function. (But alternative suggestions welcome.)

This PR also adds layers to the watch sources, and slightly tightens what paths trigger a regeneration of the app. Layers will be excluded automatically if they are in node_modules, of course, so the effect is only to include base layers within a monorepo.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

