### PR TITLE
fix(nuxt): don't return stub function from tree-shaken composables

### DIFF
--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -10,7 +10,7 @@ interface TreeShakePluginOptions {
 }
 
 export const TreeShakePlugin = createUnplugin((options: TreeShakePluginOptions) => {
-  const COMPOSABLE_RE = new RegExp(`($|\\s*)(${options.treeShake.join('|')})(?=\\()`, 'g')
+  const COMPOSABLE_RE = new RegExp(`($|\\s+)(${options.treeShake.join('|')})(?=\\()`, 'gm')
 
   return {
     name: 'nuxt:server-treeshake:transfrom',
@@ -35,7 +35,7 @@ export const TreeShakePlugin = createUnplugin((options: TreeShakePluginOptions) 
       const s = new MagicString(code)
       const strippedCode = stripLiteral(code)
       for (const match of strippedCode.matchAll(COMPOSABLE_RE) || []) {
-        s.overwrite(match.index, match.index + match[0].length, `(() => {}) || /*#__PURE__*/ false && ${match[0]}`)
+        s.overwrite(match.index, match.index + match[0].length, `${match[1]} /*#__PURE__*/ false && ${match[2]}`)
       }
 
       if (s.hasChanged()) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a bug introduced in composable tree-shaking regexp. Also implemented in #5750 but if that's pending we should merge this hotfix sooner.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

