### PR TITLE
fix(vite): support custom postcss config

### DIFF
--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -4,6 +4,13 @@ import type { ViteOptions } from './vite'
 import { distDir } from './dirs'
 
 export function resolveCSSOptions (nuxt: Nuxt): ViteOptions['css'] {
+  // Early return if user is taking control with a custom postcss config file
+  if (typeof nuxt.options.postcss.config === 'string') {
+    return {
+      postcss: nuxt.options.postcss.config
+    }
+  }
+
   const css: ViteOptions['css'] & { postcss: Exclude<ViteOptions['css']['postcss'], string> } = {
     postcss: {
       plugins: []


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/5237

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We currently support a custom postcss config file with `postcss.config`, but this is only respected by the webpack builder. This PR respects a custom config file by passing it to vite - although note that both builders are consistent in that this overrides any other postcss config provided in the `postcss` nuxt option.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

