### PR TITLE
fix(vite): unset `build.watch` options for production build

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -73,9 +73,6 @@ export async function buildServer (ctx: ViteBuildContext) {
             rollupWarn(warning)
           }
         }
-      },
-      watch: {
-        exclude: ctx.nuxt.options.ignore
       }
     },
     server: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -63,6 +63,9 @@ export async function bundle (nuxt: Nuxt) {
           rollupOptions: {
             output: { sanitizeFileName: sanitizeFilePath },
             input: resolve(nuxt.options.appDir, 'entry')
+          },
+          watch: {
+            exclude: nuxt.options.ignore
           }
         },
         plugins: [
@@ -101,6 +104,7 @@ export async function bundle (nuxt: Nuxt) {
   if (!nuxt.options.dev) {
     ctx.config.server.hmr = false
     ctx.config.server.watch = undefined
+    ctx.config.build.watch = undefined
   }
 
   await nuxt.callHook('vite:extend', ctx)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #5899

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression was introduced in rc.5 with #5632 by adding `build.watch` key. The change likely only unrevealed an issue in vite. When this key exists for production, the server build promise succeeds but no output is generated! Removing `watch` key from production seems to solve this issue. This PR also refactors config placement to the shared one for more readability.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

