### PR TITLE
fix(nuxt): support `RouterView` props in `NuxtPage`

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -1,5 +1,5 @@
-import { defineComponent, h, inject, provide, Suspense, Transition } from 'vue'
-import { RouteLocationNormalizedLoaded, RouterView } from 'vue-router'
+import { DefineComponent, defineComponent, h, inject, provide, Suspense, Transition } from 'vue'
+import { RouteLocationNormalized, RouteLocationNormalizedLoaded, RouterView } from 'vue-router'
 
 import { generateRouteKey, RouterViewSlotProps, wrapInKeepAlive } from './utils'
 import { useNuxtApp } from '#app'
@@ -9,20 +9,27 @@ const isNestedKey = Symbol('isNested')
 
 export default defineComponent({
   name: 'NuxtPage',
+  inheritAttrs: false,
   props: {
+    name: {
+      type: String
+    },
+    route: {
+      type: Object as () => RouteLocationNormalized
+    },
     pageKey: {
       type: [Function, String] as unknown as () => string | ((route: RouteLocationNormalizedLoaded) => string),
       default: null
     }
   },
-  setup (props) {
+  setup (props, { attrs }) {
     const nuxtApp = useNuxtApp()
 
     const isNested = inject(isNestedKey, false)
     provide(isNestedKey, true)
 
     return () => {
-      return h(RouterView, {}, {
+      return h(RouterView, { name: props.name, route: props.route, ...attrs }, {
         default: (routeProps: RouterViewSlotProps) => routeProps.Component &&
             _wrapIf(Transition, routeProps.route.meta.pageTransition ?? defaultPageTransition,
               wrapInKeepAlive(routeProps.route.meta.keepalive,
@@ -37,6 +44,11 @@ export default defineComponent({
       })
     }
   }
-})
+}) as DefineComponent<{
+  name?: string,
+  route?: RouteLocationNormalized
+  pageKey?: string | ((route: RouteLocationNormalizedLoaded) => string)
+  [key: string]: any
+}>
 
 const defaultPageTransition = { name: 'page', mode: 'out-in' }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5271

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support to NuxtPage for features present in RouterView:

* updating typing to allow passing custom props (e.g. for child routes: #5271)
* passing explicit name/route props to render a specific view

It also allows RouterView to handle attrs for consistency.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

