### PR TITLE
fix(webpack): write stub server file with `ssr: false`

### DIFF
--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { writeFile } from 'node:fs/promises'
 import pify from 'pify'
 import webpack from 'webpack'
 import webpackDevMiddleware, { API } from 'webpack-dev-middleware'
@@ -8,6 +9,7 @@ import type { Compiler, Watching } from 'webpack'
 import type { Nuxt } from '@nuxt/schema'
 import { joinURL } from 'ufo'
 import { logger, useNuxt } from '@nuxt/kit'
+import { resolve } from 'pathe'
 import { DynamicBasePlugin } from '../../vite/src/plugins/dynamic-base'
 import { createMFS } from './utils/mfs'
 import { registerVirtualModules } from './virtual-modules'
@@ -62,6 +64,11 @@ export async function bundle (nuxt: Nuxt) {
 
   for (const c of compilers) {
     await compile(c)
+  }
+
+  // Write stub file to enable rollup to resolve it for dynamic import
+  if (!nuxt.options.ssr) {
+    await writeFile(resolve(nuxt.options.buildDir, 'dist/server/server.mjs'), 'export default () => {}')
   }
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5013

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Rollup needs to resolve `#build/dist/server/server.mjs` even though it will never be used/imported ([src](https://github.com/nuxt/framework/blob/822928b07e41b4579d7079927988cd6cd90c48ce/packages/nuxt/src/core/runtime/nitro/renderer.ts#L36)). This PR ensures the stub is present in webpack, just as it is in vite.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

