### PR TITLE
fix(nuxt): lazy load and tree-shake error templates

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -37,10 +37,10 @@ const description = error.message || error.toString()
 const stack = process.dev && !is404 ? error.description || `<pre>${stacktrace}</pre>` : undefined
 
 // TODO: Investigate side-effect issue with imports
-const get404Template = () => import('@nuxt/ui-templates/templates/error-404.vue')
-const getErrorTemplate = process.dev
-  ? () => import('@nuxt/ui-templates/templates/error-dev.vue').then(r => r.default || r)
-  : () => import('@nuxt/ui-templates/templates/error-500.vue').then(r => r.default || r)
+const _Error404 = defineAsyncComponent(() => import('@nuxt/ui-templates/templates/error-404.vue'))
+const _Error = process.dev
+  ? defineAsyncComponent(import('@nuxt/ui-templates/templates/error-dev.vue'))
+  : defineAsyncComponent(import('@nuxt/ui-templates/templates/error-500.vue'))
 
-const ErrorTemplate = defineAsyncComponent(is404 ? get404Template : getErrorTemplate)
+const ErrorTemplate = is404 ? _Error404 : _Error
 </script>

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -39,8 +39,8 @@ const stack = process.dev && !is404 ? error.description || `<pre>${stacktrace}</
 // TODO: Investigate side-effect issue with imports
 const _Error404 = defineAsyncComponent(() => import('@nuxt/ui-templates/templates/error-404.vue'))
 const _Error = process.dev
-  ? defineAsyncComponent(import('@nuxt/ui-templates/templates/error-dev.vue'))
-  : defineAsyncComponent(import('@nuxt/ui-templates/templates/error-500.vue'))
+  ? defineAsyncComponent(() => import('@nuxt/ui-templates/templates/error-dev.vue'))
+  : defineAsyncComponent(() => import('@nuxt/ui-templates/templates/error-500.vue'))
 
 const ErrorTemplate = is404 ? _Error404 : _Error
 </script>

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -3,9 +3,6 @@
 </template>
 
 <script setup>
-import Error404 from '@nuxt/ui-templates/templates/error-404.vue'
-import Error500 from '@nuxt/ui-templates/templates/error-500.vue'
-
 const props = defineProps({
   error: Object
 })
@@ -24,8 +21,8 @@ const stacktrace = (error.stack || '')
     return {
       text,
       internal: (line.includes('node_modules') && !line.includes('.cache')) ||
-          line.includes('internal') ||
-          line.includes('new Promise')
+        line.includes('internal') ||
+        line.includes('new Promise')
     }
   }).map(i => `<span class="stack${i.internal ? ' internal' : ''}">${i.text}</span>`).join('\n')
 
@@ -37,6 +34,11 @@ const statusMessage = error.statusMessage ?? (is404 ? 'Page Not Found' : 'Intern
 const description = error.message || error.toString()
 const stack = process.dev && !is404 ? error.description || `<pre>${stacktrace}</pre>` : undefined
 
-// TODO: Investigate tree-shaking issues
-const ErrorTemplate = is404 ? Error404 : process.dev ? await import('@nuxt/ui-templates/templates/error-dev.vue').then(r => r.default || r) : Error500
+// TODO: Investigate side-effect issue with imports
+const get404Template = () => import('@nuxt/ui-templates/templates/error-404.vue')
+const getErrorTemplate = process.dev
+  ? () => import('@nuxt/ui-templates/templates/error-dev.vue').then(r => r.default || r)
+  : () => import('@nuxt/ui-templates/templates/error-500.vue').then(r => r.default || r)
+
+const ErrorTemplate = is404 ? await get404Template() : await getErrorTemplate()
 </script>

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -37,5 +37,6 @@ const statusMessage = error.statusMessage ?? (is404 ? 'Page Not Found' : 'Intern
 const description = error.message || error.toString()
 const stack = process.dev && !is404 ? error.description || `<pre>${stacktrace}</pre>` : undefined
 
+// TODO: Investigate tree-shaking issues
 const ErrorTemplate = is404 ? Error404 : process.dev ? await import('@nuxt/ui-templates/templates/error-dev.vue').then(r => r.default || r) : Error500
 </script>

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -5,7 +5,6 @@
 <script setup>
 import Error404 from '@nuxt/ui-templates/templates/error-404.vue'
 import Error500 from '@nuxt/ui-templates/templates/error-500.vue'
-import ErrorDev from '@nuxt/ui-templates/templates/error-dev.vue'
 
 const props = defineProps({
   error: Object
@@ -38,5 +37,5 @@ const statusMessage = error.statusMessage ?? (is404 ? 'Page Not Found' : 'Intern
 const description = error.message || error.toString()
 const stack = process.dev && !is404 ? error.description || `<pre>${stacktrace}</pre>` : undefined
 
-const ErrorTemplate = is404 ? Error404 : process.dev ? ErrorDev : Error500
+const ErrorTemplate = is404 ? Error404 : process.dev ? await import('@nuxt/ui-templates/templates/error-dev.vue').then(r => r.default || r) : Error500
 </script>

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script setup>
+import { defineAsyncComponent } from 'vue'
+
 const props = defineProps({
   error: Object
 })
@@ -40,5 +42,5 @@ const getErrorTemplate = process.dev
   ? () => import('@nuxt/ui-templates/templates/error-dev.vue').then(r => r.default || r)
   : () => import('@nuxt/ui-templates/templates/error-500.vue').then(r => r.default || r)
 
-const ErrorTemplate = is404 ? await get404Template() : await getErrorTemplate()
+const ErrorTemplate = defineAsyncComponent(is404 ? get404Template : getErrorTemplate)
 </script>

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -6,10 +6,10 @@
 </template>
 
 <script setup>
-import { onErrorCaptured } from 'vue'
+import { defineAsyncComponent, onErrorCaptured } from 'vue'
 import { callWithNuxt, throwError, useError, useNuxtApp } from '#app'
-// @ts-ignore
-import ErrorComponent from '#build/error-component.mjs'
+
+const ErrorComponent = defineAsyncComponent(() => import('#build/error-component.mjs'))
 
 const nuxtApp = useNuxtApp()
 const onResolve = () => nuxtApp.callHook('app:suspense:resolve')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently `error-dev` is being bundled and not tree-shaken. This change uses a dynamic import for dev errors which allows vite to tree-shake it out of the final build.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

