### PR TITLE
fix(vite): use shared watcher instance

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -129,6 +129,20 @@ export async function bundle (nuxt: Nuxt) {
       .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
       .catch(logger.error)
   })
+
+  // Use single watcher instance shared between client and server
+  // https://github.com/nuxt/framework/issues/2047
+  // TODO: Not needed for MacOS
+  let viteWatcher
+  nuxt.hook('vite:serverCreated', async (server: vite.ViteDevServer) => {
+    if (viteWatcher) {
+      await server.watcher.close()
+      server.watcher = viteWatcher
+    } else {
+      viteWatcher = server.watcher
+    }
+  })
+
   await buildClient(ctx)
   await buildServer(ctx)
 }

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,12 +1,9 @@
-<script setup lang="ts">
+<script setup>
+const data = ref('b')
 </script>
 
 <template>
-  <!-- Edit this file to play around with Nuxt but never commit changes! -->
   <div>
-    Nuxt 3 Playground
+    {{ data }}
   </div>
 </template>
-
-<style scoped>
-</style>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,5 @@
 import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
+  // ssr: false
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #2047

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In platforms other than macOS (Windows, Linux, and WSL2) when two vite server watchers are running (client and bundle), only the last one (server) receives watcher events causing HMR to be broken. This is likely an issue with chokidar (without `fsevents` that is used for macOS) within vite. (https://github.com/nuxt/framework/issues/2047#issuecomment-1186034999)

This PR tried to work around this by using a shared watcher and close another one. Since both vite servers (client and server) use exactly the same chokidar params, it should be safe also more performant.

[PR is playground for now not working]

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

