### PR TITLE
fix: Temporary fix for https://github.com/nuxt/framework/issues/4758

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -113,10 +113,14 @@ export function useAsyncData<
         }
         asyncData.data.value = result
         asyncData.error.value = null
+
+        return asyncData;
       })
       .catch((error: any) => {
         asyncData.error.value = error
         asyncData.data.value = unref(options.default())
+
+        return asyncData;
       })
       .finally(() => {
         asyncData.pending.value = false
@@ -166,7 +170,7 @@ export function useAsyncData<
   }
 
   // Allow directly awaiting on asyncData
-  const asyncDataPromise = Promise.resolve(nuxt._asyncDataPromises[key]).then(() => asyncData) as AsyncData<DataT, DataE>
+  const asyncDataPromise = Promise.resolve(nuxt._asyncDataPromises[key]).then(x => x) as AsyncData<DataT, DataE>
   Object.assign(asyncDataPromise, asyncData)
 
   return asyncDataPromise as AsyncData<PickFrom<ReturnType<Transform>, PickKeys>, DataE>


### PR DESCRIPTION
### 🔗 Linked issue

#4758 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

I suppose this is technically a breaking change if applications are dependant on the original broken behaviour. 

### 📚 Description

I have modified useAsyncData to return the correct data associated with a request in the case that another call is made to useAsyncData while the original promise is still pending.

This change allows you to call useAsyncData on a single key, within multiple components, and work with the data on the server side without subsequent calls resolving to pending and null.

Resolves #4758 for now, more robust solution required in future.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

