### PR TITLE
refactor(nuxt): add import protection to nitro config

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -112,7 +112,8 @@ export async function initNitro (nuxt: Nuxt) {
     patterns: [
       ...['#app', /^#build(\/|$)/]
         .map(p => [p, 'Vue app aliases are not allowed in server routes.']) as [RegExp | string, string][]
-    ]
+    ],
+    exclude: [/core[\\/]runtime[\\/]nitro[\\/]renderer/]
   }))
 
   // Extend nitro config with hook

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -107,14 +107,13 @@ export async function initNitro (nuxt: Nuxt) {
   }
 
   // Register nuxt protection patterns
-  const plugin = ImportProtectionPlugin.rollup({
+  nitroConfig.rollupConfig.plugins.push(ImportProtectionPlugin.rollup({
     rootDir: nuxt.options.rootDir,
     patterns: [
       ...['#app', /^#build(\/|$)/]
         .map(p => [p, 'Vue app aliases are not allowed in server routes.']) as [RegExp | string, string][]
     ]
-  })
-  nitroConfig.rollupConfig.plugins.push(plugin)
+  }))
 
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -106,6 +106,16 @@ export async function initNitro (nuxt: Nuxt) {
     nitroConfig.virtual['#build/dist/server/server.mjs'] = 'export default () => {}'
   }
 
+  // Register nuxt protection patterns
+  const plugin = ImportProtectionPlugin.rollup({
+    rootDir: nuxt.options.rootDir,
+    patterns: [
+      ...['#app', /^#build(\/|$)/]
+        .map(p => [p, 'Vue app aliases are not allowed in server routes.']) as [RegExp | string, string][]
+    ]
+  })
+  nitroConfig.rollupConfig.plugins.push(plugin)
+
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
 
@@ -120,18 +130,6 @@ export async function initNitro (nuxt: Nuxt) {
 
   // Connect hooks
   nuxt.hook('close', () => nitro.hooks.callHook('close'))
-
-  // Register nuxt protection patterns
-  nitro.hooks.hook('rollup:before', (nitro) => {
-    const plugin = ImportProtectionPlugin.rollup({
-      rootDir: nuxt.options.rootDir,
-      patterns: [
-        ...['#app', /^#build(\/|$)/]
-          .map(p => [p, 'Vue app aliases are not allowed in server routes.']) as [RegExp | string, string][]
-      ]
-    })
-    nitro.options.rollupConfig.plugins.push(plugin)
-  })
 
   // Setup handlers
   const devMidlewareHandler = dynamicEventHandler()

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -10,6 +10,7 @@ const _require = createRequire(import.meta.url)
 interface ImportProtectionOptions {
   rootDir: string
   patterns: [importPattern: string | RegExp, warning?: string][]
+  exclude?: Array<RegExp | string>
 }
 
 export const vueAppPatterns = (nuxt: Nuxt) => [
@@ -25,10 +26,13 @@ export const vueAppPatterns = (nuxt: Nuxt) => [
 
 export const ImportProtectionPlugin = createUnplugin(function (options: ImportProtectionOptions) {
   const cache: Record<string, Map<string | RegExp, boolean>> = {}
+  const importersToExclude = options?.exclude || []
   return {
     name: 'nuxt:import-protection',
     enforce: 'pre',
     resolveId (id, importer) {
+      if (importersToExclude.some(p => typeof p === 'string' ? importer === p : p.test(importer))) { return }
+
       const invalidImports = options.patterns.filter(([pattern]) => pattern instanceof RegExp ? pattern.test(id) : pattern === id)
       let matched: boolean
       for (const match of invalidImports) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/content/pull/1346#issuecomment-1180431720

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While investigating https://github.com/nuxt/content/pull/1346#issuecomment-1180431720 (resolved with https://github.com/unjs/nitro/pull/335), I think it doesn't make sense to add this in a hook when we can add it directly. Additional plus is that users get the plugin in `nitro:config` hook.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

