### PR TITLE
docs: Adding start script to node-server docs

### DIFF
--- a/docs/content/2.guide/5.deploy/1.node-server.md
+++ b/docs/content/2.guide/5.deploy/1.node-server.md
@@ -24,6 +24,20 @@ $ node .output/server/index.mjs
 Listening on http://localhost:3000
 ```
 
+## Configuring start script
+
+When deploying your nuxt app to a service like Heroku, you'll need to give it a start script to avoid errors
+```js [ecosystem.config.js]
+"scripts": {
+  "build": "nuxt build",
+  "dev": "nuxt dev",
+  "generate": "nuxt generate",
+  "preview": "nuxt preview",
+  "start": "node .output/server/index.mjs", // So that Heroku starts your app
+},
+```
+
+
 ## Configuring defaults at runtime
 
 This preset will respect the following runtime environment variables:


### PR DESCRIPTION
When deploying to a service like Heroku, users will need to define a start script to avoid errors.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
When trying to deploy a nuxt app to heroku, I received an error that there was no start script. My change is to update the node server documentation to include this start script. 
<!-- Why is this change required? What problem does it solve? -->
This improves the developer experience for Nuxt developers. This change makes it quicker for developers to get something deployed, reducing frustration and increasing satisfaction with Nuxt
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

