### PR TITLE
fix(nuxt): separate routes for different suspense forks

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -6,13 +6,16 @@
 </template>
 
 <script setup>
-import { defineAsyncComponent, onErrorCaptured } from 'vue'
-import { callWithNuxt, isNuxtError, showError, useError, useNuxtApp } from '#app'
+import { defineAsyncComponent, onErrorCaptured, provide } from 'vue'
+import { callWithNuxt, isNuxtError, showError, useError, useRoute, useNuxtApp } from '#app'
 
 const ErrorComponent = defineAsyncComponent(() => import('#build/error-component.mjs'))
 
 const nuxtApp = useNuxtApp()
 const onResolve = () => nuxtApp.callHook('app:suspense:resolve')
+
+// Inject default route (outside of pages) as active route
+provide('_route', useRoute())
 
 // vue:setup hook
 const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup')

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,3 +1,4 @@
+import { getCurrentInstance, inject } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, NavigationFailure } from 'vue-router'
 import { sendRedirect } from 'h3'
 import { joinURL } from 'ufo'
@@ -8,11 +9,14 @@ export const useRouter = () => {
 }
 
 export const useRoute = () => {
-  return useNuxtApp()._route as RouteLocationNormalizedLoaded
+  if (getCurrentInstance()) {
+    return inject<RouteLocationNormalizedLoaded>('_route', useNuxtApp()._route)
+  }
+  return useNuxtApp()._route
 }
 
 export const useActiveRoute = () => {
-  return useNuxtApp()._activeRoute as RouteLocationNormalizedLoaded
+  return useNuxtApp()._route as RouteLocationNormalizedLoaded
 }
 
 export interface RouteMiddleware {

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -15,6 +15,7 @@ export const useRoute = () => {
   return useNuxtApp()._route
 }
 
+/** @deprecated Use `useRoute` instead. */
 export const useActiveRoute = () => {
   return useNuxtApp()._route as RouteLocationNormalizedLoaded
 }

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -30,17 +30,28 @@ export default defineComponent({
 
     return () => {
       return h(RouterView, { name: props.name, route: props.route, ...attrs }, {
-        default: (routeProps: RouterViewSlotProps) => routeProps.Component &&
-            _wrapIf(Transition, routeProps.route.meta.pageTransition ?? defaultPageTransition,
-              wrapInKeepAlive(routeProps.route.meta.keepalive,
-                isNested && nuxtApp.isHydrating
-                  // Include route children in parent suspense
-                  ? h(routeProps.Component, { key: generateRouteKey(props.pageKey, routeProps) } as {})
-                  : h(Suspense, {
-                    onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
-                    onResolve: () => nuxtApp.callHook('page:finish', routeProps.Component)
-                  }, { default: () => h(routeProps.Component, { key: generateRouteKey(props.pageKey, routeProps) } as {}) })
-              )).default()
+        default: (routeProps: RouterViewSlotProps) => {
+          if (!routeProps.Component) { return }
+
+          const Component = defineComponent({
+            setup () {
+              provide('_route', routeProps.route)
+              return () => h(routeProps.Component, {
+                key: generateRouteKey(props.pageKey, routeProps)
+              } as {})
+            }
+          })
+
+          return _wrapIf(Transition, routeProps.route.meta.pageTransition ?? defaultPageTransition,
+            wrapInKeepAlive(routeProps.route.meta.keepalive, isNested && nuxtApp.isHydrating
+            // Include route children in parent suspense
+              ? h(Component)
+              : h(Suspense, {
+                onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
+                onResolve: () => nuxtApp.callHook('page:finish', routeProps.Component)
+              }, { default: () => h(Component) })
+            )).default()
+        }
       })
     }
   }

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -77,7 +77,6 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   })
 
   // Allows suspending the route object until page navigation completes
-  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
   const _route = shallowRef(router.resolve(initialURL) as RouteLocation)
   const syncCurrentRoute = () => { _route.value = router.currentRoute.value }
   nuxtApp.hook('page:finish', syncCurrentRoute)
@@ -89,7 +88,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
   })
 
-  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
+  // https://github.com/vuejs/router/blob/main/packages/router/src/router.ts#L1225-L1233
   const route = {}
   for (const key in _route.value) {
     route[key] = computed(() => _route.value[key])

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -76,15 +76,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     get: () => previousRoute.value
   })
 
-  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
-  const route = {}
-  for (const key in router.currentRoute.value) {
-    route[key] = computed(() => router.currentRoute.value[key])
-  }
-
   // Allows suspending the route object until page navigation completes
-  const _activeRoute = shallowRef(router.resolve(initialURL) as RouteLocation)
-  const syncCurrentRoute = () => { _activeRoute.value = router.currentRoute.value }
+  // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
+  const _route = shallowRef(router.resolve(initialURL) as RouteLocation)
+  const syncCurrentRoute = () => { _route.value = router.currentRoute.value }
   nuxtApp.hook('page:finish', syncCurrentRoute)
   router.afterEach((to, from) => {
     // We won't trigger suspense if the component is reused between routes
@@ -93,14 +88,14 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       syncCurrentRoute()
     }
   })
+
   // https://github.com/vuejs/vue-router-next/blob/master/src/router.ts#L1192-L1200
-  const activeRoute = {}
-  for (const key in _activeRoute.value) {
-    activeRoute[key] = computed(() => _activeRoute.value[key])
+  const route = {}
+  for (const key in _route.value) {
+    route[key] = computed(() => _route.value[key])
   }
 
   nuxtApp._route = reactive(route)
-  nuxtApp._activeRoute = reactive(activeRoute)
 
   nuxtApp._middleware = nuxtApp._middleware || {
     global: [],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #6274

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR provides the current route directly at the point of suspense, meaning within the context of a suspense fork, the route will not change until suspense has resolved. We also update the default `useRoute` behaviour to mean that the route will not change outside of a page context until suspense has resolved.

**Context**: https://github.com/nuxt/framework/pull/4124, https://github.com/nuxt/framework/issues/4122, https://github.com/nuxt/framework/pull/4092.

---

**Previous behaviour**:

![CleanShot 2022-08-01 at 09 50 46](https://user-images.githubusercontent.com/28706372/182111110-75165f3e-e821-4cff-a9f0-72bb4e8d599f.gif)

**New behaviour**:

![CleanShot 2022-08-01 at 09 51 37](https://user-images.githubusercontent.com/28706372/182111293-97d549f6-21ea-49c4-9c37-d9598e64895b.gif)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

