### PR TITLE
fix(nuxt): `useRequestHeaders` type should allow for undefined values

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -3,8 +3,8 @@ import type { CompatibilityEvent } from 'h3'
 import { useNuxtApp } from '#app'
 import { NuxtApp } from '#app/nuxt'
 
-export function useRequestHeaders<K extends string = string> (include: K[]): Record<K, string>;
-export function useRequestHeaders (): Readonly<Record<string, string>>;
+export function useRequestHeaders<K extends string = string> (include: K[]): Record<K, string | undefined>
+export function useRequestHeaders (): Readonly<Record<string, string | undefined>>
 export function useRequestHeaders (include?) {
   if (process.client) { return {} }
   const headers: Record<string, string | string[]> = useNuxtApp().ssrContext?.event.req.headers ?? {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5746

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This explicitly adds `undefined` as a possible value of the return type. This will only have effect if users are using TypeScript in strict mode, as is best practice.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

