### PR TITLE
chore: clean up jsdoc

### DIFF
--- a/packages/vite/src/runtime/vite-node-shared.mjs
+++ b/packages/vite/src/runtime/vite-node-shared.mjs
@@ -1,4 +1,3 @@
-/** @type {import('./vite-node-shared').getViteNodeOptions} */
 export function getViteNodeOptions () {
   return JSON.parse(process.env.NUXT_VITE_NODE_OPTIONS || '{}')
 }


### PR DESCRIPTION
to bypress the warning in CI