### PR TITLE
fix(nuxt): add emits.error declaration to NuxtErrorBoundary component

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-error-boundary.ts
+++ b/packages/nuxt/src/app/components/nuxt-error-boundary.ts
@@ -2,6 +2,11 @@ import { defineComponent, ref, onErrorCaptured } from 'vue'
 import { useNuxtApp } from '#app'
 
 export default defineComponent({
+  emits: {
+    error (_error: unknown) {
+      return true
+    }
+  },
   setup (_props, { slots, emit }) {
     const error = ref(null)
     const nuxtApp = useNuxtApp()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#6140 Get warning when v-on:error event handler is set to NuxtErrorBoundary

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
add `emits.error` declaration to NuxtErrorBoundary to prevent prevent getting warning message.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

