### PR TITLE
fix(nuxt): replace `process.dev` in nitro bundle

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -94,7 +94,8 @@ export async function initNitro (nuxt: Nuxt) {
       ...nuxt.options.alias
     },
     replace: {
-      'process.env.NUXT_NO_SSR': nuxt.options.ssr === false
+      'process.env.NUXT_NO_SSR': nuxt.options.ssr === false,
+      'process.dev': nuxt.options.dev
     },
     rollupConfig: {
       plugins: []

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -57,7 +57,8 @@ const getSSRRenderer = lazyCachedFunction(async () => {
   async function renderToString (input, context) {
     const html = await _renderToString(input, context)
     // In development with vite-node, the manifest is on-demand and will be available after rendering
-    if (process.dev && process.env.NUXT_VITE_NODE_OPTIONS) {
+    if (process.env.NUXT_VITE_NODE_OPTIONS) {
+      console.log('HII')
       renderer.rendererContext.updateManifest(await getClientManifest())
     }
     return `<div id="__nuxt">${html}</div>`

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -57,7 +57,7 @@ const getSSRRenderer = lazyCachedFunction(async () => {
   async function renderToString (input, context) {
     const html = await _renderToString(input, context)
     // In development with vite-node, the manifest is on-demand and will be available after rendering
-    if (process.env.NUXT_VITE_NODE_OPTIONS) {
+    if (process.dev && process.env.NUXT_VITE_NODE_OPTIONS) {
       renderer.rendererContext.updateManifest(await getClientManifest())
     }
     return `<div id="__nuxt">${html}</div>`

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -58,7 +58,6 @@ const getSSRRenderer = lazyCachedFunction(async () => {
     const html = await _renderToString(input, context)
     // In development with vite-node, the manifest is on-demand and will be available after rendering
     if (process.env.NUXT_VITE_NODE_OPTIONS) {
-      console.log('HII')
       renderer.rendererContext.updateManifest(await getClientManifest())
     }
     return `<div id="__nuxt">${html}</div>`


### PR DESCRIPTION
`process.dev` is undefined in the npm build (while it works in the local playground). Since `NUXT_VITE_NODE_OPTIONS` will only be injected in dev, I guess it's safe to remove it