### PR TITLE
fix(vite): don't terminate with escaped delimiters

### DIFF
--- a/packages/vite/src/plugins/dynamic-base.ts
+++ b/packages/vite/src/plugins/dynamic-base.ts
@@ -89,7 +89,7 @@ export const DynamicBasePlugin = createUnplugin(function (options: DynamicBasePl
       s.replace(/from *['"]\/__NUXT_BASE__(\/[^'"]*)['"]/g, 'from "$1"')
 
       // Dynamically compute string URLs featuring baseURL
-      const delimiterRE = /(?<!(const base = |from *))(`([^`]*)\/__NUXT_BASE__\/([^`]*)`|'([^\n']*)\/__NUXT_BASE__\/([^\n']*)'|"([^\n"]*)\/__NUXT_BASE__\/([^\n"]*)")/g
+      const delimiterRE = /(?<!(const base = |from *))((?<!\\)`([^`]*)\/__NUXT_BASE__\/([^`]*)(?<!\\)`|(?<!\\)'([^\n']*)\/__NUXT_BASE__\/([^\n']*)(?<!\\)'|(?<!\\)"([^\n"]*)\/__NUXT_BASE__\/([^\n"]*)(?<!\\)")/g
       /* eslint-disable-next-line no-template-curly-in-string */
       s.replace(delimiterRE, r => '`' + r.replace(/\/__NUXT_BASE__\//g, '${__publicAssetsURL()}').slice(1, -1) + '`')
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -349,6 +349,8 @@ describe('dynamic paths', () => {
         [
           "./logo.svg",
           "../public.svg",
+          "../public.svg",
+          "../public.svg",
         ]
       `)
   })

--- a/test/fixtures/basic/pages/assets.vue
+++ b/test/fixtures/basic/pages/assets.vue
@@ -13,8 +13,14 @@ import logo from '~/assets/logo.svg'
 <style>
 #__nuxt {
   background-image: url('~/assets/logo.svg');
+  @font-face {
+    src: url("/public.svg") format("woff2");
+  }
 }
 body {
   background-image: url('/public.svg');
+  @font-face {
+    src: url('/public.svg') format('woff2');
+  }
 }
 </style>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5329

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves an issue where an escaped quotation was terminating a regexp wrongly.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

