### PR TITLE
fix(vite): use more strict app entry check in dev-bundler

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -63,7 +63,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
     if (id.match(/^\/\w:/)) {
       id = id.slice(1)
     }
-  } else if (!id.includes('entry') && id.startsWith('/')) {
+  } else if (!id.includes('app/entry') && id.startsWith('/')) {
     // Relative to the root directory
     const resolvedPath = resolve(opts.viteServer.config.root, '.' + id)
     if (existsSync(resolvedPath)) {

--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -63,7 +63,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
     if (id.match(/^\/\w:/)) {
       id = id.slice(1)
     }
-  } else if (!id.includes('app/entry') && id.startsWith('/')) {
+  } else if (!(/\/app\/(entry|entry.mjs)$/.test(id)) && id.startsWith('/')) {
     // Relative to the root directory
     const resolvedPath = resolve(opts.viteServer.config.root, '.' + id)
     if (existsSync(resolvedPath)) {

--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -63,7 +63,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
     if (id.match(/^\/\w:/)) {
       id = id.slice(1)
     }
-  } else if (!(/\/app\/(entry|entry.mjs)$/.test(id)) && id.startsWith('/')) {
+  } else if (id.startsWith('/') && !(/\/app\/(entry|entry.mjs)$/.test(id))) {
     // Relative to the root directory
     const resolvedPath = resolve(opts.viteServer.config.root, '.' + id)
     if (existsSync(resolvedPath)) {

--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -63,7 +63,7 @@ async function transformRequest (opts: TransformOptions, id: string) {
     if (id.match(/^\/\w:/)) {
       id = id.slice(1)
     }
-  } else if (id.startsWith('/') && !(/\/app\/(entry|entry.mjs)$/.test(id))) {
+  } else if (id.startsWith('/') && !(/\/app\/entry(|.mjs)$/.test(id))) {
     // Relative to the root directory
     const resolvedPath = resolve(opts.viteServer.config.root, '.' + id)
     if (existsSync(resolvedPath)) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resovles #5954

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With #1172 we added a workaround for absolute paths converting them into relative but it was ignoring any file containing "entry" as part of this path.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

