### PR TITLE
fix(kit): resolve aliases in plugin src

### DIFF
--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -2,6 +2,7 @@ import { normalize } from 'pathe'
 import type { NuxtPlugin, NuxtPluginTemplate } from '@nuxt/schema'
 import { useNuxt } from './context'
 import { addTemplate } from './template'
+import { resolveAlias } from './resolve'
 
 /**
  * Normalize a nuxt plugin object
@@ -19,7 +20,7 @@ export function normalizePlugin (plugin: NuxtPlugin | string): NuxtPlugin {
   }
 
   // Normalize full path to plugin
-  plugin.src = normalize(plugin.src)
+  plugin.src = normalize(resolveAlias(plugin.src))
 
   // Normalize mode
   if (plugin.ssr) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5822

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The test in https://github.com/nuxt/framework/blob/8c2c80e43e80cd8f1c4246d7563214fa695a3e98/packages/nuxt/src/core/plugins/unctx.ts#L17 relies on an absolute path. It probably makes sense to resolve plugin paths to absolute when normalizing though, and this resolves the other issue too.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

