### PR TITLE
refactor(nuxi): provide better advice on failing clone

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -46,7 +46,7 @@ export default defineNuxtCommand({
       await tiged.clone(dstDir)
     } catch (e) {
       if (e.toString().includes('could not find commit hash')) {
-        consola.error(`Failed to clone template from \`${src}\`; please check the repo is valid.`)
+        consola.error(`Failed to clone template from \`${src}\`; please check the repo is valid and that you have installed \`git\` correctly.`)
         process.exit(1)
       }
       throw e

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -46,7 +46,7 @@ export default defineNuxtCommand({
       await tiged.clone(dstDir)
     } catch (e) {
       if (e.toString().includes('could not find commit hash')) {
-        consola.error(`Failed to clone template \`${src}\`, please check the repo is valid.`)
+        consola.error(`Failed to clone template from \`${src}\`; please check the repo is valid.`)
         process.exit(1)
       }
       throw e

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -46,7 +46,7 @@ export default defineNuxtCommand({
       await tiged.clone(dstDir)
     } catch (e) {
       if (e.toString().includes('could not find commit hash')) {
-        consola.warn('Make sure you have installed `git` correctly')
+        consola.error(`Failed to init with template \`${src}\`, please check it's valid.`)
         process.exit(1)
       }
       throw e

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -46,7 +46,7 @@ export default defineNuxtCommand({
       await tiged.clone(dstDir)
     } catch (e) {
       if (e.toString().includes('could not find commit hash')) {
-        consola.error(`Failed to clone template from \`${src}\`; please check the repo is valid and that you have installed \`git\` correctly.`)
+        consola.error(`Failed to clone template from \`${src}\`. Please check the repo is valid and that you have installed \`git\` correctly.`)
         process.exit(1)
       }
       throw e

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -46,7 +46,7 @@ export default defineNuxtCommand({
       await tiged.clone(dstDir)
     } catch (e) {
       if (e.toString().includes('could not find commit hash')) {
-        consola.error(`Failed to init with template \`${src}\`, please check it's valid.`)
+        consola.error(`Failed to clone template \`${src}\`, please check the repo is valid.`)
         process.exit(1)
       }
       throw e


### PR DESCRIPTION
### 🔗 Linked issue

see https://github.com/nuxt/framework/pull/923 & https://github.com/nuxt/framework/pull/1052

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The issue was identified when using `nuxi init`, I modified the arguments incorrectly and got an error that wasn't helpful.

![image](https://user-images.githubusercontent.com/5326365/170450013-875b341c-814d-4366-9f6d-cc89792ad244.png)


The PR https://github.com/nuxt/framework/pull/923 introduced a try/catch for degit cloning, it correctly showed when a user required `git` if they didn't have it installed.

The switch to tiged https://github.com/nuxt/framework/pull/1052 changed what was being caught. Tiged works without git, it will download the tarball if git isn't available. So the error message is actually catching when the repo isn't valid.

The output will now look like this:

![image](https://user-images.githubusercontent.com/5326365/170450230-48ef8b4a-e1a8-47e3-a410-24499edcb4fd.png)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

