### PR TITLE
fix(kit, nuxt): always sort globby results

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -148,5 +148,5 @@ async function existsSensitive (path: string) {
 
 export async function resolveFiles (path: string, pattern: string | string[]) {
   const files = await globby(pattern, { cwd: path, followSymbolicLinks: true })
-  return files.map(p => resolve(path, p)).filter(p => !isIgnored(p))
+  return files.map(p => resolve(path, p)).filter(p => !isIgnored(p)).sort()
 }

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -27,7 +27,8 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
     // A map from resolved path to component name (used for making duplicate warning message)
     const resolvedNames = new Map<string, string>()
 
-    for (const _file of await globby(dir.pattern!, { cwd: dir.path, ignore: dir.ignore })) {
+    const files = (await globby(dir.pattern!, { cwd: dir.path, ignore: dir.ignore })).sort()
+    for (const _file of files) {
       const filePath = join(dir.path, _file)
 
       if (scannedPaths.find(d => filePath.startsWith(d)) || isIgnored(filePath)) {

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -34,7 +34,7 @@ type Package = ThenArg<ReturnType<typeof loadPackage>>
 
 async function loadWorkspace (dir: string) {
   const workspacePkg = await loadPackage(dir)
-  const pkgDirs = await globby(workspacePkg.data.workspaces || [], { onlyDirectories: true })
+  const pkgDirs = (await globby(workspacePkg.data.workspaces || [], { onlyDirectories: true })).sort()
 
   const packages: Package[] = []
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The order of the result from `globby` is not reliable. This will potentially cause the order of installed plugins/modules to be unstable across multiple builts or on different machines. We should always sort them to make it stable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

