### PR TITLE
docs: add `theme-color` meta

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -50,7 +50,7 @@ export default withDocus({
         content: 'https://res.cloudinary.com/nuxt/video/upload/v1634114611/nuxt3-beta_sznsf8.mp4'
       },
       {
-        hid: "theme-color",
+        hid: "meta_theme_color",
         name: "theme-color",
         content: "#00db80"
       }

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -48,6 +48,11 @@ export default withDocus({
         hid: 'og:video',
         name: 'og:video',
         content: 'https://res.cloudinary.com/nuxt/video/upload/v1634114611/nuxt3-beta_sznsf8.mp4'
+      },
+      {
+        hid: "theme-color",
+        name: "theme-color",
+        content: "#00db80"
       }
     ],
     bodyAttrs: {

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -50,7 +50,7 @@ export default withDocus({
         content: 'https://res.cloudinary.com/nuxt/video/upload/v1634114611/nuxt3-beta_sznsf8.mp4'
       },
       {
-        hid: "meta_theme_color",
+        hid: "nuxt_doc_theme_color",
         name: "theme-color",
         content: "#00db80"
       }


### PR DESCRIPTION
Hi, By adding `<meta name="theme-color " />` we can customise the colour of the app bar. For more info please [click here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)

I have added #00db80 as a theme-colour  :)

_Extremely sorry if I made any mistakes :(_