### PR TITLE
fix(nuxt): only tree-shake composables on their own lines

### DIFF
--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -10,17 +10,17 @@ interface TreeShakePluginOptions {
 }
 
 export const TreeShakePlugin = createUnplugin((options: TreeShakePluginOptions) => {
-  const COMPOSABLE_RE = new RegExp(`($|\\s+)(${options.treeShake.join('|')})(?=\\()`, 'gm')
+  const COMPOSABLE_RE = new RegExp(`($\\s+)(${options.treeShake.join('|')})(?=\\()`, 'gm')
 
   return {
     name: 'nuxt:server-treeshake:transfrom',
     enforce: 'post',
     transformInclude (id) {
       const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      const { type, macro } = parseQuery(search)
+      const { type } = parseQuery(search)
 
       // vue files
-      if (pathname.endsWith('.vue') && (type === 'script' || macro || !search)) {
+      if (pathname.endsWith('.vue') && (type === 'script' || !search)) {
         return true
       }
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This further restricts the tree-shaking of composables, requiring nothing on the line before it to reduce the chance of false positives. (So this will no longer treeshake something like `const cb = onMounted()`.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

