### PR TITLE
fix(nuxt): update `useFetch` key warning to include any function or blob

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -26,8 +26,8 @@ export function useFetch<
   request: Ref<ReqT> | ReqT | (() => ReqT),
   opts: UseFetchOptions<_ResT, Transform, PickKeys> = {}
 ) {
-  if (process.dev && opts.transform && !opts.key) {
-    console.warn('[nuxt] You should provide a key for `useFetch` when using a custom transform function.')
+  if (process.dev && !opts.key && Object.values(opts).some(v => typeof v === 'function' || v instanceof Blob)) {
+    console.warn('[nuxt] You should provide a key for `useFetch` when passing options that are not serializable to JSON.')
   }
   const key = '$f_' + (opts.key || hash([request, { ...opts, transform: null }]))
   const _request = computed(() => {

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -27,7 +27,7 @@ export function useFetch<
   opts: UseFetchOptions<_ResT, Transform, PickKeys> = {}
 ) {
   if (process.dev && !opts.key && Object.values(opts).some(v => typeof v === 'function' || v instanceof Blob)) {
-    console.warn('[nuxt] You should provide a key for `useFetch` when passing options that are not serializable to JSON.')
+    console.warn('[nuxt] [useFetch] You should provide a key when passing options that are not serializable to JSON:', opts)
   }
   const key = '$f_' + (opts.key || hash([request, { ...opts, transform: null }]))
   const _request = computed(() => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5690

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This slightly extends the warning for `useFetch` options to include _any_ function passed to it, or also any Blob. (Though `ohash` will also throw an error if a Blob is passed.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

