### PR TITLE
fix(webpack): output `.mjs` to use crossorigin preloads

### DIFF
--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -122,8 +122,8 @@ export default {
      * ```
      */
     filenames: {
-      app: ({ isDev }) => isDev ? `[name].js` : `[contenthash:7].js`,
-      chunk: ({ isDev }) => isDev ? `[name].js` : `[contenthash:7].js`,
+      app: ({ isDev }) => isDev ? `[name].mjs` : `[contenthash:7].mjs`,
+      chunk: ({ isDev }) => isDev ? `[name].mjs` : `[contenthash:7].mjs`,
       css: ({ isDev }) => isDev ? '[name].css' : 'css/[contenthash:7].css',
       img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[name].[contenthash:7].[ext]',
       font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[name].[contenthash:7].[ext]',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -42,7 +42,7 @@ export async function expectNoClientErrors (path: string) {
   const { pageErrors, consoleLogs } = await renderPage(path)
 
   const consoleLogErrors = consoleLogs.filter(i => i.type === 'error')
-  const consoleLogWarnings = consoleLogs.filter(i => i.type === 'warn')
+  const consoleLogWarnings = consoleLogs.filter(i => i.type === 'warning')
 
   expect(pageErrors).toEqual([])
   expect(consoleLogErrors).toEqual([])

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -42,7 +42,7 @@ export async function expectNoClientErrors (path: string) {
   const { pageErrors, consoleLogs } = await renderPage(path)
 
   const consoleLogErrors = consoleLogs.filter(i => i.type === 'error')
-  const consoleLogWarnings = consoleLogs.filter(i => i.type === 'warning')
+  const consoleLogWarnings = consoleLogs.filter(i => ['warning', 'warn'].includes(i.type))
 
   expect(pageErrors).toEqual([])
   expect(consoleLogErrors).toEqual([])

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -42,7 +42,7 @@ export async function expectNoClientErrors (path: string) {
   const { pageErrors, consoleLogs } = await renderPage(path)
 
   const consoleLogErrors = consoleLogs.filter(i => i.type === 'error')
-  const consoleLogWarnings = consoleLogs.filter(i => ['warning', 'warn'].includes(i.type))
+  const consoleLogWarnings = consoleLogs.filter(i => i.type === 'warning')
 
   expect(pageErrors).toEqual([])
   expect(consoleLogErrors).toEqual([])


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are outputting `.js` files for webpack, which means we also don't add the `crossorigin` attribute when rendering. Because of a typo in our tests we weren't pick up on this.

Bug shows up with following warnings (+ double fetches of all webpack JS assets):

```
A preload for 'http://localhost:3000/_nuxt/59e3a34.js' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
The resource http://localhost:3000/_nuxt/59e3a34.js was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

