### PR TITLE
fix(kit): only call `viteExtendConfig` callback once if possible

### DIFF
--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -99,6 +99,11 @@ export function extendViteConfig (
     return
   }
 
+  if (options.server !== false && options.client !== false) {
+    // Call fn() only once
+    return nuxt.hook('vite:extend', ({ config }) => fn(config))
+  }
+
   nuxt.hook('vite:extendConfig', (config, { isClient, isServer }) => {
     if (options.server !== false && isServer) {
       return fn(config)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There's an outstanding issue with kit RC 5 that may break plugins that rely on being shared between client + server vite configs. (see https://github.com/unocss/unocss/pull/1276 for an upstream hotfix). This PR ensures that if client/server flags aren't set, we will call the function only once.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

