### PR TITLE
fix(nuxt): don't call renderMeta if it is not defined

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -146,9 +146,9 @@ export default eventHandler(async (event) => {
   }
 
   // Render meta
-  const renderedMeta = await ssrContext.renderMeta()
+  const renderedMeta = await ssrContext.renderMeta?.() ?? {}
 
-  // Create render conrtext
+  // Create render context
   const rendered: NuxtRenderContext = {
     ssrContext,
     html: {

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -178,7 +178,7 @@ export default eventHandler(async (event) => {
 
   // Allow hooking into the rendered result
   const nitroApp = useNitroApp()
-  await ssrContext.nuxt.hooks.callHook('app:rendered', rendered)
+  await ssrContext.nuxt?.hooks.callHook('app:rendered', rendered)
   await nitroApp.hooks.callHook('nuxt:app:rendered', rendered)
 
   // Construct HTML response


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`.renderMeta` is not defined in SPA mode. I think we should also serialize `app.head` for use in this context, but that can be a follow-up PR.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

