### PR TITLE
fix(nuxt): remove literal `<script setup>` from comment

### DIFF
--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -21,7 +21,7 @@ export default defineComponent({
 export function createClientOnly (component) {
   const { setup, render: _render, template: _template } = component
   if (_render) {
-    // override the component render (non <script setup> component)
+    // override the component render (non script setup component)
     component.render = (ctx, ...args) => {
       return ctx.mounted$
         ? h(Fragment, null, [h(_render(ctx, ...args), ctx.$attrs ?? ctx._.attrs)])


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Seems there's a compiler bug (which I will look into) giving this error when using client-only. This PR is a hotfix.

```
 ERROR  [@vue/compiler-sfc] Missing semicolon. (1:10)                                                  12:30:39

anonymous.vue
22 |    const { setup, render: _render, template: _template } = component
23 |    if (_render) {
24 |      // override the component render (non <script setup> component)
   |                                                                    ^
25 |      component.render = (ctx, ...args) => {
26 |        return ctx.mounted$

  
  anonymous.vue
  22 |    const { setup, render: _render, template: _template } = component
  23 |    if (_render) {
  24 |      // override the component render (non <script setup> component)
  |                                                                    ^
  25 |      component.render = (ctx, ...args) => {
  26 |        return ctx.mounted$
  at instantiate (node_modules/@babel/parser/lib/index.js:72:32)
  at constructor (node_modules/@babel/parser/lib/index.js:359:12)
  at Object.raise (node_modules/@babel/parser/lib/index.js:3339:19)
  at Object.semicolon (node_modules/@babel/parser/lib/index.js:4000:10)
  at Object.parseExpressionStatement (node_modules/@babel/parser/lib/index.js:15244:10)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

