### PR TITLE
fix(nuxi): load `.env` file before starting dev server

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -1,9 +1,11 @@
+import { existsSync } from 'node:fs'
 import { resolve, relative, normalize } from 'pathe'
 import chokidar from 'chokidar'
 import { debounce } from 'perfect-debounce'
 import type { Nuxt } from '@nuxt/schema'
 import consola from 'consola'
 import { withTrailingSlash } from 'ufo'
+import { loadDotenv } from 'c12'
 import { showBanner } from '../utils/banner'
 import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
@@ -33,6 +35,12 @@ export default defineNuxtCommand({
       return currentHandler ? currentHandler(req, res) : loadingHandler(req, res)
     }
 
+    const rootDir = resolve(args._[0] || '.')
+
+    if (existsSync(resolve(rootDir, '.env'))) {
+      process.env = await loadDotenv({ cwd: rootDir, fileName: '.env', env: process.env })
+    }
+
     const listener = await listen(serverHandler, {
       showURL: false,
       clipboard: args.clipboard,
@@ -45,8 +53,6 @@ export default defineNuxtCommand({
         key: args['ssl-key']
       }
     })
-
-    const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt, buildNuxt } = await loadKit(rootDir)
 

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -1,11 +1,10 @@
-import { existsSync } from 'node:fs'
 import { resolve, relative, normalize } from 'pathe'
 import chokidar from 'chokidar'
 import { debounce } from 'perfect-debounce'
 import type { Nuxt } from '@nuxt/schema'
 import consola from 'consola'
 import { withTrailingSlash } from 'ufo'
-import { loadDotenv } from 'c12'
+import { setupDotenv } from 'c12'
 import { showBanner } from '../utils/banner'
 import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
@@ -36,10 +35,7 @@ export default defineNuxtCommand({
     }
 
     const rootDir = resolve(args._[0] || '.')
-
-    if (existsSync(resolve(rootDir, '.env'))) {
-      process.env = await loadDotenv({ cwd: rootDir, fileName: '.env', env: process.env })
-    }
+    await setupDotenv({ cwd: rootDir })
 
     const listener = await listen(serverHandler, {
       showURL: false,

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -35,8 +35,10 @@ export default defineNuxtCommand({
       process.exit(1)
     }
 
-    consola.info('Loading `.env`. This will not be loaded when running the server in production.')
-    await setupDotenv({ cwd: rootDir })
+    if (existsSync(resolve(rootDir, '.env'))) {
+      consola.info('Loading `.env`. This will not be loaded when running the server in production.')
+      await setupDotenv({ cwd: rootDir })
+    }
 
     consola.info('Starting preview command:', nitroJSON.commands.preview)
     const [command, ...commandArgs] = nitroJSON.commands.preview.split(' ')

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fsp } from 'node:fs'
 import { dirname, relative } from 'node:path'
 import { execa } from 'execa'
-import { loadDotenv } from 'c12'
+import { setupDotenv } from 'c12'
 import { resolve } from 'pathe'
 import consola from 'consola'
 
@@ -35,10 +35,8 @@ export default defineNuxtCommand({
       process.exit(1)
     }
 
-    if (existsSync(resolve(rootDir, '.env'))) {
-      consola.info('Loading `.env`. This will not be loaded when running the server in production.')
-      process.env = await loadDotenv({ cwd: rootDir, fileName: '.env', env: process.env })
-    }
+    consola.info('Loading `.env`. This will not be loaded when running the server in production.')
+    await setupDotenv({ cwd: rootDir })
 
     consola.info('Starting preview command:', nitroJSON.commands.preview)
     const [command, ...commandArgs] = nitroJSON.commands.preview.split(' ')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/6118

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We load `.env` for `nuxi preview` and even later in the process, so it seems reasonable to read it in before starting the dev server, allowing host/port to be defined there when developing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

