### PR TITLE
fix(schema): add typings for `vite.vue` options

### DIFF
--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -29,6 +29,7 @@ export default defineBuildConfig({
     'webpack-bundle-analyzer',
     'rollup-plugin-visualizer',
     'vite',
+    '@vitejs/plugin-vue',
     'mini-css-extract-plugin',
     'terser-webpack-plugin',
     'css-minimizer-webpack-plugin',

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -8,7 +8,7 @@ export default {
    * See https://vitejs.dev/config for more information.
    * Please note that not all vite options are supported in Nuxt.
    *
-   * @type {typeof import('vite').UserConfig & { vue?: typeof import('@vitejs/plugin-vue').Options }}
+   * @type {typeof import('../src/types/config').ViteConfig}
    * @version 3
    */
   vite: {

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -8,7 +8,7 @@ export default {
    * See https://vitejs.dev/config for more information.
    * Please note that not all vite options are supported in Nuxt.
    *
-   * @type {typeof import('vite').UserConfig}
+   * @type {typeof import('vite').UserConfig & { vue?: typeof import('@vitejs/plugin-vue').Options }}
    * @version 3
    */
   vite: {

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,5 +1,7 @@
 import { ConfigSchema } from '../../schema/config'
 import type { ResolvedConfig } from 'c12'
+import { UserConfig } from 'vite'
+import { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 
 type DeepPartial<T> = T extends Function ? T : T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 
@@ -24,4 +26,12 @@ export interface PrivateRuntimeConfig extends RuntimeConfigNamespace { }
 
 export interface RuntimeConfig extends PrivateRuntimeConfig, RuntimeConfigNamespace {
   public: PublicRuntimeConfig
+}
+
+export interface ViteConfig extends UserConfig {
+  /**
+   * Options passed to @vitejs/plugin-vue
+   * @see https://github.com/vitejs/vite/tree/main/packages/plugin-vue
+   */
+  vue?: VuePluginOptions
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #6218

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds typings for `vite.vue` to the schema.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

