### PR TITLE
docs: add way to pass `.env` variables to nuxt app in production

### DIFF
--- a/docs/content/2.guide/2.features/10.runtime-config.md
+++ b/docs/content/2.guide/2.features/10.runtime-config.md
@@ -39,7 +39,7 @@ Nuxt CLI has built-in [dotenv](https://github.com/motdotla/dotenv) support.
 
 In addition to any process environment variables, if you have a `.env` file in your project root directory, it will be automatically loaded into `process.env` and accessible within your `nuxt.config` file and modules.
 
-However, **after your project is built**, you are responsible for setting environment variables when you run the server - your `.env` file will not be read at this point.
+However, **after your project is built**, you are responsible for setting environment variables when you run the server - your `.env` file will not be read at this point. For example, you could pass the environment variables as arguments using the terminal `DATABASE_HOST=mydatabaseconnectionstring yarn start`. 
 ::
 
 Runtime config values are automatically replaced by matching environment variables at runtime. For this to work, you _must_ have a fallback value (which can just be an empty string) defined in your `nuxt.config`.

--- a/docs/content/2.guide/2.features/10.runtime-config.md
+++ b/docs/content/2.guide/2.features/10.runtime-config.md
@@ -39,7 +39,7 @@ Nuxt CLI has built-in [dotenv](https://github.com/motdotla/dotenv) support.
 
 In addition to any process environment variables, if you have a `.env` file in your project root directory, it will be automatically loaded into `process.env` and accessible within your `nuxt.config` file and modules.
 
-However, **after your project is built**, you are responsible for setting environment variables when you run the server - your `.env` file will not be read at this point. For example, you could pass the environment variables as arguments using the terminal `DATABASE_HOST=mydatabaseconnectionstring yarn start`. 
+However, **after your project is built**, you are responsible for setting environment variables when you run the server - your `.env` file will not be read at this point. For example, you could pass the environment variables as arguments using the terminal `DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs`.
 ::
 
 Runtime config values are automatically replaced by matching environment variables at runtime. For this to work, you _must_ have a fallback value (which can just be an empty string) defined in your `nuxt.config`.


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description
Add an example to clarify this. 

### 📝 Checklist
- [x] I have updated the documentation accordingly.

