### PR TITLE
docs: add client side only hint for `app:beforeMount`

### DIFF
--- a/docs/content/3.api/4.advanced/1.hooks.md
+++ b/docs/content/3.api/4.advanced/1.hooks.md
@@ -10,7 +10,7 @@ Check the [app source code](https://github.com/nuxt/framework/blob/main/packages
 Hook                   | Arguments         | Description
 -----------------------|-------------------|---------------
 `app:created`          | `vueApp`          | When initial `vueApp` instance is created
-`app:beforeMount`      | `vueApp`          | Same as `app:created`
+`app:beforeMount`      | `vueApp`          | Same as `app:created` (client side only)
 `app:mounted`          | `vueApp`          | When Vue app is initialized and mounted in browser
 `app:rendered`         | -                 | When SSR rendering is done
 `app:suspense:resolve` | `appComponent`    | On [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) resolved event


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#6327 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add client-side only hint for `app:beforeMount` hook. Resolves #6327 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

