### PR TITLE
docs: replace invalid link to composables.

### DIFF
--- a/docs/content/2.guide/1.concepts/2.vuejs-development.md
+++ b/docs/content/2.guide/1.concepts/2.vuejs-development.md
@@ -100,7 +100,7 @@ Used with the `setup` keyword in the `<script>` definition, here is the above co
 
 The goal of Nuxt 3 is to provide a great developer experience around the Composition API.
 
-- Use auto-imported [Reactivity functions](https://vuejs.org/api/reactivity-core.html) from Vue and Nuxt 3 [built-in composables](/api/composables).
+- Use auto-imported [Reactivity functions](https://vuejs.org/api/reactivity-core.html) from Vue and Nuxt 3 [built-in composables](/api/composables/use-async-data).
 - Write your own auto-imported reusable functions in the `composables/` directory.
 
 ### TypeScript support


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue [#5610](https://github.com/nuxt/framework/issues/5610)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Line 103:  the route ' /api/composables/ ' results in error 404.
Suggest replacing it with ' /api/composables/use-async-data ' - it is the first page in the list of composables (see https://v3.nuxtjs.org/api/composables/use-async-data).
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

