### PR TITLE
fix(nuxt): do not log `404` and `showError` as fatal by default

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -10,7 +10,6 @@ export interface NuxtError extends H3Error {}
 
 export const showError = (_err: string | Error | Partial<NuxtError>) => {
   const err = createError(_err)
-  err.fatal = true
 
   try {
     const nuxtApp = useNuxtApp()

--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -165,6 +165,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     if (to.matched.length === 0) {
       callWithNuxt(nuxtApp, showError, [createError({
         statusCode: 404,
+        fatal: false,
         statusMessage: `Page not found: ${to.fullPath}`
       })])
     } else if (process.server && to.matched[0].name === '404' && nuxtApp.ssrContext) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With #4539 and https://github.com/unjs/h3/pull/148 we introduced new `fatal` flag for error that are intended to be logged. 404 Page not found errors we throw are not _fatal_ to be verbosely logged by h3.

Also with this change, `showError` by default does not set fatality of error but only mark there is an error and display it (locally testing works both when calling from client and server side).

Related: In future versions of h3, we might make createError smarter to infer fatal flag from known codes.


Appendix current output: 

<img width="738" alt="image" src="https://user-images.githubusercontent.com/5158436/183409838-85895874-a451-47de-ae75-0ca92a3dd31e.png">



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

