### PR TITLE
fix(schema): add missed types `title`, `bodyAttrs`, `htmlAttrs`

### DIFF
--- a/packages/schema/src/types/meta.ts
+++ b/packages/schema/src/types/meta.ts
@@ -25,6 +25,6 @@ export interface MetaObject extends Record<string, any> {
   titleTemplate?: string | ((title: string) => string)
   title: string,
   
-  bodyAttr: Record<string, any>
-  htmlAttr: Record<string, any>
+  bodyAttrs: Record<string, any>
+  htmlAttrs: Record<string, any>
 }

--- a/packages/schema/src/types/meta.ts
+++ b/packages/schema/src/types/meta.ts
@@ -23,4 +23,8 @@ export interface MetaObject extends Record<string, any> {
   script?: Array<Record<string, any>>
 
   titleTemplate?: string | ((title: string) => string)
+  title: string,
+  
+  bodyAttr: Record<string, any>
+  htmlAttr: Record<string, any>
 }

--- a/packages/schema/src/types/meta.ts
+++ b/packages/schema/src/types/meta.ts
@@ -23,7 +23,7 @@ export interface MetaObject extends Record<string, any> {
   script?: Array<Record<string, any>>
 
   titleTemplate?: string | ((title: string) => string)
-  title: string,
+  title: string
   
   bodyAttrs: Record<string, any>
   htmlAttrs: Record<string, any>

--- a/packages/schema/src/types/meta.ts
+++ b/packages/schema/src/types/meta.ts
@@ -23,8 +23,8 @@ export interface MetaObject extends Record<string, any> {
   script?: Array<Record<string, any>>
 
   titleTemplate?: string | ((title: string) => string)
-  title: string
+  title?: string
   
-  bodyAttrs: Record<string, any>
-  htmlAttrs: Record<string, any>
+  bodyAttrs?: Record<string, any>
+  htmlAttrs?: Record<string, any>
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In fact, these properties already work but were not in the type declarations

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

