### PR TITLE
fix(vite): improve `vite-node` hmr

### DIFF
--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -29,7 +29,7 @@ export default async (ssrContext) => {
     runner.moduleCache.delete(key)
   }
 
-  // Execute SSR bundle on-demand
+  // Execute SSR bundle on demand
   render = render || (await runner.executeFile(viteNodeOptions.entryPath)).default
   const result = await render(ssrContext)
   return result

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -21,7 +21,7 @@ export default async (ssrContext) => {
   // https://github.com/nuxt/framework/pull/3983
   process.server = true
 
-  // Invaildate cache for files changed since last rendering
+  // Invalidate cache for files changed since last rendering
   const invalidates = await $fetch('/invalidates', {
     baseURL: viteNodeOptions.baseURL
   })

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -20,13 +20,17 @@ export default async (ssrContext) => {
   // Workaround for stub mode
   // https://github.com/nuxt/framework/pull/3983
   process.server = true
+
+  // Invaildate cache for files changed since last rendering
+  const invalidates = await $fetch('/invalidates', {
+    baseURL: viteNodeOptions.baseURL
+  })
+  for (const key of invalidates) {
+    runner.moduleCache.delete(key)
+  }
+
+  // Execute SSR bundle on-demand
   render = render || (await runner.executeFile(viteNodeOptions.entryPath)).default
   const result = await render(ssrContext)
-  // reset cache for non-node-modules
-  for (const key of runner.moduleCache.keys()) {
-    if (!key.includes('/node_modules/')) {
-      runner.moduleCache.delete(key)
-    }
-  }
   return result
 }

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -4,7 +4,7 @@ import { ViteNodeServer } from 'vite-node/server'
 import fse from 'fs-extra'
 import { resolve } from 'pathe'
 import { addServerMiddleware } from '@nuxt/kit'
-import type { Plugin as VitePlugin, ViteDevServer } from 'vite'
+import type { ModuleNode, Plugin as VitePlugin, ViteDevServer } from 'vite'
 import { resolve as resolveModule } from 'mlly'
 import { distDir } from './dirs'
 import type { ViteBuildContext } from './vite'
@@ -14,11 +14,27 @@ import { createIsExternal } from './utils/external'
 // TODO: Remove this in favor of registerViteNodeMiddleware
 // after Nitropack or h3 fixed for adding middlewares after setup
 export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
+  const invalidateIDs = new Set<string>()
   return {
     name: 'nuxt:vite-node-server',
-    enforce: 'pre',
+    enforce: 'post',
     configureServer (server) {
-      server.middlewares.use('/__nuxt_vite_node__', createViteNodeMiddleware(ctx))
+      server.middlewares.use('/__nuxt_vite_node__', createViteNodeMiddleware(ctx, invalidateIDs))
+    },
+    handleHotUpdate ({ file, server }) {
+      function markMod (mod: ModuleNode) {
+        if (invalidateIDs.has(mod.id)) {
+          return
+        }
+        invalidateIDs.add(mod.id)
+        for (const importer of mod.importers) {
+          markMod(importer)
+        }
+      }
+      const mods = server.moduleGraph.getModulesByFile(file) || []
+      for (const mod of mods) {
+        markMod(mod)
+      }
     }
   }
 }
@@ -49,12 +65,26 @@ function getManifest (server: ViteDevServer) {
   }
 }
 
-function createViteNodeMiddleware (ctx: ViteBuildContext) {
+function createViteNodeMiddleware (ctx: ViteBuildContext, invalidateIDs: Set<string> = new Set()) {
   const app = createApp()
 
   app.use('/manifest', defineEventHandler(() => {
     const manifest = getManifest(ctx.ssrServer)
     return manifest
+  }))
+
+  app.use('/invalidates', defineEventHandler(() => {
+    // When a file has been invalidate, we also invalidate the entry module
+    if (invalidateIDs.size) {
+      for (const key of ctx.ssrServer.moduleGraph.fileToModulesMap.keys()) {
+        if (key.startsWith(ctx.nuxt.options.appDir)) {
+          invalidateIDs.add(key)
+        }
+      }
+    }
+    const ids = Array.from(invalidateIDs)
+    invalidateIDs.clear()
+    return ids
   }))
 
   app.use('/module', defineLazyEventHandler(() => {

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -78,7 +78,7 @@ function createViteNodeMiddleware (ctx: ViteBuildContext, invalidates: Set<strin
     // When a file has been invalidated, we also invalidate the entry module
     if (invalidates.size) {
       for (const key of ctx.ssrServer.moduleGraph.fileToModulesMap.keys()) {
-        if (key.startsWith(ctx.nuxt.options.appDir)) {
+        if (key.startsWith(ctx.nuxt.options.appDir + '/entry')) {
           invalidates.add(key)
         }
       }

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -75,7 +75,7 @@ function createViteNodeMiddleware (ctx: ViteBuildContext, invalidates: Set<strin
   }))
 
   app.use('/invalidates', defineEventHandler(() => {
-    // When a file has been invalidate, we also invalidate the entry module
+    // When a file has been invalidated, we also invalidate the entry module
     if (invalidates.size) {
       for (const key of ctx.ssrServer.moduleGraph.fileToModulesMap.keys()) {
         if (key.startsWith(ctx.nuxt.options.appDir)) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

close #6243

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR implemented the full HMR support of vite-node as mentioned in https://github.com/nuxt/framework/pull/6154#issuecomment-1195505167

Re #6243, the bug is caused because in the release build, `entry.mjs` is laying under `node_modules` which bypasses the cache clear up due to https://github.com/nuxt/framework/pull/6153

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

