### PR TITLE
fix(nuxt): prefer nuxt app context over `getCurrentInstance`

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -236,17 +236,17 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
  * Returns the current Nuxt instance.
  */
 export function useNuxtApp () {
-  const vm = getCurrentInstance()
+  const nuxtAppInstance = nuxtAppCtx.use()
 
-  if (!vm) {
-    const nuxtAppInstance = nuxtAppCtx.use()
-    if (!nuxtAppInstance) {
+  if (!nuxtAppInstance) {
+    const vm = getCurrentInstance()
+    if (!vm) {
       throw new Error('nuxt instance unavailable')
     }
-    return nuxtAppInstance
+    return vm.appContext.app.$nuxt as NuxtApp
   }
 
-  return vm.appContext.app.$nuxt as NuxtApp
+  return nuxtAppInstance
 }
 
 export function useRuntimeConfig (): RuntimeConfig {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5327

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a workaround for https://github.com/vuejs/core/issues/6110 - by preferring the `unctx` version of Nuxt rather than the vm. We can't trust `getCurrentInstance` to return null when called within Nuxt plugins, nor is there an exposed way to _unset_ the instance.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

