### PR TITLE
fix(nuxt): use virtual server stub with `ssr: false`

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -29,6 +29,7 @@ export async function initNitro (nuxt: Nuxt) {
     handlers,
     devHandlers: [],
     baseURL: nuxt.options.app.baseURL,
+    virtual: {},
     runtimeConfig: {
       ...nuxt.options.runtimeConfig,
       nitro: {
@@ -99,6 +100,11 @@ export async function initNitro (nuxt: Nuxt) {
       plugins: []
     }
   })
+
+  // Add fallback server for `ssr: false`
+  if (!nuxt.options.ssr) {
+    nitroConfig.virtual['#build/dist/server/server.mjs'] = 'export default () => {}'
+  }
 
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -35,7 +35,7 @@ const getClientManifest = () => import('#build/dist/server/client.manifest.mjs')
   .then(r => typeof r === 'function' ? r() : r)
 
 // @ts-ignore
-const getServerEntry = () => process.env.NUXT_NO_SSR ? Promise.resolve(null) : import('#build/dist/server/server.mjs').then(r => r.default || r)
+const getServerEntry = () => import('#build/dist/server/server.mjs').then(r => r.default || r)
 
 // -- SSR Renderer --
 const getSSRRenderer = lazyCachedFunction(async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/5013

resolves https://github.com/nuxt/framework/issues/4784


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When server-side rendering is disabled, we do not generate `.nuxt/dist/server/index.mjs`. A guard with `NUXT_NO_SSR` environment variable was being used but it does not always works and makes issues with rollup that tries to eagerly parse the import statement.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

