### PR TITLE
docs: add documentation for `titleTemplate`

### DIFF
--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -13,7 +13,7 @@ For example:
 ```vue
 <script setup>
 useHead({
-  titleTemplate: 'My App - %s',
+  title: 'My App',
   // or, instead:
   // titleTemplate: (title) => `My App - ${title}`,
   viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
@@ -30,6 +30,34 @@ useHead({
 
 ::ReadMore{link="/api/composables/use-head"}
 ::
+
+## Title Templates
+
+You can use the `titleTemplate` option to provide a dynamic template for customizing the title of your site, for example, by adding the name of your site to the title of every page.
+
+Create a `title.js` plugin within your `plugins` folder, with the following code:
+
+```js
+export default defineNuxtPlugin(() => {
+  useHead({
+    titleTemplate: (titleChunk) => {
+      return titleChunk ? `${titleChunk} - Site Title` : 'Site Title';
+    },
+  });
+});
+```
+
+Then you can set a title as you usually would:
+
+```vue [/pages/my-page.vue]
+<script setup>
+  useHead({
+    title: 'My Page'
+  });
+</script>
+```
+
+This will now appear as 'My Page - Site Title' in the browser tab.
 
 ## Meta Components
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#4984 (And https://github.com/nuxt/framework/pull/5057 for PR)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This change adds more clarity to the `titleTemplate` option, as currently in Nuxt 3 this doesn't work as intended. This resolves #4984. This is a re-added PR to https://github.com/nuxt/framework/pull/5057, accidentally deleted the repo when adding multiple PRs to Nuxt.

Some changes were resolved by @manniL, @danielroe and @DamianGlowala.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

