### PR TITLE
docs: fix mdn links for 301 and 302 http status

### DIFF
--- a/docs/content/2.guide/3.directory-structure/7.middleware.md
+++ b/docs/content/2.guide/3.directory-structure/7.middleware.md
@@ -41,10 +41,8 @@ Nuxt provides two globally available helpers that can be returned directly from 
 Unlike navigation guards in [the vue-router docs](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards), a third `next()` argument is not passed, and redirects or route cancellation is handled by returning a value from the middleware. Possible return values are:
 
 * nothing - does not block navigation and will move to the next middleware function, if any, or complete the route navigation
-* `navigateTo('/')` or `navigateTo({ path: '/' })` - redirects to the given path and will set the redirect code to [`302` Found
-](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) if the redirect happens on the server side
-* `navigateTo('/', { redirectCode: 301 })` - redirects to the given path and will set the redirect code to [`301` Moved Permanently
-](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) if the redirect happens on the server side
+* `navigateTo('/')` or `navigateTo({ path: '/' })` - redirects to the given path and will set the redirect code to [`302` Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) if the redirect happens on the server side
+* `navigateTo('/', { redirectCode: 301 })` - redirects to the given path and will set the redirect code to [`301` Moved Permanently](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) if the redirect happens on the server side
 * `abortNavigation()` - stops the current navigation
 * `abortNavigation(error)` - rejects the current navigation with an error
 


### PR DESCRIPTION
On the https://v3.nuxtjs.org/guide/directory-structure/middleware page the links for 301 and 302 are broken.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### ❓ Type of change

The link was broken in the documentation 

- [* ] 📖 Documentation (updates to the documentation or readme)
- [ *] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The page https://v3.nuxtjs.org/guide/directory-structure/middleware shows the 302 and 301 links broken as seen below on the photo.
![282EFAC4-E962-4B16-880A-046756222681](https://user-images.githubusercontent.com/73140396/173183711-50020ca9-fac3-4a2f-9f45-527923c1237c.png)
