### PR TITLE
docs: demonstrate the multiple `useState` with same key

### DIFF
--- a/examples/composables/use-state/app.vue
+++ b/examples/composables/use-state/app.vue
@@ -1,12 +1,12 @@
 <script setup>
 const counter = useState('counter', () => Math.round(Math.random() * 1000))
-const counterAlt = useState('counter');
+const sameCounter = useState('counter');
 </script>
 
 <template>
   <NuxtExampleLayout example="composables/use-state">
     <div>Counter: {{ counter }}</div>
-    <div>Parallel Counter: {{ counterAlt }}</div>
+    <div>Same Counter: {{ sameCounter }}</div>
     <div>
       <NButton class="font-mono" @click="counter++">
         +

--- a/examples/composables/use-state/app.vue
+++ b/examples/composables/use-state/app.vue
@@ -1,10 +1,12 @@
 <script setup>
 const counter = useState('counter', () => Math.round(Math.random() * 1000))
+const counterAlt = useState('counter');
 </script>
 
 <template>
   <NuxtExampleLayout example="composables/use-state">
     <div>Counter: {{ counter }}</div>
+    <div>Parallel Counter: {{ counterAlt }}</div>
     <div>
       <NButton class="font-mono" @click="counter++">
         +


### PR DESCRIPTION
Add another counter instance with the same id and show that they change in parallel

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

