### PR TITLE
fix(nuxt): narrow `nuxt.config` import protection

### DIFF
--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -15,7 +15,7 @@ interface ImportProtectionOptions {
 
 export const vueAppPatterns = (nuxt: Nuxt) => [
   [/^(nuxt3|nuxt)$/, '`nuxt3`/`nuxt` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or `#imports`.'],
-  [/^(\/)?nuxt\.config\./, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
+  [/^((|~|~~|@|@@)\/)?nuxt\.config(\.|$)/, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
   [/(^|node_modules\/)@vue\/composition-api/],
   ...nuxt.options.modules.filter(m => typeof m === 'string').map((m: string) =>
     [new RegExp(`^${escapeRE(m)}$`), 'Importing directly from module entry points is not allowed.']),

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -15,7 +15,7 @@ interface ImportProtectionOptions {
 
 export const vueAppPatterns = (nuxt: Nuxt) => [
   [/^(nuxt3|nuxt)$/, '`nuxt3`/`nuxt` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or `#imports`.'],
-  [/nuxt\.config/, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
+  [/^(\/)?nuxt\.config\./, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
   [/(^|node_modules\/)@vue\/composition-api/],
   ...nuxt.options.modules.filter(m => typeof m === 'string').map((m: string) =>
     [new RegExp(`^${escapeRE(m)}$`), 'Importing directly from module entry points is not allowed.']),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #6271

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This narrows down import protection for `nuxt.config`. Vite will pass the id `/nuxt.config.ts` even when aliased or relative imports are used. Webpack will pass the full ID so it's possible to devise imports that won't be caught (but the import of `defineNuxtConfig` from `nuxt` will be caught).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

