### PR TITLE
fix(nuxi, kit): enable `esmResolve` flag for `jiti`

### DIFF
--- a/packages/kit/src/internal/cjs.ts
+++ b/packages/kit/src/internal/cjs.ts
@@ -4,7 +4,7 @@ import { interopDefault } from 'mlly'
 import jiti from 'jiti'
 
 // TODO: use create-require for jest environment
-const _require = jiti(process.cwd(), { interopDefault: true })
+const _require = jiti(process.cwd(), { interopDefault: true, esmResolve: true })
 
 export interface ResolveModuleOptions {
   paths?: string | string[]

--- a/packages/nuxi/src/commands/info.ts
+++ b/packages/nuxi/src/commands/info.ts
@@ -115,7 +115,7 @@ function normalizeConfigModule (module, rootDir) {
 
 function getNuxtConfig (rootDir) {
   try {
-    return jiti(rootDir, { interopDefault: true })('./nuxt.config')
+    return jiti(rootDir, { interopDefault: true, esmResolve: true })('./nuxt.config')
   } catch (err) {
     // TODO: Show error as warning if it is not 404
     return {}

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -154,7 +154,7 @@ export default {
       val = process.env.NUXT_CREATE_REQUIRE || val ||
         (typeof globalThis.jest !== 'undefined' ? 'native' : 'jiti')
       if (val === 'jiti') {
-        return p => jiti(typeof p === 'string' ? p : p.filename)
+        return p => jiti(typeof p === 'string' ? p : p.filename, { esmResolve: true })
       }
       if (val === 'native') {
         return p => createRequire(typeof p === 'string' ? p : p.filename)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Related: #6340, https://github.com/unjs/unctx/pull/23, https://github.com/unjs/unctx/issues/25

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Some dependencies like `estree-walker`, are not only esm-only but only use `exports.import` field in `package.json`. This makes sure they are broken unless using esm native resolution!

We introduced an experimental flag few months ago for jiti to enable esm resolution and handle such package. It is already enabled for c12 and framework repo. This PR enabled it for kit utils as well.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

