### PR TITLE
build(vite): add missing `pkg-types` dependency

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -40,6 +40,7 @@
     "ohash": "^0.1.4",
     "pathe": "^0.3.2",
     "perfect-debounce": "^0.1.3",
+    "pkg-types": "^0.3.3",
     "postcss": "^8.4.14",
     "postcss-import": "^14.1.0",
     "postcss-url": "^10.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,6 +1807,7 @@ __metadata:
     ohash: ^0.1.4
     pathe: ^0.3.2
     perfect-debounce: ^0.1.3
+    pkg-types: ^0.3.3
     postcss: ^8.4.14
     postcss-import: ^14.1.0
     postcss-url: ^10.1.3


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #6126

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Likely an upstream issue to fix in `unbuild` also (can track in https://github.com/unjs/unbuild/issues/97 - cc: @pi0). But we should not be inlining `pkg-types` in any case (introduced in https://github.com/nuxt/framework/pull/6069).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

