### PR TITLE
fix(vite): do not watch ignored pathes

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve, join, normalize } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolveModule } from '@nuxt/kit'
+import { logger, resolveModule, isIgnored } from '@nuxt/kit'
 import fse from 'fs-extra'
 import { debounce } from 'perfect-debounce'
 import { withoutTrailingSlash } from 'ufo'
@@ -71,6 +71,9 @@ export async function buildServer (ctx: ViteBuildContext) {
             rollupWarn(warning)
           }
         }
+      },
+      watch: {
+        exclude: ctx.nuxt.options.ignore
       }
     },
     server: {
@@ -176,7 +179,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     // Watch
     viteServer.watcher.on('all', (_event, file) => {
       file = normalize(file) // Fix windows paths
-      if (file.indexOf(ctx.nuxt.options.buildDir) === 0) { return }
+      if (file.indexOf(ctx.nuxt.options.buildDir) === 0 || isIgnored(file)) { return }
       doBuild()
     })
     // ctx.nuxt.hook('builder:watch', () => doBuild())


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add `nuxt.ignore` list into Vite's `rollupOptions.watch.exclude` to prevent those files from being watched.
https://rollupjs.org/guide/en/#watchexclude

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

