### PR TITLE
feat(nuxt): prerender all pages by default

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -55,23 +55,24 @@ export default defineNuxtModule({
     // Prerender all non-dynamic page routes when generating app
     if (!nuxt.options.dev && nuxt.options._generate) {
       const routes = new Set<string>()
-
-      nuxt.hook('pages:extend', (pages) => {
-        routes.clear()
-        for (const path of nuxt.options.nitro.prerender?.routes || []) {
-          routes.add(path)
-        }
-        const processPages = (pages: NuxtPage[], currentPath = '/') => {
-          for (const page of pages) {
-            // Skip dynamic paths
-            if (page.path.includes(':')) { continue }
-
-            const path = joinURL(currentPath, page.path)
+      nuxt.hook('modules:done', () => {
+        nuxt.hook('pages:extend', (pages) => {
+          routes.clear()
+          for (const path of nuxt.options.nitro.prerender?.routes || []) {
             routes.add(path)
-            if (page.children) { processPages(page.children, path) }
           }
-        }
-        processPages(pages)
+          const processPages = (pages: NuxtPage[], currentPath = '/') => {
+            for (const page of pages) {
+              // Skip dynamic paths
+              if (page.path.includes(':')) { continue }
+
+              const path = joinURL(currentPath, page.path)
+              routes.add(path)
+              if (page.children) { processPages(page.children, path) }
+            }
+          }
+          processPages(pages)
+        })
       })
 
       nuxt.hook('nitro:build:before', (nitro) => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4879

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds all non-dynamic routes to the prerenderer by default, as we can't always rely on the crawler to fetch every page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

