### PR TITLE
fix(nuxt): render head scripts that use `body: true`

### DIFF
--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -66,7 +66,7 @@ useHead({
       src: 'https://third-party-script.com',
       body: true
     }
-  ],
+  ]
 })
 </script>
 ```

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -51,6 +51,9 @@ Now, if you set the title to `My Page` with `useHead` on another page of your si
 
 ## Body Meta Tags
 
+::StabilityEdge{title="Body Meta Tatgs"}
+::
+
 You can use the `body: true` option on the `link` and `script` meta tags to append them to the end of your `<body>` tag.
 
 For example:

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -51,7 +51,7 @@ Now, if you set the title to `My Page` with `useHead` on another page of your si
 
 ## Body Meta Tags
 
-::StabilityEdge{title="Body Meta Tatgs"}
+::StabilityEdge{title="Body Meta Tags"}
 ::
 
 You can use the `body: true` option on the `link` and `script` meta tags to append them to the end of your `<body>` tag.

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -49,6 +49,26 @@ The `titleTemplate` can either be a string, where `%s` is replaced with the titl
 
 Now, if you set the title to `My Page` with `useHead` on another page of your site, the title would appear as 'My Page - Site Title' in the browser tab. You could also pass `undefined` to default to the site title.
 
+## Body Meta Tags
+
+You can use the `body: true` option on the `link` and `script` meta tags to append them to the end of your `<body>` tag.
+
+For example:
+
+```vue
+<script setup>
+useHead({
+  script: [
+    {
+      src: 'https://third-party-script.com',
+      body: true
+    }
+  ],
+})
+</script>
+```
+
+
 ## Meta Components
 
 Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>`, `<Html>` and `<Head>` components so that you can interact directly with your metadata within your component's template.

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -68,7 +68,6 @@ useHead({
 </script>
 ```
 
-
 ## Meta Components
 
 Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>`, `<Html>` and `<Head>` components so that you can interact directly with your metadata within your component's template.

--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -54,7 +54,7 @@ Now, if you set the title to `My Page` with `useHead` on another page of your si
 ::StabilityEdge{title="Body Meta Tags"}
 ::
 
-You can use the `body: true` option on the `link` and `script` meta tags to append them to the end of your `<body>` tag.
+You can use the `body: true` option on the `link` and `script` meta tags to append them to the end of the `<body>` tag.
 
 For example:
 

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -171,7 +171,7 @@ export default eventHandler(async (event) => {
       bodyAppend: normalizeChunks([
       `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`,
       _rendered.renderScripts(),
-      // Note: bodyScripts may contain other tags other than <script>
+      // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts
       ])
     }

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -171,6 +171,7 @@ export default eventHandler(async (event) => {
       bodyAppend: normalizeChunks([
       `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`,
       _rendered.renderScripts(),
+      // Note: bodyScripts may contain other tags other than <script>
       renderedMeta.bodyScripts
       ])
     }

--- a/packages/nuxt/src/head/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt/src/head/runtime/lib/vueuse-head.plugin.ts
@@ -54,6 +54,13 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   if (process.server) {
-    nuxtApp.ssrContext.renderMeta = () => renderHeadToString(head)
+    nuxtApp.ssrContext.renderMeta = () => {
+      const meta = renderHeadToString(head)
+      return {
+        ...meta,
+        // resolves naming difference with NuxtMeta and @vueuse/head
+        bodyScripts: meta.bodyTags
+      }
+    }
   }
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -140,7 +140,7 @@ describe('head tags', () => {
     expect(html).toMatch(/<html[^>]*class="html-attrs-test"/)
     expect(html).toMatch(/<body[^>]*class="body-attrs-test"/)
     expect(html).toContain('script>console.log("works with useMeta too")</script>')
-    expect(html).toContain('<script src="https://a-body-appended-script.com" data-meta-body="true"></script></body>')
+    expect(html).toContain('<script src="https://a-body-appended-script.com" data-meta-body></script></body>')
 
     const index = await $fetch('/')
     // should render charset by default

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -140,6 +140,7 @@ describe('head tags', () => {
     expect(html).toMatch(/<html[^>]*class="html-attrs-test"/)
     expect(html).toMatch(/<body[^>]*class="body-attrs-test"/)
     expect(html).toContain('script>console.log("works with useMeta too")</script>')
+    expect(html).toContain('<script src="https://a-body-appended-script.com" data-meta-body="true"></script></body>')
 
     const index = await $fetch('/')
     // should render charset by default

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -140,7 +140,7 @@ describe('head tags', () => {
     expect(headHtml).toMatch(/<html[^>]*class="html-attrs-test"/)
     expect(headHtml).toMatch(/<body[^>]*class="body-attrs-test"/)
     expect(headHtml).toContain('script>console.log("works with useMeta too")</script>')
-    expect(html).toContain('<script src="https://a-body-appended-script.com" data-meta-body></script></body>')
+    expect(headHtml).toContain('<script src="https://a-body-appended-script.com" data-meta-body="true"></script></body>')
 
     const indexHtml = await $fetch('/')
     // should render charset by default

--- a/test/fixtures/basic/pages/head.vue
+++ b/test/fixtures/basic/pages/head.vue
@@ -4,6 +4,12 @@ useHead({
   bodyAttrs: {
     class: 'body-attrs-test'
   },
+  script: [
+    {
+      src: 'https://a-body-appended-script.com',
+      body: true
+    }
+  ],
   meta: [{ name: 'description', content: 'first' }]
 })
 useHead({ charset: 'utf-16', meta: [{ name: 'description', content: computed(() => `${a.value} with an inline useHead call`) }] })


### PR DESCRIPTION
### 🔗 Linked issue

@vueuse/head PR: https://github.com/vueuse/head/pull/67

issues: https://github.com/nuxt/framework/issues/2374, https://github.com/nuxt/framework/issues/5014, https://github.com/nuxt/framework/issues/3130

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With nuxt using the latest version of @vueuse/head, it already has support for appending script and links to the end of the body tag with the `body: true` option. 

However due to a mismatch with property names of NuxtMeta and @vueuse/head nothing is rendered, this fixes that and adds some small doc and tests around the feature

Note: This does not work in components, this will need to be looked at in a separate PR as there is some extra complexity involved

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

