### PR TITLE
docs(config): correct naming of `NUXT_APP_CDN_URL` environment variable

### DIFF
--- a/packages/schema/src/config/_app.ts
+++ b/packages/schema/src/config/_app.ts
@@ -60,10 +60,10 @@ export default {
     /**
      * An absolute URL to serve the public folder from (production-only).
      *
-     * This can be set to a different value at runtime by setting the CDN_URL environment variable.
+     * This can be set to a different value at runtime by setting the NUXT_APP_CDN_URL environment variable.
      * @example
      * ```bash
-     * CDN_URL=https://mycdn.org/ node .output/server/index.mjs
+     * NUXT_APP_CDN_URL=https://mycdn.org/ node .output/server/index.mjs
      * ```
     */
     cdnURL: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When setting up CDN configuration Nuxt parses the value of `NUXT_APP_CDN_URL`, but documentation is incorrectly showing the variable as `CDN_URL`.

https://github.com/nuxt/framework/blob/cd37a21c2e98d99fd7c944986e42f2b3964da6ec/packages/schema/src/config/_app.ts#L70

### 📝 Checklist
- [ ] I have linked an issue or discussion.
> If you spot an area where we can improve documentation or error messages, please do open a PR - even if it's just to fix a typo!

Implies no issue required.

- [X] I have updated the documentation accordingly.


