### PR TITLE
fix(nuxt): fix issues with `vue-router` and `@vue/devtools-api` bundling

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -68,7 +68,7 @@
     "untyped": "^0.4.4",
     "vue": "^3.2.37",
     "vue-bundle-renderer": "^0.3.9",
-    "vue-router": "~4.0.16"
+    "vue-router": "^4.1.2"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -52,7 +52,7 @@
     "knitwork": "^0.1.2",
     "magic-string": "^0.26.2",
     "mlly": "^0.5.4",
-    "nitropack": "^0.4.9",
+    "nitropack": "^0.4.10",
     "nuxi": "^3.0.0-rc.4",
     "ohash": "^0.1.0",
     "ohmyfetch": "^0.4.18",

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -85,7 +85,7 @@ export async function initNitro (nuxt: Nuxt) {
       '@vue/compiler-core': 'unenv/runtime/mock/proxy',
       '@vue/compiler-dom': 'unenv/runtime/mock/proxy',
       '@vue/compiler-ssr': 'unenv/runtime/mock/proxy',
-      '@vue/devtools-api': 'unenv/runtime/mock/proxy',
+      '@vue/devtools-api': 'unenv/runtime/mock/proxy-cjs',
 
       // Paths
       '#paths': resolve(distDir, 'core/runtime/nitro/paths'),

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
     "@nuxtjs"
   ],
   "ignoreDeps": [
-    "vue-router",
     "docus",
     "@docus/app",
     "@docus/github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,10 +3034,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/devtools-api@npm:^6.0.0":
-  version: 6.2.0
-  resolution: "@vue/devtools-api@npm:6.2.0"
-  checksum: 20cc7a3393af1992e02dfdd21c494b33fc1ed00b7b6b57bea92ae360b43f938a416759e8c3c1a269ba44fe8ae4436b9520419a7a3f1a6d65fb3cf4d56c2e8763
+"@vue/devtools-api@npm:^6.1.4":
+  version: 6.2.1
+  resolution: "@vue/devtools-api@npm:6.2.1"
+  checksum: 34765af0be9b0cc7e3def73b2792b1514e3c348852c5a7503fe07d013f0e907af6c27c0a32c0637dd748caf37c075af8e53ca3220433e0bd34b6f3405f358272
   languageName: node
   linkType: hard
 
@@ -9706,7 +9706,7 @@ __metadata:
     vue: ^3.2.37
     vue-bundle-renderer: ^0.3.9
     vue-meta: next
-    vue-router: ~4.0.16
+    vue-router: ^4.1.2
   bin:
     nuxi: ./bin/nuxt.mjs
     nuxt: ./bin/nuxt.mjs
@@ -13221,14 +13221,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-router@npm:~4.0.16":
-  version: 4.0.16
-  resolution: "vue-router@npm:4.0.16"
+"vue-router@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "vue-router@npm:4.1.2"
   dependencies:
-    "@vue/devtools-api": ^6.0.0
+    "@vue/devtools-api": ^6.1.4
   peerDependencies:
     vue: ^3.2.0
-  checksum: 4b8e417c96404d4f4c69539112dfafc52f3b2427db3663d5129413a9b65aafdb95889d756af4c6d08a84d7f9e80cc0ae4667383f2c090f27c27ea4b5d83c4cec
+  checksum: f4b900f0db25a098647ada5eee05de6bc48e8f9c87deb403a87e7996965f39560654580f2d074c1ae0da427cc8d47eac9395cb17f6dc58a29d7d555f7510600e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9147,9 +9147,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitropack@npm:^0.4.9":
-  version: 0.4.9
-  resolution: "nitropack@npm:0.4.9"
+"nitropack@npm:^0.4.10":
+  version: 0.4.10
+  resolution: "nitropack@npm:0.4.10"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
     "@netlify/functions": ^1.0.0
@@ -9164,7 +9164,7 @@ __metadata:
     "@types/jsdom": ^16.2.14
     "@vercel/nft": ^0.20.1
     archiver: ^5.3.1
-    c12: ^0.2.7
+    c12: ^0.2.8
     chalk: ^5.0.1
     chokidar: ^3.5.3
     consola: ^2.15.3
@@ -9172,7 +9172,7 @@ __metadata:
     defu: ^6.0.0
     destr: ^1.1.1
     dot-prop: ^7.2.0
-    esbuild: ^0.14.47
+    esbuild: ^0.14.49
     escape-string-regexp: ^5.0.0
     etag: ^1.8.1
     fs-extra: ^10.1.0
@@ -9191,12 +9191,12 @@ __metadata:
     node-fetch-native: ^0.1.4
     ohash: ^0.1.0
     ohmyfetch: ^0.4.18
-    pathe: ^0.3.1
+    pathe: ^0.3.2
     perfect-debounce: ^0.1.3
     pkg-types: ^0.3.3
     pretty-bytes: ^6.0.0
     radix3: ^0.1.2
-    rollup: ^2.75.7
+    rollup: ^2.76.0
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-visualizer: ^5.6.0
     scule: ^0.2.1
@@ -9206,14 +9206,14 @@ __metadata:
     source-map-support: ^0.5.21
     std-env: ^3.1.1
     table: ^6.8.0
-    ufo: ^0.8.4
+    ufo: ^0.8.5
     unenv: ^0.5.2
-    unimport: ^0.4.0
-    unstorage: ^0.5.3
+    unimport: ^0.4.4
+    unstorage: ^0.5.4
   bin:
     nitro: dist/cli.mjs
     nitropack: dist/cli.mjs
-  checksum: c333e468dcfa1a00214a454651267a2606c155d42f43f5944772e454ee577e1201c1cb4edf31e5d7fc9e45e97bdb07034dfe978a1038ac7e0ca0860bce38a29f
+  checksum: 3f8538485c3160aec56135f7dbece37431cb4c710a7d3d0a5c4c1963e60507fbcb52fed3338dd6fd6a1ffb06e93fddbb38abadb0e736afe0708a00d31408fc0f
   languageName: node
   linkType: hard
 
@@ -9688,7 +9688,7 @@ __metadata:
     knitwork: ^0.1.2
     magic-string: ^0.26.2
     mlly: ^0.5.4
-    nitropack: ^0.4.9
+    nitropack: ^0.4.10
     nuxi: ^3.0.0-rc.4
     ohash: ^0.1.0
     ohmyfetch: ^0.4.18
@@ -11358,7 +11358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.59.0, rollup@npm:^2.70.1, rollup@npm:^2.75.7, rollup@npm:^2.76.0":
+"rollup@npm:^2.59.0, rollup@npm:^2.70.1, rollup@npm:^2.76.0":
   version: 2.76.0
   resolution: "rollup@npm:2.76.0"
   dependencies:
@@ -12716,7 +12716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unimport@npm:^0.4.0, unimport@npm:^0.4.4":
+"unimport@npm:^0.4.4":
   version: 0.4.4
   resolution: "unimport@npm:0.4.4"
   dependencies:
@@ -12861,7 +12861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unstorage@npm:^0.5.3":
+"unstorage@npm:^0.5.4":
   version: 0.5.4
   resolution: "unstorage@npm:0.5.4"
   dependencies:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #4325

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Rollup build fails with ESM proxy mocks. Using cjs entry allows ESM syntax import.
- Updated nitro to respect `development` and `production` export conditions used by latest `vue-router`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

