### PR TITLE
fix(vite-node): transform mode of Vue files

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -63,6 +63,10 @@ function createViteNodeMiddleware (ctx: ViteBuildContext) {
           /^#/,
           ...ctx.nuxt.options.build.transpile as string[]
         ]
+      },
+      transformMode: {
+        ssr: [/.*/],
+        web: []
       }
     })
     return async (event) => {


### PR DESCRIPTION
close #5543

Vite Node by default only passes `ssr: true` when transforming js-like modules. For other files like `.vue`, it transforms into client mode to preserve the reactivity (e.g. for testing). In our case, we don't need the capability since we only do SSR.
