### PR TITLE
feat(nuxt): share `asyncData` between calls

### DIFF
--- a/docs/content/3.api/1.composables/use-async-data.md
+++ b/docs/content/3.api/1.composables/use-async-data.md
@@ -51,7 +51,7 @@ Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the rout
 * **refresh**: a function that can be used to refresh the data returned by the `handler` function
 * **error**: an error object if the data fetching failed
 
-By default, Nuxt waits until a `refresh` is finished before it can be executed again. Passing `true` as parameter skips that wait.
+By default, Nuxt waits until a `refresh` is finished before it can be executed again. Passing `{ force: true }` as parameter skips that wait.
 
 ## Example
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -111,7 +111,6 @@ export function useAsyncData<
   }
 
   payload.refresh = async (refreshOptions: RefreshOptions) => {
-
     refreshOptions = refreshOptions ?? { _initial: false, force: false }
 
     // Check if a refresh is already in progress, if it is just tag along
@@ -152,8 +151,7 @@ export function useAsyncData<
 
     // Cache our data if its the inital fetch, or we're running on the server
     // We don't need to cache client `refresh` calls, but we should cache server `refresh` calls
-    if (refreshOptions._initial || process.server)
-    {
+    if (refreshOptions._initial || process.server) {
       nuxt.payload.data[key] = payload.data.value
     }
 
@@ -177,7 +175,6 @@ export function useAsyncData<
     // Make our promise resolve when the refresh is complete
     promise = payload.refresh({ _initial: true })
 
-    // Our refresh will always skip cache, our RefreshOptions don't matter
     onServerPrefetch(() => promise)
   } else if (process.client) {
     const instance = getCurrentInstance()

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -55,8 +55,7 @@ export function useAsyncData<
   handler: (ctx?: NuxtApp) => Promise<DataT>,
   options: AsyncDataOptions<DataT, Transform, PickKeys> = {}
 ): AsyncData<PickFrom<ReturnType<Transform>, PickKeys>, ErrorT | null | true> {
-
-   // Validate arguments
+  // Validate arguments
   if (typeof key !== 'string') { throw new TypeError('asyncData key must be a string') }
 
   if (typeof handler !== 'function') { throw new TypeError('asyncData handler must be a function') }
@@ -83,7 +82,7 @@ export function useAsyncData<
   let payload: AsyncData<DataT, ErrorT> = nuxt._asyncDataPayloads[key]
 
   // If there's no payload
-  if (!payload) {    
+  if (!payload) {
     payload = {
       data: wrapInRef(unref(options.default())),
       pending: ref(true),
@@ -92,17 +91,16 @@ export function useAsyncData<
 
     nuxt._asyncDataPayloads[key] = payload
 
-    nuxt.hook("app:rendered", () => {
-        delete nuxt._asyncDataPayloads[key]
+    nuxt.hook('app:rendered', () => {
+      delete nuxt._asyncDataPayloads[key]
     })
   }
 
   const tagAlongOrRun = <T>(
     run: (ctx?: NuxtApp) => Promise<T>
   ): [boolean, Promise<T>] => {
-
     // Nobody else has run the promise yet! Let everyone know
-    if (nuxt._asyncDataPromises[key] == undefined) {
+    if (nuxt._asyncDataPromises[key] === undefined) {
       nuxt._asyncDataPromises[key] = run(nuxt)
       return [false, nuxt._asyncDataPromises[key]]
     } else {
@@ -110,23 +108,21 @@ export function useAsyncData<
     }
   }
 
-  payload.refresh = async (refresh_options: RefreshOptions | true) => {
-
+  payload.refresh = async (refreshOptions: RefreshOptions | true) => {
     // The documentation states passing `true` to refresh will not wait for other refreshes to be executed
     // In reality this would not happen, as you cannot pass true to refresh, and if you passed it as _inital = true
     // Your refresh function would then use cache, which defeats the purpose of refresh
-    const skip = refresh_options === true
+    const skip = refreshOptions === true
 
     // Check if a refresh is already in progress, if it is just tag along
     // Otherwise grab a new promise from the handler
     let promise: Promise<any> = null
     let isTagAlong = false
 
-    if (skip) { 
-        promise = handler(nuxt)
-    }
-    else { 
-        [isTagAlong, promise] = tagAlongOrRun(handler)
+    if (skip) {
+      promise = handler(nuxt)
+    } else {
+      [isTagAlong, promise] = tagAlongOrRun(handler)
     }
 
     promise = promise.then(x => [true, x])
@@ -142,10 +138,8 @@ export function useAsyncData<
     if (!success) {
       payload.error.value = result as ErrorT
       nuxt.payload._errors[key] = true
-    }
-
-    // If our promise resolved update our payload!
-    else {
+    } else {
+      // If our promise resolved update our payload!
       let data = result as DataT
 
       if (options.transform) { data = options.transform(data) }
@@ -173,7 +167,6 @@ export function useAsyncData<
     payload.data.value = nuxt.payload.data[key]
     payload.pending.value = false
   } else if (process.server && fetchOnServer) {
-
     // Make our promise resolve when the refresh is complete
     promise = payload.refresh({ _initial: false })
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -7,6 +7,7 @@ import { getContext } from 'unctx'
 import type { SSRContext } from 'vue-bundle-renderer'
 import type { CompatibilityEvent } from 'h3'
 import { legacyPlugin, LegacyContext } from './compat/legacy-app'
+import { AsyncData } from './composables'
 
 const nuxtAppCtx = getContext<NuxtApp>('nuxt-app')
 
@@ -48,6 +49,7 @@ interface _NuxtApp {
   [key: string]: any
 
   _asyncDataPromises?: Record<string, Promise<any>>
+  _asyncDataPayloads?: Record<string, AsyncData<any, any>>
   _legacyContext?: LegacyContext
 
   ssrContext?: SSRContext & {
@@ -105,6 +107,7 @@ export function createNuxtApp (options: CreateOptions) {
     }),
     isHydrating: process.client,
     _asyncDataPromises: {},
+    _asyncDataPayloads: {},
     ...options
   } as any as NuxtApp
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -127,6 +127,26 @@ describe('pages', () => {
   })
 })
 
+describe('useAsyncData', () => {
+  it('single request resolves', async () => {
+    await expectNoClientErrors('/useAsyncData/single')
+  })
+
+  it('two requests resolve', async () => {
+    await expectNoClientErrors('/useAsyncData/double')
+  })
+
+  it('two requests resolve and sync', async () => {
+    await $fetch('/useAsyncData/refresh', { onResponseError: async (ctx) => {
+      console.error(ctx)
+    }})
+  })
+
+  it('two requests made at once resolve and sync', async () => {
+    await expectNoClientErrors('/useAsyncData/promise-all')
+  })
+})
+
 describe('head tags', () => {
   it('should render tags', async () => {
     const html = await $fetch('/head')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -137,9 +137,7 @@ describe('useAsyncData', () => {
   })
 
   it('two requests resolve and sync', async () => {
-    await $fetch('/useAsyncData/refresh', { onResponseError: async (ctx) => {
-      console.error(ctx)
-    }})
+    await $fetch('/useAsyncData/refresh')
   })
 
   it('two requests made at once resolve and sync', async () => {

--- a/test/fixtures/basic/composables/asyncDataTests.ts
+++ b/test/fixtures/basic/composables/asyncDataTests.ts
@@ -1,5 +1,5 @@
 export const useSleep = () => useAsyncData('sleep', async () => {
-  await new Promise((resolve, _) => setTimeout(resolve, 50))
+  await new Promise(resolve => setTimeout(resolve, 50))
 
   return 'Slept!'
 })

--- a/test/fixtures/basic/composables/asyncDataTests.ts
+++ b/test/fixtures/basic/composables/asyncDataTests.ts
@@ -1,0 +1,7 @@
+export const useSleep = () => useAsyncData('sleep', async () => {
+  await new Promise((resolve, _) => setTimeout(resolve, 50))
+
+  return 'Slept!'
+})
+
+export const useCounter = () => useFetch('/api/useAsyncData/count')

--- a/test/fixtures/basic/pages/useAsyncData/double.vue
+++ b/test/fixtures/basic/pages/useAsyncData/double.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    Single
+    <div>
+      data1: {{ data1 }}
+      data2: {{ data2 }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { data: data1 } = await useSleep()
+const { data: data2 } = await useSleep()
+
+if (data1.value === null || data1.value === undefined || data1.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (data2.value === null || data2.value === undefined || data2.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (data1.value !== data2.value) {
+  throw new Error('AsyncData not synchronised')
+}
+</script>

--- a/test/fixtures/basic/pages/useAsyncData/promise-all.vue
+++ b/test/fixtures/basic/pages/useAsyncData/promise-all.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    Single
+    <div>
+      data1: {{ result1.data.value }}
+      data2: {{ result2.data.value }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const [result1, result2] = await Promise.all([useSleep(), useSleep()])
+
+if (result1.data.value === null || result1.data.value === undefined || result1.data.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (result2.data.value === null || result2.data.value === undefined || result2.data.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (result1.data.value !== result2.data.value) {
+  throw new Error('AsyncData not synchronised')
+}
+
+await result1.refresh()
+
+if (result1.data.value !== result2.data.value) {
+  throw new Error('AsyncData not synchronised')
+}
+</script>

--- a/test/fixtures/basic/pages/useAsyncData/refresh.vue
+++ b/test/fixtures/basic/pages/useAsyncData/refresh.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    Single
+    <div>
+      {{ data }} - {{ data2 }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { data, refresh } = await useCounter()
+const { data: data2, refresh: refresh2 } = await useCounter()
+
+let inital = data.value.count
+
+// Refresh on client and server side
+await refresh()
+
+if (data.value.count !== inital + 1) {
+  throw new Error('Data not refreshed?' + data.value.count + ' : ' + data2.value.count)
+}
+
+if (data.value.count !== data2.value.count) {
+  throw new Error('AsyncData not synchronised')
+}
+
+inital = data.value.count
+
+await refresh2()
+
+if (data.value.count !== inital + 1) {
+  throw new Error('data2 refresh not syncronised?')
+}
+
+if (data.value.count !== data2.value.count) {
+  throw new Error('AsyncData not synchronised')
+}
+
+</script>

--- a/test/fixtures/basic/pages/useAsyncData/single.vue
+++ b/test/fixtures/basic/pages/useAsyncData/single.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    Single
+    <div>
+      {{ data }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { data } = await useSleep()
+
+if (data.value === null || data.value === undefined || data.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+</script>

--- a/test/fixtures/basic/server/api/useAsyncData/count.ts
+++ b/test/fixtures/basic/server/api/useAsyncData/count.ts
@@ -1,0 +1,3 @@
+let counter = 0
+
+export default () => ({ count: counter++ })


### PR DESCRIPTION
Had a look at https://github.com/nuxt/framework/issues/4758 and https://github.com/nuxt/framework/pull/5078 and made some changes to improve readability, and fix the race condition mentioned in the issue.

I have also implemented the change suggested in the other pull request to share `asyncData` between calls.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#4758 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

1. I have refactored `useAsyncData` to use more async await, this (hopefully) makes it much more readable + manageable.
2. I have eliminated some dead code from various code paths, `_nuxtOnBeforeMountCbs` are no longer touched at all server side, data caching is handled top level rather than within refresh, 
3. `refresh` was simplified with the concept of 'tagging along', if a promise is found for a key, use that instead of calling the handler again.
4. `asyncData` is sync'd between calls, for example, if you had a `useUserData` composable, that displays user data in two separate components, calling refresh will change both.
5. As a result of the previous point various bugs related to no sync are resolved (#4758 and likely others)
6. Added a `force` option to refresh, this seems to make more sense then what was provided in the documentation originally, this may be a breaking change.
7. Added some tests for `useAsyncData`, as it's fairly easy to break.
8. Refreshing on the server side updates the cache, this seemed logical.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

