### PR TITLE
feat(nuxi): `nuxi cleanup` command

### DIFF
--- a/docs/content/3.api/5.commands/cleanup.md
+++ b/docs/content/3.api/5.commands/cleanup.md
@@ -1,0 +1,16 @@
+# `nuxi build`
+
+```{bash}
+npx nuxi clean|cleanup [rootDir]
+```
+
+The `cleanup` command, removes common generated nuxt files and caches. Including:
+
+- `.nuxt`
+- `.output`
+- `node_modules/.vite`
+- `node_modules/.cache`
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The root directory of the project.

--- a/docs/content/3.api/5.commands/cleanup.md
+++ b/docs/content/3.api/5.commands/cleanup.md
@@ -1,4 +1,4 @@
-# `nuxi build`
+# `nuxi cleanup`
 
 ```{bash}
 npx nuxi clean|cleanup [rootDir]

--- a/packages/nuxi/src/commands/cleanup.ts
+++ b/packages/nuxi/src/commands/cleanup.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'pathe'
+import { cleanupNuxtDirs } from '../utils/fs'
+import { defineNuxtCommand } from './index'
+
+export default defineNuxtCommand({
+  meta: {
+    name: 'cleanup',
+    usage: 'npx nuxi clean|cleanup',
+    description: 'Cleanup generated nuxt files and caches'
+  },
+  async invoke (args) {
+    const rootDir = resolve(args._[0] || '.')
+    await cleanupNuxtDirs(rootDir)
+  }
+})

--- a/packages/nuxi/src/commands/index.ts
+++ b/packages/nuxi/src/commands/index.ts
@@ -5,6 +5,8 @@ const _rDefault = r => r.default || r
 export const commands = {
   dev: () => import('./dev').then(_rDefault),
   build: () => import('./build').then(_rDefault),
+  cleanup: () => import('./cleanup').then(_rDefault),
+  clean: () => import('./cleanup').then(_rDefault),
   preview: () => import('./preview').then(_rDefault),
   start: () => import('./preview').then(_rDefault),
   analyze: () => import('./analyze').then(_rDefault),

--- a/packages/nuxi/src/utils/fs.ts
+++ b/packages/nuxi/src/utils/fs.ts
@@ -1,5 +1,6 @@
 import { promises as fsp } from 'node:fs'
-import { dirname } from 'pathe'
+import { dirname, resolve } from 'pathe'
+import consola from 'consola'
 
 // Check if a file exists
 export async function exists (path: string) {
@@ -14,6 +15,24 @@ export async function exists (path: string) {
 export async function clearDir (path: string) {
   await fsp.rm(path, { recursive: true, force: true })
   await fsp.mkdir(path, { recursive: true })
+}
+
+export async function rmRecursive (paths: string[]) {
+  await Promise.all(paths.map(async (path) => {
+    await fsp.rm(path, { recursive: true, force: true })
+  }))
+}
+
+export async function cleanupNuxtDirs (rootDir: string) {
+  consola.info('Cleaning up generated nuxt files and caches...')
+
+  await rmRecursive([
+    '.nuxt',
+    '.output',
+    'dist',
+    'node_modules/.vite',
+    'node_modules/.cache'
+  ].map(dir => resolve(rootDir, dir)))
 }
 
 export function findup<T> (rootDir: string, fn: (dir: string) => T | undefined): T | null {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #6123

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Introduce a new `nuxi cleanup` command that removes commonly generates nuxt files and caches.

This PR also improves `nuxi upgrade` by reusing new logic including more directories.

(after merge) It can be tested via `npx nuxi-edge@latest cleanup`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

