### PR TITLE
fix(vite, webpack): generate composable keys based on order

### DIFF
--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -28,6 +28,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
       const { 0: script = code, index: codeIndex = 0 } = code.match(/(?<=<script[^>]*>)[\S\s.]*?(?=<\/script>)/) || []
       const s = new MagicString(code)
       // https://github.com/unjs/unplugin/issues/90
+      let count = 0
       const relativeID = isAbsolute(id) ? relative(options.rootDir, id) : id
       walk(this.parse(script, {
         sourceType: 'module',
@@ -39,7 +40,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
             const end = (node as any).end
             s.appendLeft(
               codeIndex + end - 1,
-              (node.arguments.length ? ', ' : '') + "'$" + hash(`${relativeID}-${codeIndex + end}`) + "'"
+              (node.arguments.length ? ', ' : '') + "'$" + hash(`${relativeID}-${++count}`) + "'"
             )
           }
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/6178

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Introduced in #4955, we were creating hashed based on code index. But this differs between server + client for vue components (among others) due to differences in the code generated in the two environments. However, I think the _order_ of keyed composables is more solid and likely to remain fixed between client/server.

Other approaches I also tried:

1. using sourcemaps to get original LOC - I think the best approach conceptually. This did not match however (1 line out), surprisingly, due to a bug (I think) in vite's vue plugin - I'll need to investigate further and report. Additionally, we don't yet have isomorphic support for sourcemaps in unplugin (https://github.com/unjs/unplugin/issues/146) so it would add some complexity for webpack.

2. moving the key generation 'up' to earlier in the pipeline (via `enforce: pre`). Also much more reliable as an approach. This would work except that acorn can't handle TS. I could add an additional esbuild transform in before parsing with acorn, but it felt like this would be too heavy.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

