### PR TITLE
fix(vite): disable hmr in build

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -79,12 +79,14 @@ export async function bundle (nuxt: Nuxt) {
           watch: {
             ignored: isIgnored
           },
-          hmr: {
-            // https://github.com/nuxt/framework/issues/4191
-            protocol: 'ws',
-            clientPort: hmrPort,
-            port: hmrPort
-          },
+          hmr: nuxt.options.dev
+            ? {
+                // https://github.com/nuxt/framework/issues/4191
+                protocol: 'ws',
+                clientPort: hmrPort,
+                port: hmrPort
+              }
+            : false,
           fs: {
             allow: [
               nuxt.options.appDir


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/5196

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite tests whether hmr is truthy in deciding whether to inject certain code. We should disable this in build mode as a matter of best practice, although there shouldn't be any active bugs as we are [now overriding NODE_ENV](https://github.com/nuxt/framework/pull/5417).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

