### PR TITLE
fix(nuxt): add `ssrContext` types on `NuxtApp`

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -7,7 +7,7 @@ export function useRequestHeaders<K extends string = string> (include: K[]): Rec
 export function useRequestHeaders (): Readonly<Record<string, string>>;
 export function useRequestHeaders (include?) {
   if (process.client) { return {} }
-  const headers: Record<string, string> = useNuxtApp().ssrContext?.event.req.headers ?? {}
+  const headers: Record<string, string | string[]> = useNuxtApp().ssrContext?.event.req.headers ?? {}
   if (!include) { return headers }
   return Object.fromEntries(include.filter(key => headers[key]).map(key => [key, headers[key]]))
 }

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -24,7 +24,7 @@ let entry: Function
 const plugins = normalizePlugins(_plugins)
 
 if (process.server) {
-  entry = async function createNuxtAppServer (ssrContext: CreateOptions['ssrContext'] = {}) {
+  entry = async function createNuxtAppServer (ssrContext: CreateOptions['ssrContext']) {
     const vueApp = createApp(RootComponent)
     vueApp.component('App', AppComponent)
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -4,6 +4,8 @@ import type { App, onErrorCaptured, VNode } from 'vue'
 import { createHooks, Hookable } from 'hookable'
 import type { RuntimeConfig } from '@nuxt/schema'
 import { getContext } from 'unctx'
+import type { SSRContext } from 'vue-bundle-renderer'
+import type { CompatibilityEvent } from 'h3'
 import { legacyPlugin, LegacyContext } from './compat/legacy-app'
 
 const nuxtAppCtx = getContext<NuxtApp>('nuxt-app')
@@ -48,11 +50,23 @@ interface _NuxtApp {
   _asyncDataPromises?: Record<string, Promise<any>>
   _legacyContext?: LegacyContext
 
-  ssrContext?: Record<string, any> & {
+  ssrContext?: SSRContext & {
+    url: string
+    event: CompatibilityEvent
+    /** @deprecated Use `event` instead. */
+    req?: CompatibilityEvent['req']
+    /** @deprecated Use `event` instead. */
+    res?: CompatibilityEvent['res']
+    runtimeConfig: RuntimeConfig
+    noSSR: boolean
+    error?: any
+    nuxt: _NuxtApp
+    payload: _NuxtApp['payload']
+    teleports?: Record<string, string>
     renderMeta?: () => Promise<NuxtMeta> | NuxtMeta
   }
   payload: {
-    serverRendered?: true
+    serverRendered?: boolean
     data?: Record<string, any>
     state?: Record<string, any>
     rendered?: Function

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -129,7 +129,7 @@ export function createNuxtApp (options: CreateOptions) {
 
   if (process.server) {
     // Expose to server renderer to create window.__NUXT__
-    nuxtApp.ssrContext = nuxtApp.ssrContext || {}
+    nuxtApp.ssrContext = nuxtApp.ssrContext || {} as any
     nuxtApp.ssrContext.payload = nuxtApp.payload
   }
 

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -1,9 +1,9 @@
 import { createRenderer } from 'vue-bundle-renderer'
-import type { SSRContext } from 'vue-bundle-renderer'
-import { CompatibilityEvent, eventHandler, useQuery } from 'h3'
+import { eventHandler, useQuery } from 'h3'
 import devalue from '@nuxt/devalue'
-import { RuntimeConfig } from '@nuxt/schema'
 import { renderToString as _renderToString } from 'vue/server-renderer'
+
+import type { NuxtApp } from '#app'
 
 // @ts-ignore
 import { useRuntimeConfig } from '#internal/nitro'
@@ -12,20 +12,7 @@ import { buildAssetsURL } from '#paths'
 // @ts-ignore
 import htmlTemplate from '#build/views/document.template.mjs'
 
-interface NuxtSSRContext extends SSRContext {
-  url: string
-  noSSR: boolean
-  redirected: boolean
-  event: CompatibilityEvent
-  req: CompatibilityEvent['req']
-  res: CompatibilityEvent['res']
-  runtimeConfig: RuntimeConfig
-  error?: any
-  nuxt?: any
-  payload?: any
-  teleports?: { body?: string }
-  renderMeta?: () => Promise<any>
-}
+type NuxtSSRContext = NuxtApp['ssrContext']
 
 interface RenderResult {
   html: any
@@ -126,7 +113,6 @@ export default eventHandler(async (event) => {
     runtimeConfig: useRuntimeConfig(),
     noSSR: !!event.req.headers['x-nuxt-no-ssr'],
     error: ssrError,
-    redirected: undefined,
     nuxt: undefined, /* NuxtApp */
     payload: undefined
   }
@@ -140,7 +126,7 @@ export default eventHandler(async (event) => {
   // If we error on rendering error page, we bail out and directly return to the error handler
   if (!rendered) { return }
 
-  if (ssrContext.redirected || event.res.writableEnded) {
+  if (event.res.writableEnded) {
     return
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5330

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds types to `ssrContext` (with req/res deprecated).

Relevant code changes: it also removes `redirected` (Nuxt 2, not otherwise used in Nuxt 3 codebase) and doesn't pass an empty object to initialise server entry.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

