### PR TITLE
feat(nuxi): single `modules` entry for Nuxt 3 and Bridge when using `npx nuxi info`

### DIFF
--- a/packages/nuxi/src/commands/info.ts
+++ b/packages/nuxi/src/commands/info.ts
@@ -63,9 +63,16 @@ export default defineNuxtCommand({
       NuxtVersion: nuxtVersion,
       PackageManager: packageManager,
       Builder: builder,
-      UserConfig: Object.keys(nuxtConfig).map(key => '`' + key + '`').join(', '),
-      RuntimeModules: listModules(nuxtConfig.modules),
-      BuildModules: listModules(nuxtConfig.buildModules)
+      UserConfig: Object.keys(nuxtConfig).map(key => '`' + key + '`').join(', ')
+    }
+    
+    const isNuxt3OrBridge = infoObj.NuxtVersion.startsWith('3') || infoObj.BuildModules.includes('bridge')
+    
+    if (isNuxt3OrBridge) {
+      infoObj.Modules = listModules(nuxtConfig.modules)
+    } else {
+      infoObj.RuntimeModules = listModules(nuxtConfig.modules)
+      infoObj.BuildModules: listModules(nuxtConfig.buildModules)
     }
 
     console.log('RootDir:', rootDir)
@@ -84,8 +91,7 @@ export default defineNuxtCommand({
     const copied = await clipboardy.write(infoStr).then(() => true).catch(() => false)
     const splitter = '------------------------------'
     console.log(`Nuxt project info: ${copied ? '(copied to clipboard)' : ''}\n\n${splitter}\n${infoStr}${splitter}\n`)
-
-    const isNuxt3OrBridge = infoObj.NuxtVersion.startsWith('3') || infoObj.BuildModules.includes('bridge')
+    
     const repo = isNuxt3OrBridge ? 'nuxt/framework' : 'nuxt/nuxt.js'
     console.log([
       `👉 Report an issue: https://github.com/${repo}/issues/new`,

--- a/packages/nuxi/src/commands/info.ts
+++ b/packages/nuxi/src/commands/info.ts
@@ -72,7 +72,7 @@ export default defineNuxtCommand({
       infoObj.Modules = listModules(nuxtConfig.modules)
     } else {
       infoObj.RuntimeModules = listModules(nuxtConfig.modules)
-      infoObj.BuildModules: listModules(nuxtConfig.buildModules)
+      infoObj.BuildModules = listModules(nuxtConfig.buildModules)
     }
 
     console.log('RootDir:', rootDir)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
As `buildModules` property is deprecated in Nuxt 3 and Bridge, it might be a good idea to differentiate the `npx nuxi info` output based on the framework's version.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

