### PR TITLE
fix(nuxt): relax server import protections

### DIFF
--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -20,7 +20,7 @@ export const vueAppPatterns = (nuxt: Nuxt) => [
     [new RegExp(`^${escapeRE(m)}$`), 'Importing directly from module entry points is not allowed.']),
   ...[/(^|node_modules\/)@nuxt\/kit/, /^nitropack/]
     .map(i => [i, 'This module cannot be imported in the Vue part of your app.']),
-  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|middleware|plugins)\\/'), 'Importing from server is not allowed in the Vue part of your app.']
+  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|routes|middleware|plugins)\\/'), 'Importing from server is not allowed in the Vue part of your app.']
 ] as ImportProtectionOptions['patterns']
 
 export const ImportProtectionPlugin = createUnplugin(function (options: ImportProtectionOptions) {

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -20,7 +20,7 @@ export const vueAppPatterns = (nuxt: Nuxt) => [
     [new RegExp(`^${escapeRE(m)}$`), 'Importing directly from module entry points is not allowed.']),
   ...[/(^|node_modules\/)@nuxt\/kit/, /^nitropack/]
     .map(i => [i, 'This module cannot be imported in the Vue part of your app.']),
-  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|middleware)\\/'), 'Importing from server middleware is not allowed in the Vue part of your app.']
+  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|middleware|plugins)\\/'), 'Importing from server is not allowed in the Vue part of your app.']
 ] as ImportProtectionOptions['patterns']
 
 export const ImportProtectionPlugin = createUnplugin(function (options: ImportProtectionOptions) {

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -20,7 +20,7 @@ export const vueAppPatterns = (nuxt: Nuxt) => [
     [new RegExp(`^${escapeRE(m)}$`), 'Importing directly from module entry points is not allowed.']),
   ...[/(^|node_modules\/)@nuxt\/kit/, /^nitropack/]
     .map(i => [i, 'This module cannot be imported in the Vue part of your app.']),
-  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server'))), 'Importing from server middleware is not allowed in the Vue part of your app.']
+  [new RegExp(escapeRE(resolve(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|middleware)\\/'), 'Importing from server middleware is not allowed in the Vue part of your app.']
 ] as ImportProtectionOptions['patterns']
 
 export const ImportProtectionPlugin = createUnplugin(function (options: ImportProtectionOptions) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5354

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes import protection outside of `~/server/api/` and `~/server/middleware/` directories, for shared utilities.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

