### PR TITLE
fix(vite): allow overriding client hmr options

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -4,7 +4,6 @@ import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { Connect } from 'vite'
 import { logger } from '@nuxt/kit'
-import { getPort } from 'get-port-please'
 import { joinURL, withLeadingSlash, withoutLeadingSlash, withTrailingSlash } from 'ufo'
 import escapeRE from 'escape-string-regexp'
 import { cacheDirPlugin } from './plugins/cache-dir'
@@ -16,11 +15,6 @@ import { devStyleSSRPlugin } from './plugins/dev-ssr-css'
 import { viteNodePlugin } from './vite-node'
 
 export async function buildClient (ctx: ViteBuildContext) {
-  const hmrPortDefault = 24678 // Vite's default HMR port
-  const hmrPort = await getPort({
-    port: hmrPortDefault,
-    ports: Array.from({ length: 20 }, (_, i) => hmrPortDefault + 1 + i)
-  })
   const clientConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
     experimental: {
       renderBuiltUrl: (filename, { type, hostType }) => {
@@ -66,21 +60,9 @@ export async function buildClient (ctx: ViteBuildContext) {
     ],
     appType: 'custom',
     server: {
-      hmr: {
-        // https://github.com/nuxt/framework/issues/4191
-        protocol: 'ws',
-        clientPort: hmrPort,
-        port: hmrPort
-      },
       middlewareMode: true
     }
   } as ViteOptions)
-
-  // In build mode we explicitly override any vite options that vite is relying on
-  // to detect whether to inject production or development code (such as HMR code)
-  if (!ctx.nuxt.options.dev) {
-    clientConfig.server.hmr = false
-  }
 
   // Add analyze plugin if needed
   if (ctx.nuxt.options.build.analyze) {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -2,7 +2,7 @@ import { join, resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import type { Connect } from 'vite'
+import type { Connect, HmrOptions } from 'vite'
 import { logger } from '@nuxt/kit'
 import { getPort } from 'get-port-please'
 import { joinURL, withLeadingSlash, withoutLeadingSlash, withTrailingSlash } from 'ufo'
@@ -78,8 +78,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       port: hmrPortDefault,
       ports: Array.from({ length: 20 }, (_, i) => hmrPortDefault + 1 + i)
     })
-    const userHMRConfig = clientConfig.server.hmr === true ? {} : clientConfig.server.hmr
-    clientConfig.server.hmr = defu(userHMRConfig, {
+    clientConfig.server.hmr = defu(clientConfig.server.hmr as HmrOptions, {
       // https://github.com/nuxt/framework/issues/4191
       protocol: 'ws',
       port: hmrPort

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -96,7 +96,8 @@ export async function buildServer (ctx: ViteBuildContext) {
     },
     server: {
       // https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027
-      preTransformRequests: false
+      preTransformRequests: false,
+      hmr: false
     },
     plugins: [
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'server'),

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -95,7 +95,6 @@ export async function buildServer (ctx: ViteBuildContext) {
       }
     },
     server: {
-      hmr: false,
       // https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027
       preTransformRequests: false
     },

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -95,6 +95,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       }
     },
     server: {
+      hmr: false,
       // https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027
       preTransformRequests: false
     },

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -6,6 +6,7 @@ import { logger, isIgnored } from '@nuxt/kit'
 import type { Options } from '@vitejs/plugin-vue'
 import replace from '@rollup/plugin-replace'
 import { sanitizeFilePath } from 'mlly'
+import { getPort } from 'get-port-please'
 import { buildClient } from './client'
 import { buildServer } from './server'
 import virtual from './plugins/virtual'
@@ -26,6 +27,11 @@ export interface ViteBuildContext {
 }
 
 export async function bundle (nuxt: Nuxt) {
+  const hmrPortDefault = 24678 // Vite's default HMR port
+  const hmrPort = await getPort({
+    port: hmrPortDefault,
+    ports: Array.from({ length: 20 }, (_, i) => hmrPortDefault + 1 + i)
+  })
   const ctx: ViteBuildContext = {
     nuxt,
     config: vite.mergeConfig(
@@ -72,6 +78,12 @@ export async function bundle (nuxt: Nuxt) {
           reactivityTransform: nuxt.options.experimental.reactivityTransform
         },
         server: {
+          hmr: {
+            // https://github.com/nuxt/framework/issues/4191
+            protocol: 'ws',
+            clientPort: hmrPort,
+            port: hmrPort
+          },
           watch: { ignored: isIgnored },
           fs: {
             allow: [
@@ -88,6 +100,7 @@ export async function bundle (nuxt: Nuxt) {
   // to detect whether to inject production or development code (such as HMR code)
   if (!nuxt.options.dev) {
     ctx.config.server.watch = undefined
+    ctx.config.server.hmr = false
     ctx.config.build.watch = undefined
   }
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -6,7 +6,6 @@ import { logger, isIgnored } from '@nuxt/kit'
 import type { Options } from '@vitejs/plugin-vue'
 import replace from '@rollup/plugin-replace'
 import { sanitizeFilePath } from 'mlly'
-import { getPort } from 'get-port-please'
 import { buildClient } from './client'
 import { buildServer } from './server'
 import virtual from './plugins/virtual'
@@ -27,11 +26,6 @@ export interface ViteBuildContext {
 }
 
 export async function bundle (nuxt: Nuxt) {
-  const hmrPortDefault = 24678 // Vite's default HMR port
-  const hmrPort = await getPort({
-    port: hmrPortDefault,
-    ports: Array.from({ length: 20 }, (_, i) => hmrPortDefault + 1 + i)
-  })
   const ctx: ViteBuildContext = {
     nuxt,
     config: vite.mergeConfig(
@@ -78,12 +72,6 @@ export async function bundle (nuxt: Nuxt) {
           reactivityTransform: nuxt.options.experimental.reactivityTransform
         },
         server: {
-          hmr: {
-            // https://github.com/nuxt/framework/issues/4191
-            protocol: 'ws',
-            clientPort: hmrPort,
-            port: hmrPort
-          },
           watch: { ignored: isIgnored },
           fs: {
             allow: [
@@ -100,7 +88,6 @@ export async function bundle (nuxt: Nuxt) {
   // to detect whether to inject production or development code (such as HMR code)
   if (!nuxt.options.dev) {
     ctx.config.server.watch = undefined
-    ctx.config.server.hmr = false
     ctx.config.build.watch = undefined
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #6078

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression in upgrade to Vite 3. Our client config should only contain what we want to override the basic user config, and HMR is probably in the list of things that should be configurable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

