### PR TITLE
fix(nuxt): warn about legacy and invalid plugins

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -189,13 +189,13 @@ export function normalizePlugins (_plugins: Plugin[]) {
     }
     if (plugin.length > 1) {
       needsLegacyContext = true
-      return (nuxtApp: NuxtApp) => (plugin as any)(nuxtApp, nuxtApp.provide)
+      return () => {}
     }
     return plugin
   })
 
   if (process.dev && needsLegacyContext) {
-    console.warn('[nuxt] You are using a legacy Nuxt 2 format plugin which takes a second argument. In the future this will throw a fatal error.')
+    console.warn('[nuxt] You are using a legacy Nuxt 2 format plugin which takes a second argument. It has been ignored, and in the future may throw a fatal error.')
   }
 
   return plugins as Plugin[]

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -203,7 +203,7 @@ export function normalizePlugins (_plugins: Plugin[]) {
   }
 
   if (process.dev && isUnwrappedPlugin) {
-    console.warn('[nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in future this may enable enhancements.')
+    console.warn('[nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in the future this may enable enhancements.')
   }
 
   return plugins as Plugin[]

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -181,12 +181,22 @@ export async function applyPlugins (nuxtApp: NuxtApp, plugins: Plugin[]) {
 }
 
 export function normalizePlugins (_plugins: Plugin[]) {
+  let needsLegacyContext = false
+
   const plugins = _plugins.map((plugin) => {
     if (typeof plugin !== 'function') {
       return () => {}
     }
+    if (plugin.length > 1) {
+      needsLegacyContext = true
+      return (nuxtApp: NuxtApp) => (plugin as any)(nuxtApp, nuxtApp.provide)
+    }
     return plugin
   })
+
+  if (process.dev && needsLegacyContext) {
+    console.warn('[nuxt] You are using a legacy Nuxt 2 format plugin which takes a second argument. In the future this will throw a fatal error.')
+  }
 
   return plugins as Plugin[]
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -181,34 +181,34 @@ export async function applyPlugins (nuxtApp: NuxtApp, plugins: Plugin[]) {
 }
 
 export function normalizePlugins (_plugins: Plugin[]) {
-  let hasUnwrappedPlugin = false
-  let hasLegacyInject = false
-  let hasInvalidPlugin = false
+  const unwrappedPlugins = []
+  const legacyInjectPlugins = []
+  const invalidPlugins = []
 
   const plugins = _plugins.map((plugin) => {
     if (typeof plugin !== 'function') {
-      hasInvalidPlugin = true
+      invalidPlugins.push(plugin)
       return null
     }
     if (plugin.length > 1) {
-      hasLegacyInject = true
+      legacyInjectPlugins.push(plugin)
       return null
     }
     if (!isNuxtPlugin(plugin)) {
-      hasUnwrappedPlugin = true
+      unwrappedPlugins.push(plugin)
       // Allow usage without wrapper but warn
     }
     return plugin
   }).filter(Boolean)
 
-  if (process.dev && hasLegacyInject) {
-    console.warn('[warn] [nuxt] You are using a plugin with legacy Nuxt 2 format which takes a second argument. It has been ignored, and in the future may throw a fatal error.')
+  if (process.dev && legacyInjectPlugins.length) {
+    console.warn('[warn] [nuxt] You are using a plugin with legacy Nuxt 2 format (context, inject). It has been ignored, and in the future may throw a fatal error:', legacyInjectPlugins.map(p => p.name || p).join(','))
   }
-  if (process.dev && hasInvalidPlugin) {
-    console.warn('[warn] [nuxt] Some plugins are not exposing a function and skipped.')
+  if (process.dev && invalidPlugins.length) {
+    console.warn('[warn] [nuxt] Some plugins are not exposing a function and skipped:', invalidPlugins)
   }
-  if (process.dev && hasUnwrappedPlugin) {
-    console.warn('[warn] [nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in the future this may enable enhancements.')
+  if (process.dev && unwrappedPlugins.length) {
+    console.warn('[warn] [nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in the future this may enable enhancements:', unwrappedPlugins.map(p => p.name || p).join(','))
   }
 
   return plugins as Plugin[]

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -181,28 +181,28 @@ export async function applyPlugins (nuxtApp: NuxtApp, plugins: Plugin[]) {
 }
 
 export function normalizePlugins (_plugins: Plugin[]) {
-  let isUnwrappedPlugin = false
-  let needsLegacyInject = false
+  let hasUnwrappedPlugin = false
+  let hasLegacyInject = false
 
   const plugins = _plugins.map((plugin) => {
     if (typeof plugin !== 'function') {
       return () => {}
     }
     if (plugin.length > 1) {
-      needsLegacyInject = true
+      hasUnwrappedPlugin = true
       return () => {}
     }
     if (!isNuxtPlugin(plugin)) {
-      isUnwrappedPlugin = true
+      hasLegacyInject = true
     }
     return plugin
   })
 
-  if (process.dev && needsLegacyInject) {
+  if (process.dev && hasLegacyInject) {
     console.warn('[nuxt] You are using a legacy Nuxt 2 format plugin which takes a second argument. It has been ignored, and in the future may throw a fatal error.')
   }
 
-  if (process.dev && isUnwrappedPlugin) {
+  if (process.dev && hasUnwrappedPlugin) {
     console.warn('[nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in the future this may enable enhancements.')
   }
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -192,7 +192,11 @@ export function normalizePlugins (_plugins: Plugin[]) {
     }
     if (plugin.length > 1) {
       legacyInjectPlugins.push(plugin)
-      return null
+      // Allow usage without wrapper but warn
+      // TODO: Skip invalid in next releases
+      // @ts-ignore
+      return (nuxtApp: NuxtApp) => plugin(nuxtApp, nuxtApp.provide)
+      // return null
     }
     if (!isNuxtPlugin(plugin)) {
       unwrappedPlugins.push(plugin)
@@ -202,7 +206,7 @@ export function normalizePlugins (_plugins: Plugin[]) {
   }).filter(Boolean)
 
   if (process.dev && legacyInjectPlugins.length) {
-    console.warn('[warn] [nuxt] You are using a plugin with legacy Nuxt 2 format (context, inject). It has been ignored, and in the future may throw a fatal error:', legacyInjectPlugins.map(p => p.name || p).join(','))
+    console.warn('[warn] [nuxt] You are using a plugin with legacy Nuxt 2 format (context, inject) which is likely to be broken. In the future they will be ignored:', legacyInjectPlugins.map(p => p.name || p).join(','))
   }
   if (process.dev && invalidPlugins.length) {
     console.warn('[warn] [nuxt] Some plugins are not exposing a function and skipped:', invalidPlugins)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following https://github.com/nuxt/framework/pull/5630, plugins which take a second argument for `inject` will silently fail. This at least adds a warning if they are being used. Example: https://github.com/moritzsternemann/vue-plausible/blob/main/src/nuxt-plugin.ts ([hotfix PR](https://github.com/moritzsternemann/vue-plausible/pull/21)).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

