### PR TITLE
fix(nuxt): generate `200.html` and `404.html` spa fallback files

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -51,7 +51,7 @@ export async function initNitro (nuxt: Nuxt) {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: []
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
+        .concat(nuxt.options.ssr === false ? ['/', '/200.html', '/404.html'] : [])
     },
     sourcemap: nuxt.options.sourcemap,
     externals: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As a regression of https://github.com/unjs/nitro/issues/166, we were generating `dist/200/index.html` instead of `dist/200.html` for spa fallbacks. This makes expected output.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

