### PR TITLE
docs: add --no-clear flag in the documentation of development server

### DIFF
--- a/docs/content/3.api/5.commands/dev.md
+++ b/docs/content/3.api/5.commands/dev.md
@@ -1,7 +1,7 @@
 # `nuxi dev`
 
 ```{bash}
-npx nuxi dev [rootDir] [--clipboard] [--open, -o] [--port, -p] [--host, -h] [--https] [--ssl-cert] [--ssl-key]
+npx nuxi dev [rootDir] [--clipboard] [--open, -o] [--no-clear] [--port, -p] [--host, -h] [--https] [--ssl-cert] [--ssl-key]
 ```
 
 The `dev` command starts a development server with hot module replacement at [http://localhost:3000](https://localhost:3000)
@@ -11,6 +11,7 @@ Option        | Default          | Description
 `rootDir` | `.` | The root directory of the application to serve.
 `--clipboard` | `false` | Copy URL to clipboard.
 `--open, -o` | `false` | Open URL in browser.
+`--no-clear` | `false` | Does not clear the console after startup.
 `--port, -p` | `3000` | Port to listen.
 `--host, -h` | `localhost` | Hostname of the server.
 `--https` | `false` | Listen with `https` protocol with a self-signed certificate by default.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
#5052 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the ``--no-clear`` flag in the documentation of development server.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.

