### PR TITLE
docs: fix typo in programmatic navigation

### DIFF
--- a/docs/content/2.guide/3.directory-structure/10.pages.md
+++ b/docs/content/2.guide/3.directory-structure/10.pages.md
@@ -361,7 +361,7 @@ export default defineNuxtConfig({
 
 Nuxt 3 allows programmatic navigation through the `navigateTo()` utility method. Using this utility method, you will be able to programmatically navigate the user in your app. This is great for taking input from the user and navigating them dynamically throughout your application. In this example, we have a simple method called `navigate()` that gets called when the user submits a search form.
 
-**Note:** Ensure to always `await` on `navigateTo` or chain it's result by returning from functions.
+**Note:** Ensure to always `await` on `navigateTo` or chain its result by returning from functions.
 
 ```vue
 <script setup>

--- a/docs/content/2.guide/3.directory-structure/10.pages.md
+++ b/docs/content/2.guide/3.directory-structure/10.pages.md
@@ -359,7 +359,7 @@ export default defineNuxtConfig({
 
 ## Programmatic Navigation
 
-Nuxt 3 allows programmatic navigation through the `navigateTo()` utility method. Using this utility method, you will be able to programmatically navigate the user in your app. This is great for taking input from the user and navigating them dynamically throughout your application. In this example, we have a simple method called `navigation()` that gets called when the user submits a search form.
+Nuxt 3 allows programmatic navigation through the `navigateTo()` utility method. Using this utility method, you will be able to programmatically navigate the user in your app. This is great for taking input from the user and navigating them dynamically throughout your application. In this example, we have a simple method called `navigate()` that gets called when the user submits a search form.
 
 **Note:** Ensure to always `await` on `navigateTo` or chain it's result by returning from functions.
 


### PR DESCRIPTION
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X ] 📖 Documentation (updates to the documentation or readme)

### 📚 Description
Description text for Programmatic Navigation referenced a method called "navigation", while the example method was named "navigate". Updated the description text to match the example.


