### PR TITLE
docs: add explicit `createError` import

### DIFF
--- a/docs/components/atoms/StabilityEdge.vue
+++ b/docs/components/atoms/StabilityEdge.vue
@@ -1,8 +1,10 @@
 <template>
   <Alert icon="🧪">
-    {{ title }} is available on edge channel. Check out the <Link to="/guide/going-further/edge-channel">
-      Edge Channel Documentation
+    {{ title }} is available on edge channel. Check out the
+    <Link to="/guide/going-further/edge-channel">
+    Edge Channel Documentation
     </Link> to beta test.
+    <slot />
   </Alert>
 </template>
 

--- a/docs/content/2.guide/2.features/7.error-handling.md
+++ b/docs/content/2.guide/2.features/7.error-handling.md
@@ -93,6 +93,10 @@ If you throw an error created with `createError`:
 
 ### Example
 
+::StabilityEdge{title="Auto import of createError"}
+In the current version, add `import { createError } from 'h3'` in order to use `createError`.
+::
+
 ```vue [pages/movies/[slug].vue]
 <script setup>
 const route = useRoute()
@@ -104,6 +108,10 @@ if (!data.value) {
 ```
 
 ### `showError`
+
+::StabilityEdge{title="showError"}
+In the current version, use `throwError` or `throw createError` instead.
+::
 
 * `function showError (err: string | Error | { statusCode, statusMessage }): Error`
 

--- a/docs/content/3.api/3.utils/create-error.md
+++ b/docs/content/3.api/3.utils/create-error.md
@@ -15,9 +15,12 @@ If you throw an error created with `createError`:
 
 ### Example
 
+::StabilityEdge{title="Auto import of createError"}
+In the current version, add `import { createError } from 'h3'` in order to use `createError`.
+::
+
 ```vue [pages/movies/[slug].vue]
 <script setup>
-import {createError} from "h3"
 const route = useRoute()
 const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 if (!data.value) {

--- a/docs/content/3.api/3.utils/create-error.md
+++ b/docs/content/3.api/3.utils/create-error.md
@@ -17,6 +17,7 @@ If you throw an error created with `createError`:
 
 ```vue [pages/movies/[slug].vue]
 <script setup>
+import {createError} from "h3"
 const route = useRoute()
 const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 if (!data.value) {


### PR DESCRIPTION
### ❓ Type of change
- [x ] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

`createError` should be imported from `h3` otherwise Nuxt will throw an error:
```
[nuxt] [request error] createError is not defined
```

### 📝 Checklist
- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

