### PR TITLE
docs: small typo in the "catch-all route" description

### DIFF
--- a/docs/content/2.guide/2.features/9.server-routes.md
+++ b/docs/content/2.guide/2.features/9.server-routes.md
@@ -103,7 +103,7 @@ Given the Example above, fetching `/test` with:
 
 ### Catch-all route
 
-Catch-all routes are helpful for fallback route handling. For Example, creating a file in the `~/server/api/foo/[...].ts` will register a catch-all route for all requests that do not match any route handler, such as `/api/foo/bar/baz`.
+Catch-all routes are helpful for fallback route handling. For example, creating a file named `~/server/api/foo/[...].ts` will register a catch-all route for all requests that do not match any route handler, such as `/api/foo/bar/baz`.
 
 **Examples:**
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While reading through the documentation for Nuxt 3, I caught a small typo in the `Catch-all route` section. It's not much, but that'll be one less that the team has to find!

> For ~~Example~~ **example**, creating a file ~~in the~~ **named** `~/server/api/foo/[...].ts` will register...

[Location](https://v3.nuxtjs.org/guide/features/server-routes#catch-all-route)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

