### PR TITLE
fix(nuxt): resolve plugins and middleware to their full path

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -2,7 +2,7 @@ import { promises as fsp } from 'node:fs'
 import { dirname, resolve } from 'pathe'
 import defu from 'defu'
 import type { Nuxt, NuxtApp, NuxtPlugin } from '@nuxt/schema'
-import { findPath, resolveFiles, normalizePlugin, normalizeTemplate, compileTemplate, templateUtils, tryResolveModule } from '@nuxt/kit'
+import { findPath, resolveFiles, normalizePlugin, normalizeTemplate, compileTemplate, templateUtils, tryResolveModule, resolvePath, resolveAlias } from '@nuxt/kit'
 
 import * as defaultTemplates from './templates'
 import { getNameFromPath, hasSuffix, uniqueBy } from './utils'
@@ -94,7 +94,6 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       return { name, path: file, global: hasSuffix(file, '.global') }
     }))
   }
-  app.middleware = uniqueBy(app.middleware, 'name')
 
   // Resolve plugins
   app.plugins = [
@@ -109,8 +108,21 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       ])
     ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
   }
-  app.plugins = uniqueBy(app.plugins, 'src')
 
   // Extend app
   await nuxt.callHook('app:resolve', app)
+
+  // Normalize and de-duplicate plugins and middleware
+  app.middleware = uniqueBy(await normalizePaths(app.middleware, 'path'), 'name')
+  app.plugins = uniqueBy(await normalizePaths(app.plugins, 'src'), 'src')
+}
+
+const normalizePaths = <Item extends Record<string, any>>(items: Item[], key: { [K in keyof Item]: Item[K] extends string ? K : never }[keyof Item]) => {
+  return Promise.all(items.map(async (item) => {
+    if (!item[key]) { return item }
+    return {
+      ...item,
+      [key]: await resolvePath(resolveAlias(item[key]))
+    }
+  }))
 }

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -14,7 +14,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
     name: 'unctx:transfrom',
     enforce: 'post',
     transformInclude (id) {
-      return Boolean(app?.plugins.find(i => matchesPath(id, i.src)) || app.middleware.find(m => matchesPath(id, m.path)))
+      return app?.plugins.some(i => i.src === id) || app.middleware.some(m => m.path === id)
     },
     transform (code, id) {
       const result = transformer.transform(code)
@@ -27,5 +27,3 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
     }
   }))
 }
-
-const matchesPath = (path: string, withoutExt: string) => path === withoutExt || path.startsWith(withoutExt + '.')

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -14,7 +14,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
     name: 'unctx:transfrom',
     enforce: 'post',
     transformInclude (id) {
-      return Boolean(app?.plugins.find(i => i.src === id) || app.middleware.find(m => m.path === id))
+      return Boolean(app?.plugins.find(i => matchesPath(id, i.src)) || app.middleware.find(m => matchesPath(id, m.path)))
     },
     transform (code, id) {
       const result = transformer.transform(code)
@@ -27,3 +27,5 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
     }
   }))
 }
+
+const matchesPath = (path: string, withoutExt: string) => path === withoutExt || path.startsWith(withoutExt + '.')

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -14,7 +14,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
     name: 'unctx:transfrom',
     enforce: 'post',
     transformInclude (id) {
-      return app?.plugins.some(i => i.src === id) || app.middleware.some(m => m.path === id)
+      return app?.plugins.some(i => i.src === id) || app?.middleware.some(m => m.path === id)
     },
     transform (code, id) {
       const result = transformer.transform(code)

--- a/test/fixtures/basic/modules/example.ts
+++ b/test/fixtures/basic/modules/example.ts
@@ -1,4 +1,5 @@
-import { defineNuxtModule } from '@nuxt/kit'
+import { fileURLToPath } from 'node:url'
+import { defineNuxtModule, addPlugin, useNuxt } from '@nuxt/kit'
 
 export default defineNuxtModule({
   defaults: {
@@ -7,5 +8,15 @@ export default defineNuxtModule({
   meta: {
     name: 'my-module',
     configKey: 'sampleModule'
+  },
+  setup () {
+    addPlugin(fileURLToPath(new URL('./runtime/plugin', import.meta.url)))
+    useNuxt().hook('app:resolve', (app) => {
+      app.middleware.push({
+        name: 'unctx-test',
+        path: fileURLToPath(new URL('./runtime/middleware', import.meta.url)),
+        global: true
+      })
+    })
   }
 })

--- a/test/fixtures/basic/modules/runtime/middleware.ts
+++ b/test/fixtures/basic/modules/runtime/middleware.ts
@@ -1,0 +1,4 @@
+export default defineNuxtRouteMiddleware(async () => {
+  await new Promise(resolve => setTimeout(resolve, 1))
+  useNuxtApp()
+})

--- a/test/fixtures/basic/modules/runtime/plugin.ts
+++ b/test/fixtures/basic/modules/runtime/plugin.ts
@@ -1,0 +1,4 @@
+export default defineNuxtPlugin(async () => {
+  await new Promise(resolve => setTimeout(resolve, 1))
+  useNuxtApp()
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #6300

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a plugin is in injected like `/path/to/someplugin` without the extension, we can likely match `/path/to/someplugin.*`. A more accurate, but more costly, route would be to use `resolvePath` when adding plugins (or to normalize afterwards before `app:resolve`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

