### PR TITLE
feat(nuxt): allow passing custom fetch options to `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -38,16 +38,32 @@ export function useFetch<
     return (isRef(r) ? r.value : r) as NitroFetchRequest
   })
 
+  const {
+    server,
+    lazy,
+    default: defaultFn,
+    transform,
+    pick,
+    watch,
+    initialCache,
+    ...fetchOptions
+  } = opts
+
   const _fetchOptions = {
-    ...opts,
+    ...fetchOptions,
     cache: typeof opts.cache === 'boolean' ? undefined : opts.cache
   }
 
   const _asyncDataOptions: AsyncDataOptions<_ResT, Transform, PickKeys> = {
-    ...opts,
+    server,
+    lazy,
+    default: defaultFn,
+    transform,
+    pick,
+    initialCache,
     watch: [
       _request,
-      ...(opts.watch || [])
+      ...(watch || [])
     ]
   }
 


### PR DESCRIPTION
Hello.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/unjs/destr/issues/9

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This fix needed to provide custom `$fetch()` options, like a providing custom `parseResponse()` function to fix the memory leak caused by `destr()` function:

```ts
import type { FetchOptions } from 'ohmyfetch';

/**
 * Parse response
 * @description Replace of `destr()` function to prevent memory leak
 * @param responseText
 */
const parseResponse: FetchOptions['parseResponse'] = (responseText) => {
  // Send empty string if zero length
  if (responseText.length === 0) {
    return '';
  }

  try {
    return JSON.parse(responseText);
  } catch (_e) {
    return responseText;
  }
};

// Example of usage
useFetch('/', {
  parseResponse,
};
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Best wishes,
Sergey.