### PR TITLE
fix(kit): move relative path handling back into nuxt templates

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -24,7 +24,6 @@
     "knitwork": "^0.1.2",
     "lodash.template": "^4.5.0",
     "mlly": "^0.5.7",
-    "ohash": "^0.1.5",
     "pathe": "^0.3.3",
     "pkg-types": "^0.3.3",
     "scule": "^0.3.2",

--- a/packages/kit/src/internal/template.ts
+++ b/packages/kit/src/internal/template.ts
@@ -3,8 +3,6 @@ import lodashTemplate from 'lodash.template'
 import { genSafeVariableName, genDynamicImport, genImport } from 'knitwork'
 
 import type { NuxtTemplate } from '@nuxt/schema'
-import { relative } from 'pathe'
-import { hash } from 'ohash'
 
 export async function compileTemplate (template: NuxtTemplate, ctx: any) {
   const data = { ...ctx, options: template.options }
@@ -25,25 +23,16 @@ export async function compileTemplate (template: NuxtTemplate, ctx: any) {
 
 const serialize = (data: any) => JSON.stringify(data, null, 2).replace(/"{(.+)}"(?=,?$)/gm, r => JSON.parse(r).replace(/^{(.*)}$/, '$1'))
 
-const importSources = (sources: string | string[], root: string, { lazy = false } = {}) => {
+const importSources = (sources: string | string[], { lazy = false } = {}) => {
   if (!Array.isArray(sources)) {
     sources = [sources]
   }
-  const exports: string[] = []
-  const imports: string[] = []
-  for (const src of sources) {
-    const path = relative(root, src)
-    const variable = genSafeVariableName(path).replace(/_(45|46|47)/g, '_') + '_' + hash(path)
-    exports.push(variable)
-    imports.push(lazy
-      ? `const ${variable} = ${genDynamicImport(src, { comment: `webpackChunkName: ${JSON.stringify(src)}` })}`
-      : genImport(src, variable)
-    )
-  }
-  return {
-    exports,
-    imports
-  }
+  return sources.map((src) => {
+    if (lazy) {
+      return `const ${genSafeVariableName(src)} = ${genDynamicImport(src, { comment: `webpackChunkName: ${JSON.stringify(src)}` })}`
+    }
+    return genImport(src, genSafeVariableName(src))
+  }).join('\n')
 }
 
 export const templateUtils = { serialize, importName: genSafeVariableName, importSources }

--- a/packages/kit/src/internal/template.ts
+++ b/packages/kit/src/internal/template.ts
@@ -21,8 +21,10 @@ export async function compileTemplate (template: NuxtTemplate, ctx: any) {
   throw new Error('Invalid template: ' + JSON.stringify(template))
 }
 
+/** @deprecated */
 const serialize = (data: any) => JSON.stringify(data, null, 2).replace(/"{(.+)}"(?=,?$)/gm, r => JSON.parse(r).replace(/^{(.*)}$/, '$1'))
 
+/** @deprecated */
 const importSources = (sources: string | string[], { lazy = false } = {}) => {
   if (!Array.isArray(sources)) {
     sources = [sources]
@@ -35,4 +37,8 @@ const importSources = (sources: string | string[], { lazy = false } = {}) => {
   }).join('\n')
 }
 
-export const templateUtils = { serialize, importName: genSafeVariableName, importSources }
+/** @deprecated */
+const importName = genSafeVariableName
+
+/** @deprecated */
+export const templateUtils = { serialize, importName, importSources }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,7 +1736,6 @@ __metadata:
     knitwork: ^0.1.2
     lodash.template: ^4.5.0
     mlly: ^0.5.7
-    ohash: ^0.1.5
     pathe: ^0.3.3
     pkg-types: ^0.3.3
     scule: ^0.3.2


### PR DESCRIPTION
This reverts commit d135608ef0d607259c0ae6f5156c8f46ff78ddc3.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/content/issues/1422

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This reverts https://github.com/nuxt/framework/pull/6030, returning template utils API to previous behaviour/shape. At the same time, it moves the fix in that PR into nuxt internals and deprecates the template utils. (There are other utils that can be used directly with `knitwork`, `mlly`, etc.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

