### PR TITLE
fix(nuxt): exclude non-cwd auto-imports and don't process _all_ files

### DIFF
--- a/packages/nuxt/src/auto-imports/transform.ts
+++ b/packages/nuxt/src/auto-imports/transform.ts
@@ -15,13 +15,8 @@ export const TransformPlugin = createUnplugin(({ ctx, options, sourcemap }: {ctx
       const exclude = options.transform?.exclude || [/[\\/]node_modules[\\/]/]
       const include = options.transform?.include || []
 
-      // Custom includes
-      if (include.some(pattern => id.match(pattern))) {
-        return true
-      }
-
-      // Exclude node_modules by default
-      if (exclude.some(pattern => id.match(pattern))) {
+      // Custom includes - exclude node_modules by default
+      if (exclude.some(pattern => id.match(pattern)) && !include.some(pattern => id.match(pattern))) {
         return false
       }
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -143,7 +143,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   options._modules.push([autoImportsModule, {
     transform: {
       include: options._layers
-        .filter(i => i.cwd)
+        .filter(i => i.cwd && i.cwd.includes('node_modules'))
         .map(i => new RegExp(`(^|\\/)${escapeRE(i.cwd.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
     }
   }])


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/5414

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression introduced by https://github.com/nuxt/framework/pull/5042, by:

1. only adding layers within `node_modules` to autoImports include.
2. not force-transforming all files in `include` but only the ones that match the test for file time

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

