### PR TITLE
docs: update vue-router links

### DIFF
--- a/docs/content/2.guide/3.directory-structure/10.pages.md
+++ b/docs/content/2.guide/3.directory-structure/10.pages.md
@@ -322,7 +322,7 @@ Learn more about [`<NuxtLink>`](/api/components/nuxt-link) usage.
 
 ## Router options
 
-It is possible to set default [vue-router options](https://router.vuejs.org/api/#routeroptions).
+It is possible to set default [vue-router options](https://router.vuejs.org/api/interfaces/routeroptions.html).
 
 **Note:** `history` and `routes` options will be always overridden by Nuxt.
 
@@ -333,7 +333,7 @@ This is the recommended way to specify router options.
 ```js [app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
 
-// https://router.vuejs.org/api/#routeroptions
+// https://router.vuejs.org/api/interfaces/routeroptions.html
 export default <RouterConfig>{
 }
 ```
@@ -351,7 +351,7 @@ export default <RouterConfig>{
 ```js [nuxt.config]
 export default defineNuxtConfig({
   router: {
-    // https://router.vuejs.org/api/#routeroptions
+    // https://router.vuejs.org/api/interfaces/routeroptions.html
     options: {}
   }
 })

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -8,7 +8,7 @@ export default {
    *
    * For more control, you can use `app/router.optionts.ts` file.
    *
-   * @see [documentation](https://router.vuejs.org/api/#routeroptions)
+   * @see [documentation](https://router.vuejs.org/api/interfaces/routeroptions.html)
    * @type {import('../src/types/router').RouterConfigSerializable}
    *
    * @version 3


### PR DESCRIPTION
### ❓ Type of change
- [X] 📖 Documentation (updates to the documentation or readme)

### 📚 Description
Updated links to the correct Vue Router Options documentation URL

[https://router.vuejs.org/api/#routeroptions](https://router.vuejs.org/api/#routeroptions) (broken) -> [https://router.vuejs.org/api/interfaces/routeroptions.html](https://router.vuejs.org/api/interfaces/routeroptions.html) (working)

### 📝 Checklist
- [X] I have updated the documentation accordingly.

