### PR TITLE
fix(vite): do not inline dynamic imports in server

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -64,6 +64,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         output: {
           entryFileNames: 'server.mjs',
           preferConst: true,
+          // TODO: https://github.com/vitejs/vite/pull/8641
           inlineDynamicImports: false,
           format: 'module'
         },

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -64,6 +64,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         output: {
           entryFileNames: 'server.mjs',
           preferConst: true,
+          inlineDynamicImports: false,
           format: 'module'
         },
         onwarn (warning, rollupWarn) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #4561

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

See https://github.com/vitejs/vite/issues/8571. We should be preserving dynamic imports for better performance (otherwise our Vue server ends up being a single file). This was likely a regression in vite that will be fixed, so this is a hotfix until that point.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

