### PR TITLE
docs: fix typo in component migration guide

### DIFF
--- a/docs/content/migration/7.component-options.md
+++ b/docs/content/migration/7.component-options.md
@@ -52,7 +52,7 @@ With Nuxt 3, you can perform this data fetching using composables in your `setup
   // Define params wherever, through `defineProps()`, `useRoute()`, etc.
   const { data: post, refresh } = await useAsyncData('post', () => $fetch(`https://api.nuxtjs.dev/posts/${params.id}`) )
   // Or instead - useFetch is a convenience wrapper around useAsyncData when you're just performing a simple fetch
-  const { data: post, refresh } = await useFetch(`https://api.nuxtjs.dev/posts/${paramsÌ.id}`)
+  const { data: post, refresh } = await useFetch(`https://api.nuxtjs.dev/posts/${params.id}`)
 </script>
 ```
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Just a small typo I noticed while reading the migration docs: `${paramsÌ.id}` -> `${params.id}`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

