### PR TITLE
fix(vite-node): do not cache manifest loading

### DIFF
--- a/packages/vite/src/runtime/client.manifest.mjs
+++ b/packages/vite/src/runtime/client.manifest.mjs
@@ -3,6 +3,4 @@ import { getViteNodeOptions } from './vite-node-shared.mjs'
 
 const viteNodeOptions = getViteNodeOptions()
 
-const manifest = await $fetch('/manifest', { baseURL: viteNodeOptions.baseURL })
-
-export default manifest
+export default () => $fetch('/manifest', { baseURL: viteNodeOptions.baseURL })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

With the previous cache change in rc.3, the manifest is always cached with invalidation, causing FOUC and development changes never updates. This PR partially fixed it by opt-out renderer cache in developement. 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

