### PR TITLE
fix(nuxt): don't add macro query to the end of id

### DIFF
--- a/packages/nuxt/src/pages/macros.ts
+++ b/packages/nuxt/src/pages/macros.ts
@@ -46,7 +46,8 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
       // with workaround for vue-loader bug: https://github.com/vuejs/vue-loader/pull/1911
       const scriptImport = findStaticImports(code).find(i => parseQuery(i.specifier.replace('?macro=true', '')).type === 'script')
       if (scriptImport) {
-        const specifier = withQuery(scriptImport.specifier.replace('?macro=true', ''), { macro: 'true' })
+        const parsed = parseURL(scriptImport.specifier.replace('?macro=true', ''))
+        const specifier = withQuery(parsed.pathname, { macro: 'true', ...parseQuery(parsed.search) })
         s.overwrite(0, code.length, `export { meta } from "${specifier}"`)
         return result()
       }

--- a/packages/nuxt/src/pages/macros.ts
+++ b/packages/nuxt/src/pages/macros.ts
@@ -46,6 +46,8 @@ export const TransformMacroPlugin = createUnplugin((options: TransformMacroPlugi
       // with workaround for vue-loader bug: https://github.com/vuejs/vue-loader/pull/1911
       const scriptImport = findStaticImports(code).find(i => parseQuery(i.specifier.replace('?macro=true', '')).type === 'script')
       if (scriptImport) {
+        // https://github.com/vuejs/vue-loader/pull/1911
+        // https://github.com/vitejs/vite/issues/8473
         const parsed = parseURL(scriptImport.specifier.replace('?macro=true', ''))
         const specifier = withQuery(parsed.pathname, { macro: 'true', ...parseQuery(parsed.search) })
         s.overwrite(0, code.length, `export { meta } from "${specifier}"`)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3488

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The query `lang.jsx` of id should be at the end of id, according to https://github.com/vitejs/vite/issues/8473#issuecomment-1148715786
However `&macro=true` is added at the end so that the `lang` query is not parsed expectedly in vite plugins.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

