### PR TITLE
feat(kit): allow addServerHandler to use method suffix of the file path

### DIFF
--- a/packages/kit/src/server.ts
+++ b/packages/kit/src/server.ts
@@ -17,8 +17,8 @@ function normalizeHandlerMethod (handler: NitroEventHandler) {
   // retrieve method from handler file name
   const [, method = undefined] = handler.handler.match(/\.(get|head|patch|post|put|delete|connect|options|trace)(\.\w+)*$/) || []
   return {
-    ...handler,
-    method
+    method,
+    ...handler
   }
 }
 

--- a/packages/kit/src/server.ts
+++ b/packages/kit/src/server.ts
@@ -10,6 +10,19 @@ export interface LegacyServerMiddleware {
 }
 
 /**
+ * normalize handler object
+ *
+ */
+function normalizeHandlerMethod (handler: NitroEventHandler) {
+  // retrieve method from handler file name
+  const [, method = undefined] = handler.handler.match(/\.(get|head|patch|post|put|delete|connect|options|trace)(\.\w+)*$/) || []
+  return {
+    ...handler,
+    method
+  }
+}
+
+/**
  * Adds a new server middleware to the end of the server middleware array.
  *
  * @deprecated Use addServerHandler instead
@@ -23,7 +36,7 @@ export function addServerMiddleware (middleware: LegacyServerMiddleware) {
  *
  */
 export function addServerHandler (handler: NitroEventHandler) {
-  useNuxt().options.serverHandlers.push(handler)
+  useNuxt().options.serverHandlers.push(normalizeHandlerMethod(handler))
 }
 
 /**


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve #5020 , opened after https://github.com/unjs/nitro/pull/252 being closed  
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

allow the addServerHandler() helper to use the method suffix of the file path, NitroEventHandler.method will overwrite the method if defined

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

