### PR TITLE
fix(nuxt): do not allow catchalls to have child routes

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -74,7 +74,8 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string): Nux
       route.name += (route.name && '-') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const child = parent.find(parentRoute => parentRoute.name === route.name)
+      const child = parent.find(parentRoute => parentRoute.name === route.name && !parentRoute.path.endsWith('(.*)*'))
+
       if (child) {
         parent = child.children
         route.path = ''

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -92,7 +92,7 @@ describe('pages:generateRoutesFromFiles', () => {
       description: 'should generate correct id for catchall (order 2)',
       files: [
         `${pagesDir}/stories/[id].vue`,
-          `${pagesDir}/[...stories].vue`
+        `${pagesDir}/[...stories].vue`
       ],
       output: [
         {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -68,6 +68,48 @@ describe('pages:generateRoutesFromFiles', () => {
       ]
     },
     {
+      description: 'should generate correct id for catchall (order 1)',
+      files: [
+          `${pagesDir}/[...stories].vue`,
+          `${pagesDir}/stories/[id].vue`
+      ],
+      output: [
+        {
+          name: 'stories',
+          path: '/:stories(.*)*',
+          file: `${pagesDir}/[...stories].vue`,
+          children: []
+        },
+        {
+          name: 'stories-id',
+          path: '/stories/:id',
+          file: `${pagesDir}/stories/[id].vue`,
+          children: []
+        }
+      ]
+    },
+    {
+      description: 'should generate correct id for catchall (order 2)',
+      files: [
+        `${pagesDir}/stories/[id].vue`,
+          `${pagesDir}/[...stories].vue`
+      ],
+      output: [
+        {
+          name: 'stories-id',
+          path: '/stories/:id',
+          file: `${pagesDir}/stories/[id].vue`,
+          children: []
+        },
+        {
+          name: 'stories',
+          path: '/:stories(.*)*',
+          file: `${pagesDir}/[...stories].vue`,
+          children: []
+        }
+      ]
+    },
+    {
       description: 'should generate correct route for snake_case file',
       files: [
           `${pagesDir}/snake_case.vue`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

failing case shown in updated test

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR checks that a potential parent is not a catchall before giving it children, which can lead to very unexpected behaviour when present.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

