### PR TITLE
fix(nuxt): allow passing extraneous attrs to meta components

### DIFF
--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -61,6 +61,7 @@ const globalProps = {
 // <script>
 export const Script = defineComponent({
   name: 'Script',
+  inheritAttrs: false,
   props: {
     ...globalProps,
     async: Boolean,
@@ -88,6 +89,7 @@ export const Script = defineComponent({
 // <link>
 export const Link = defineComponent({
   name: 'Link',
+  inheritAttrs: false,
   props: {
     ...globalProps,
     as: String,
@@ -121,6 +123,7 @@ export const Link = defineComponent({
 // <base>
 export const Base = defineComponent({
   name: 'Base',
+  inheritAttrs: false,
   props: {
     ...globalProps,
     href: String,
@@ -134,6 +137,7 @@ export const Base = defineComponent({
 // <title>
 export const Title = defineComponent({
   name: 'Title',
+  inheritAttrs: false,
   setup: setupForUseMeta((_, { slots }) => {
     const title = slots.default?.()?.[0]?.children || null
     if (process.dev && title && typeof title !== 'string') {
@@ -148,6 +152,7 @@ export const Title = defineComponent({
 // <meta>
 export const Meta = defineComponent({
   name: 'Meta',
+  inheritAttrs: false,
   props: {
     ...globalProps,
     charset: String,
@@ -163,6 +168,7 @@ export const Meta = defineComponent({
 // <style>
 export const Style = defineComponent({
   name: 'Style',
+  inheritAttrs: false,
   props: {
     ...globalProps,
     type: String,
@@ -193,12 +199,14 @@ export const Style = defineComponent({
 // <head>
 export const Head = defineComponent({
   name: 'Head',
+  inheritAttrs: false,
   setup: (_props, ctx) => () => ctx.slots.default?.()
 })
 
 // <html>
 export const Html = defineComponent({
   name: 'Html',
+  inheritAttrs: false,
   props: {
     ...globalProps,
     manifest: String,
@@ -211,6 +219,7 @@ export const Html = defineComponent({
 // <body>
 export const Body = defineComponent({
   name: 'Body',
+  inheritAttrs: false,
   props: globalProps,
   setup: setupForUseMeta(bodyAttrs => ({ bodyAttrs }), true)
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/4779

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A straightforward fix - attrs aren't meant to be passed on for these meta components.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

