### PR TITLE
docs: clarify that `definePageMeta` only works in the pages directory

### DIFF
--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -105,4 +105,8 @@ useHead({
 </script>
 ```
 
+::alert{type=warning}
+`definePageMeta` will only work within the [pages/ directory](/guide/directory-structure/pages) since  it is tightly coupled to the Vue Router.
+::
+
 :LinkExample{link="/examples/composables/use-head"}

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -106,7 +106,7 @@ useHead({
 ```
 
 ::alert{type=warning}
-`definePageMeta` will only work within the [pages/ directory](/guide/directory-structure/pages) since  it is tightly coupled to the Vue Router.
+`definePageMeta` will only work within the [pages/ directory](/guide/directory-structure/pages) since it is tightly coupled to the Vue Router.
 ::
 
 :LinkExample{link="/examples/composables/use-head"}

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -81,7 +81,7 @@ const title = ref('Hello World')
 
 ## Example: usage with definePageMeta
 
-You can use `definePageMeta` along with `useHead` to set metadata based on the current route.
+Within your `pages/` directory, you can use `definePageMeta` along with `useHead` to set metadata based on the current route.
 
 For example, you can first set the current page title (this is extracted at build time via a macro, so it can't be set dynamically):
 
@@ -105,8 +105,6 @@ useHead({
 </script>
 ```
 
-::alert{type=warning}
-`definePageMeta` will only work within the [pages/ directory](/guide/directory-structure/pages) since it is tightly coupled to the Vue Router.
-::
-
 :LinkExample{link="/examples/composables/use-head"}
+
+:ReadMore{link="/guide/directory-structure/pages/#page-metadata"}


### PR DESCRIPTION
Added warning about definePageMeta macro only working in pages in pages/ directory

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

