### PR TITLE
fix(vite): close vite watcher before building

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -102,6 +102,8 @@ export async function bundle (nuxt: Nuxt) {
     ctx.config.server.hmr = false
     ctx.config.server.watch = undefined
 
+    // TODO: Workaround for vite watching tsconfig changes
+    // https://github.com/nuxt/framework/pull/5875
     ctx.config.plugins.push({
       name: 'nuxt:close-vite-watcher',
       configureServer (server) {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -101,6 +101,13 @@ export async function bundle (nuxt: Nuxt) {
   if (!nuxt.options.dev) {
     ctx.config.server.hmr = false
     ctx.config.server.watch = undefined
+
+    ctx.config.plugins.push({
+      name: 'nuxt:close-vite-watcher',
+      configureServer (server) {
+        return server?.watcher?.close()
+      }
+    })
   }
 
   await nuxt.callHook('vite:extend', ctx)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/5657

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We continue watching files during the vite build process, and if (due to a race condition) `tsconfig.json` is written after vite build starts it can trigger a vite error from the esbuild plugin.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

