### PR TITLE
feat(kit): support `followSymbolicLinks` option for  `resolveFiles`

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -151,7 +151,7 @@ async function isDirectory (path: string) {
   return (await fsp.lstat(path)).isDirectory()
 }
 
-export async function resolveFiles (path: string, pattern: string | string[], opts?: { followSymbolicLinks?: boolean }) {
+export async function resolveFiles (path: string, pattern: string | string[], opts: { followSymbolicLinks?: boolean } = {}) {
   const files = await globby(pattern, { cwd: path, followSymbolicLinks: opts?.followSymbolicLinks || true })
   return files.map(p => resolve(path, p)).filter(p => !isIgnored(p)).sort()
 }

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -151,7 +151,7 @@ async function isDirectory (path: string) {
   return (await fsp.lstat(path)).isDirectory()
 }
 
-export async function resolveFiles (path: string, pattern: string | string[], followSymbolicLinks: boolean = true) {
-  const files = await globby(pattern, { cwd: path, followSymbolicLinks })
+export async function resolveFiles (path: string, pattern: string | string[], opts?: { followSymbolicLinks?: boolean }) {
+  const files = await globby(pattern, { cwd: path, followSymbolicLinks: opts?.followSymbolicLinks || true })
   return files.map(p => resolve(path, p)).filter(p => !isIgnored(p)).sort()
 }

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -151,7 +151,7 @@ async function isDirectory (path: string) {
   return (await fsp.lstat(path)).isDirectory()
 }
 
-export async function resolveFiles (path: string, pattern: string | string[]) {
-  const files = await globby(pattern, { cwd: path, followSymbolicLinks: true })
+export async function resolveFiles (path: string, pattern: string | string[], followSymbolicLinks: boolean = true) {
+  const files = await globby(pattern, { cwd: path, followSymbolicLinks })
   return files.map(p => resolve(path, p)).filter(p => !isIgnored(p)).sort()
 }

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -152,6 +152,6 @@ async function isDirectory (path: string) {
 }
 
 export async function resolveFiles (path: string, pattern: string | string[], opts: { followSymbolicLinks?: boolean } = {}) {
-  const files = await globby(pattern, { cwd: path, followSymbolicLinks: opts?.followSymbolicLinks || true })
+  const files = await globby(pattern, { cwd: path, followSymbolicLinks: opts.followSymbolicLinks ?? true })
   return files.map(p => resolve(path, p)).filter(p => !isIgnored(p)).sort()
 }


### PR DESCRIPTION
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows module authors to opt-out of following symbolic links when using `resolveFiles`, as there are many cases where this current default isn't the desired.
