### PR TITLE
fix(head): inject `<script>` in rendered HTML when `ssr: false`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -24,8 +24,8 @@ interface RenderResult {
     bodyAttrs: string,
     headAttrs: string,
     headTags: string,
-    bodyScriptsPrepend : string,
-    bodyScripts : string
+    bodyScriptsPrepend: string,
+    bodyScripts: string
   }>
 }
 
@@ -77,7 +77,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
       entryFiles = clientManifest.initial.map(file => ({ file }))
     }
 
-    return Promise.resolve({
+    const rendered: RenderResult = {
       html: '<div id="__nuxt"></div>',
       renderResourceHints: () => '',
       renderStyles: () =>
@@ -93,7 +93,13 @@ const getSPARenderer = lazyCachedFunction(async () => {
             return `<script ${isMJS ? 'type="module"' : ''} src="${buildAssetsURL(file)}"></script>`
           })
           .join('')
-    })
+    }
+
+    if (config.meta) {
+      rendered.meta = config.meta
+    }
+
+    return Promise.resolve(rendered)
   }
 
   return { renderToString }
@@ -163,7 +169,7 @@ async function renderHTML (payload: any, rendered: RenderResult, ssrContext: Nux
   })
 }
 
-function lazyCachedFunction <T> (fn: () => Promise<T>): () => Promise<T> {
+function lazyCachedFunction<T> (fn: () => Promise<T>): () => Promise<T> {
   let res: Promise<T> | null = null
   return () => {
     if (res === null) {

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,7 @@
+import { ref } from 'vue'
 import { resolve } from 'pathe'
 import { addPlugin, addTemplate, defineNuxtModule } from '@nuxt/kit'
+import { createHead, renderHeadToString } from '@vueuse/head'
 import defu from 'defu'
 import { distDir } from '../dirs'
 import type { MetaObject } from './runtime'
@@ -27,6 +29,17 @@ export default defineNuxtModule({
       charset: options.charset,
       viewport: options.viewport
     })
+
+    if (!nuxt.options.ssr) {
+      nuxt.addHooks({
+        'nitro:config': (nitro) => {
+          const head = createHead()
+          head.addHeadObjs(ref(globalMeta))
+
+          nitro.runtimeConfig.meta = renderHeadToString(head)
+        }
+      })
+    }
 
     // Add global meta configuration
     addTemplate({

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -177,7 +177,7 @@ describe('head tags', () => {
     process.env.SSR_ENABLED = 'true'
 
     await rebuildAndRestart()
-  })
+  }, 20000)
 })
 
 describe('navigate', () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -10,6 +10,21 @@ await setup({
   browser: true
 })
 
+const rebuildAndRestart = async () => {
+  await stopServer()
+
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
+    server: true,
+    browser: true
+  })
+
+  await loadFixture()
+  await buildFixture()
+
+  await startServer()
+}
+
 describe('server api', () => {
   it('should serialize', async () => {
     expect(await $fetch('/api/hello')).toBe('Hello API')
@@ -153,22 +168,15 @@ describe('head tags', () => {
 
     expect(html).not.toContain('<script src="/config.js"></script')
 
-    await stopServer()
-
-    await setup({
-      rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
-      server: true,
-      browser: true
-    })
-
-    await loadFixture()
-    await buildFixture()
-
-    await startServer()
+    await rebuildAndRestart()
 
     html = await $fetch('/')
 
     expect(html).toContain('<script src="/config.js"></script')
+
+    process.env.SSR_ENABLED = 'true'
+
+    await rebuildAndRestart()
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 // import { isWindows } from 'std-env'
-import { setup, fetch, $fetch, startServer } from '@nuxt/test-utils'
+import { setup, fetch, $fetch, startServer, buildFixture, stopServer, loadFixture } from '@nuxt/test-utils'
 import { expectNoClientErrors } from './utils'
 
 await setup({
@@ -144,6 +144,31 @@ describe('head tags', () => {
     expect(index).toContain('<meta charset="utf-8">')
     // should render <Head> components
     expect(index).toContain('<title>Basic fixture - Fixture</title>')
+  })
+
+  it('should render global scripts in html for ssr disabled', async () => {
+    process.env.SSR_ENABLED = 'false'
+
+    let html = await $fetch('/')
+
+    expect(html).not.toContain('<script src="/config.js"></script')
+
+    await stopServer()
+
+    await setup({
+      rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
+      server: true,
+      browser: true
+    })
+
+    await loadFixture()
+    await buildFixture()
+
+    await startServer()
+
+    html = await $fetch('/')
+
+    expect(html).toContain('<script src="/config.js"></script')
   })
 })
 

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -29,5 +29,18 @@ export default defineNuxtConfig({
   },
   experimental: {
     reactivityTransform: true
+  },
+  ssr: process.env.SSR_ENABLED !== 'false',
+  app: {
+    head: {
+      script: process.env.SSR_ENABLED === 'false'
+        ? [
+            {
+            // injects the config based on the environment
+              src: '/config.js'
+            }
+          ]
+        : []
+    }
   }
 })

--- a/test/fixtures/basic/public/config.js
+++ b/test/fixtures/basic/public/config.js
@@ -1,0 +1,6 @@
+window.config = {
+  ENV: 'dev',
+  API: {
+    EXPERIENCE_RAW_SERVICE_BASE_URL: 'https://experience-raw-service.dev.company.com'
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#5492 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Add global Header to prerenderd HTML on spa mode.
This is just a first draft, so I would welcome some feedback. For example how to better handle the creation of the meta object, as I have seen there are two libraries for generating the meta object.

Resolves #5492 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
