### PR TITLE
docs: add warning against layout as root element

### DIFF
--- a/docs/content/2.guide/3.directory-structure/6.layouts.md
+++ b/docs/content/2.guide/3.directory-structure/6.layouts.md
@@ -102,11 +102,13 @@ Even if you are using the `~/pages` integration, you can take full control by us
 
 ```vue [pages/index.vue]
 <template>
-  <NuxtLayout name="custom">
-    <template #header> Some header template content. </template>
+  <div>
+    <NuxtLayout name="custom">
+      <template #header> Some header template content. </template>
 
-    The rest of the page
-  </NuxtLayout>
+      The rest of the page
+    </NuxtLayout>
+  </div>
 </template>
 
 <script setup>
@@ -116,6 +118,10 @@ definePageMeta({
 </script>
 ```
 
+::
+
+::alert{type=warning}
+If you use `<NuxtLayout>` within your pages, make sure it is not the root element (or disable layout/page transitions).
 ::
 
 ## Example: changing the layout


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/5291

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a warning against using `<NuxtLayout>` as root element in page. (In this case we have a transition within a transition, which fails.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

