### PR TITLE
fix: pin vue-router to 4.0 minor branch

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -67,7 +67,7 @@
     "untyped": "^0.4.4",
     "vue": "^3.2.37",
     "vue-bundle-renderer": "^0.3.9",
-    "vue-router": "^4.0.16"
+    "vue-router": "~4.0.16"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "@nuxtjs"
   ],
   "ignoreDeps": [
+    "vue-router",
     "docus",
     "@docus/app",
     "@docus/github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9891,7 +9891,7 @@ __metadata:
     vue: ^3.2.37
     vue-bundle-renderer: ^0.3.9
     vue-meta: next
-    vue-router: ^4.0.16
+    vue-router: ~4.0.16
   bin:
     nuxi: ./bin/nuxt.mjs
     nuxt: ./bin/nuxt.mjs
@@ -13429,7 +13429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-router@npm:^4.0.16":
+"vue-router@npm:~4.0.16":
   version: 4.0.16
   resolution: "vue-router@npm:4.0.16"
   dependencies:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

for example, https://github.com/nuxt-community/sanity-module/issues/458

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this is a hotfix for current vue-router build that includes `@vue/devtools-api` in its node build (see test failure in https://github.com/nuxt/framework/pull/5712).

cc: @posva 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

