### PR TITLE
docs(middleware): add `navigateTo` options

### DIFF
--- a/docs/content/2.guide/3.directory-structure/7.middleware.md
+++ b/docs/content/2.guide/3.directory-structure/7.middleware.md
@@ -35,7 +35,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
 
 Nuxt provides two globally available helpers that can be returned directly from the middleware:
 
-1. `navigateTo (route: string | Route, options: NavigateToOptions)` - Redirects to the given route, within plugins or middleware. It can also be called directly to perform page navigation.
+1. `navigateTo (route: string | Route, options: { redirectCode: number, replace: boolean )` - Redirects to the given route, within plugins or middleware. It can also be called directly to perform page navigation.
 2. `abortNavigation (err?: string | Error)` - Aborts the navigation, with an optional error message.
 
 Unlike navigation guards in [the vue-router docs](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards), a third `next()` argument is not passed, and redirects or route cancellation is handled by returning a value from the middleware. Possible return values are:

--- a/docs/content/2.guide/3.directory-structure/7.middleware.md
+++ b/docs/content/2.guide/3.directory-structure/7.middleware.md
@@ -38,7 +38,7 @@ Nuxt provides two globally available helpers that can be returned directly from 
 1. `navigateTo (route: string | Route, options: NavigateToOptions)` - Redirects to the given route, within plugins or middleware. It can also be called directly to perform page navigation.
 2. `abortNavigation (err?: string | Error)` - Aborts the navigation, with an optional error message.
 
-Unlike, navigation guards in [the vue-router docs](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards), a third `next()` argument is not passed, and redirects or route cancellation is handled by returning a value from the middleware. Possible return values are:
+Unlike navigation guards in [the vue-router docs](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards), a third `next()` argument is not passed, and redirects or route cancellation is handled by returning a value from the middleware. Possible return values are:
 
 * nothing - does not block navigation and will move to the next middleware function, if any, or complete the route navigation
 * `navigateTo('/')` or `navigateTo({ path: '/' })` - redirects to the given path

--- a/docs/content/2.guide/3.directory-structure/7.middleware.md
+++ b/docs/content/2.guide/3.directory-structure/7.middleware.md
@@ -35,13 +35,14 @@ export default defineNuxtRouteMiddleware((to, from) => {
 
 Nuxt provides two globally available helpers that can be returned directly from the middleware:
 
-1. `navigateTo (route: string | Route)` - Redirects to the given route, within plugins or middleware. It can also be called directly on the client side to perform page navigation.
+1. `navigateTo (route: string | Route, options: NavigateToOptions)` - Redirects to the given route, within plugins or middleware. It can also be called directly to perform page navigation.
 2. `abortNavigation (err?: string | Error)` - Aborts the navigation, with an optional error message.
 
 Unlike, navigation guards in [the vue-router docs](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards), a third `next()` argument is not passed, and redirects or route cancellation is handled by returning a value from the middleware. Possible return values are:
 
 * nothing - does not block navigation and will move to the next middleware function, if any, or complete the route navigation
 * `navigateTo('/')` or `navigateTo({ path: '/' })` - redirects to the given path
+* `navigateTo('/', { redirectCode: 302 })` - Redirects to the given path and will set the redirect code if the redirect happens on the server side (default: 301)
 * `abortNavigation()` - stops the current navigation
 * `abortNavigation(error)` - rejects the current navigation with an error
 


### PR DESCRIPTION
### 🔗 Linked issue

Related and resolves partially: #5041

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds info about the `NavigateToOptions` for `navigateTo`. Also removes the info that it can only be called on client side.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

