### PR TITLE
fix(kit): add implicit `ohash` dependency

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -24,6 +24,7 @@
     "knitwork": "^0.1.2",
     "lodash.template": "^4.5.0",
     "mlly": "^0.5.5",
+    "ohash": "^0.1.4",
     "pathe": "^0.3.2",
     "pkg-types": "^0.3.3",
     "scule": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,7 @@ __metadata:
     knitwork: ^0.1.2
     lodash.template: ^4.5.0
     mlly: ^0.5.5
+    ohash: ^0.1.4
     pathe: ^0.3.2
     pkg-types: ^0.3.3
     scule: ^0.2.1


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When running build to the repo, it warns:

```bash
ℹ Building @nuxt/kit
 WARN  Inlining implicit external ohash
 WARN  Inlining implicit external ohash
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

