### PR TITLE
fix(nuxt): pass attrs and props to client-only components

### DIFF
--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -29,7 +29,7 @@ export function createClientOnly (component) {
         if (mounted.value) {
           return h(component, attrs, slots)
         }
-        return h('div')
+        return h('div', { class: attrs.class, style: attrs.style })
       }
     }
   })

--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -20,13 +20,14 @@ export default defineComponent({
 
 export function createClientOnly (component) {
   return defineComponent({
-    name: 'ClientOnlyWrapper',
-    setup (props, { attrs, slots }) {
+    name: component.__name || 'ClientOnlyWrapper',
+    inheritAttrs: false,
+    setup (_props, { attrs, slots }) {
       const mounted = ref(false)
       onMounted(() => { mounted.value = true })
       return () => {
         if (mounted.value) {
-          return h(component, { props, attrs }, slots)
+          return h(component, attrs, slots)
         }
         return h('div')
       }

--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -20,7 +20,7 @@ export default defineComponent({
 
 export function createClientOnly (component) {
   return defineComponent({
-    name: component.__name || 'ClientOnlyWrapper',
+    name: 'ClientOnlyWrapper',
     inheritAttrs: false,
     setup (_props, { attrs, slots }) {
       const mounted = ref(false)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently props for a client-only component (e.g. `~/components/SomeComp.client.vue`) aren't getting passed properly, because the Vue 2 signature was being used.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

