### PR TITLE
docs: Fix example definition of runtimeConfig variables in nuxtConfig

### DIFF
--- a/docs/content/migration/8.runtime-config.md
+++ b/docs/content/migration/8.runtime-config.md
@@ -24,11 +24,11 @@ When referencing these variables within your components, you will have to use th
 import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
-  runtimeConfig: {
+  privateRuntimeConfig: {
     secretKey: '', // variable that can only be accessed on the server side
-    public: {
-      BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org' // variable that can also be accessed on the client side
-    }
+  },
+  publicRuntimeConfig: {
+    BASE_URL: process.env.BASE_URL || 'https://nuxtjs.org' // variable that can also be accessed on the client side
   },
 })
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#5056

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

According to the [test fixtures](https://github.com/nuxt/framework/blob/603f07c3b8f93feefb8c59c5ff3a970a60e38041/test/fixtures/basic/nuxt.config.ts#L14), api for definining runtime config has changed to 2 separate keys for public (clientside) & private (serverside) variables.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

