### PR TITLE
fix(kit): try extensions with `resolvePath` with absolute input

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -28,7 +28,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   path = normalize(path)
 
   // Fast return if the path exists
-  if (isAbsolute(path) && existsSync(path)) {
+  if (isAbsolute(path) && existsSync(path) && !(await fsp.lstat(path)).isDirectory()) {
     return path
   }
 

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -28,7 +28,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   path = normalize(path)
 
   // Fast return if the path exists
-  if (isAbsolute(path) && existsSync(path) && !(await fsp.lstat(path)).isDirectory()) {
+  if (isAbsolute(path) && existsSync(path) && !(await isDirectory(path))) {
     return path
   }
 
@@ -47,10 +47,10 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   }
 
   // Check if resolvedPath is a file
-  let isDirectory = false
+  let _isDir = false
   if (existsSync(path)) {
-    isDirectory = (await fsp.lstat(path)).isDirectory()
-    if (!isDirectory) {
+    _isDir = await isDirectory(path)
+    if (!_isDir) {
       return path
     }
   }
@@ -64,7 +64,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
     }
     // path/index.[ext]
     const pathWithIndex = join(path, 'index' + ext)
-    if (isDirectory && existsSync(pathWithIndex)) {
+    if (_isDir && existsSync(pathWithIndex)) {
       return pathWithIndex
     }
   }
@@ -89,8 +89,8 @@ export async function findPath (paths: string|string[], opts?: ResolvePathOption
   for (const path of paths) {
     const rPath = await resolvePath(path, opts)
     if (await existsSensitive(rPath)) {
-      const isDirectory = (await fsp.lstat(rPath)).isDirectory()
-      if (!pathType || (pathType === 'file' && !isDirectory) || (pathType === 'dir' && isDirectory)) {
+      const _isDir = await isDirectory(rPath)
+      if (!pathType || (pathType === 'file' && !_isDir) || (pathType === 'dir' && _isDir)) {
         return rPath
       }
     }
@@ -144,6 +144,11 @@ async function existsSensitive (path: string) {
   if (!existsSync(path)) { return false }
   const dirFiles = await fsp.readdir(dirname(path))
   return dirFiles.includes(basename(path))
+}
+
+// Usage note: We assume path existance is already ensured
+async function isDirectory (path: string) {
+  return (await fsp.lstat(path)).isDirectory()
 }
 
 export async function resolveFiles (path: string, pattern: string | string[]) {


### PR DESCRIPTION
…vided

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`resolvePath` utility, has a fast path check to directly return absolute and existing paths but this prevents continuing searching for extensions when there is an existing directory (`/full/path/app` stops searching for `/full/path/app.vue`).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

