### PR TITLE
docs: fix nuxt app guide linking to a 404 page

### DIFF
--- a/docs/content/2.guide/6.going-further/6.nuxt-app.md
+++ b/docs/content/2.guide/6.going-further/6.nuxt-app.md
@@ -35,5 +35,5 @@ console.log(nuxtApp.$hello('name')) // Prints "Hello name!"
 In Nuxt 2 plugins, this was referred to as [inject function](https://nuxtjs.org/docs/directory-structure/plugins#inject-in-root--context).
 
 ::alert{icon=👉}
-It is possible to inject helpers by returning an object with a `provide` key. See the [plugins documentation](/docs/directory-structure/plugins) for more information.
+It is possible to inject helpers by returning an object with a `provide` key. See the [plugins documentation](/guide/directory-structure/plugins) for more information.
 ::

--- a/docs/content/2.guide/6.going-further/6.nuxt-app.md
+++ b/docs/content/2.guide/6.going-further/6.nuxt-app.md
@@ -15,7 +15,7 @@ function useMyComposable () {
 }
 ```
 
-Plugins also receive `nuxtApp` as the first argument for convenience. [Read more about plugins.](/docs/directory-structure/plugins)
+Plugins also receive `nuxtApp` as the first argument for convenience. [Read more about plugins.](/guide/directory-structure/plugins)
 
 ::alert{icon=👉}
 **`useNuxtApp` (on the server) only works during `setup`, inside Nuxt plugins or `Lifecycle Hooks`**.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Updates the nuxt app docs ~~as the link went to a 404, on closer look it seems this isn't being caught by https://github.com/nuxt/framework/blob/0cbc9cb7cdf4491fcc016138399a886867575648/docs/static/_redirects#L27~~

Update: Seems navigating through the app itself gives a 404, but going directly to the link redirects me.

### Reproduction

1. Go to https://v3.nuxtjs.org/guide/going-further/nuxt-app/
2. Click **Read more about plugins**.
3. It 404's.
4. If you refresh the page at the 404, it'll redirect you.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

