### PR TITLE
feat(nuxt): update nitropack to latest

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -52,7 +52,7 @@
     "knitwork": "^0.1.2",
     "magic-string": "^0.26.2",
     "mlly": "^0.5.7",
-    "nitropack": "^0.4.13",
+    "nitropack": "^0.4.14",
     "nuxi": "^3.0.0-rc.6",
     "ohash": "^0.1.5",
     "ohmyfetch": "^0.4.18",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -52,7 +52,7 @@
     "knitwork": "^0.1.2",
     "magic-string": "^0.26.2",
     "mlly": "^0.5.7",
-    "nitropack": "^0.4.12",
+    "nitropack": "^0.4.13",
     "nuxi": "^3.0.0-rc.6",
     "ohash": "^0.1.5",
     "ohmyfetch": "^0.4.18",

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -1,16 +1,19 @@
 import { createRenderer } from 'vue-bundle-renderer/runtime'
+import type { RenderHandler, RenderResponse } from 'nitropack'
 import type { Manifest } from 'vite'
-import { getQuery } from 'h3'
+import { CompatibilityEvent, getQuery } from 'h3'
 import devalue from '@nuxt/devalue'
 import { renderToString as _renderToString } from 'vue/server-renderer'
 import type { NuxtApp } from '#app'
 
 // @ts-ignore
-import { useRuntimeConfig, useNitroApp, defineRenderHandler } from '#internal/nitro'
+import { useRuntimeConfig, useNitroApp, defineRenderHandler as _defineRenderHandler } from '#internal/nitro'
 // @ts-ignore
 import { buildAssetsURL } from '#paths'
 
 export type NuxtSSRContext = NuxtApp['ssrContext']
+
+const defineRenderHandler = _defineRenderHandler as (h: RenderHandler) => CompatibilityEvent
 
 export interface NuxtRenderContext {
   ssrContext: NuxtSSRContext
@@ -168,7 +171,7 @@ export default defineRenderHandler(async (event) => {
   await nitroApp.hooks.callHook('nuxt:app:rendered', rendered)
 
   // Construct HTML response
-  const response: NuxtRenderResponse = {
+  const response: RenderResponse = {
     body: renderHTMLDocument(rendered),
     statusCode: event.res.statusCode,
     statusMessage: event.res.statusMessage,
@@ -177,9 +180,6 @@ export default defineRenderHandler(async (event) => {
       'X-Powered-By': 'Nuxt'
     }
   }
-
-  // Allow extending the response
-  await nitroApp.hooks.callHook('nuxt:app:response', { response })
 
   return response
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,6 +490,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-loong64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "@esbuild/linux-loong64@npm:0.14.54"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^1.3.0":
   version: 1.3.0
   resolution: "@eslint/eslintrc@npm:1.3.0"
@@ -2182,6 +2189,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:^22.0.2":
+  version: 22.0.2
+  resolution: "@rollup/plugin-commonjs@npm:22.0.2"
+  dependencies:
+    "@rollup/pluginutils": ^3.1.0
+    commondir: ^1.0.1
+    estree-walker: ^2.0.1
+    glob: ^7.1.6
+    is-reference: ^1.2.1
+    magic-string: ^0.25.7
+    resolve: ^1.17.0
+  peerDependencies:
+    rollup: ^2.68.0
+  checksum: 70098a4b91afe3f164f5d27cba65edf148c5ed146ee0e07a964b66940681553ac77391083114cdcf9427e7f2706bf0d61eab310b3a2caeab83b7452c0292fcae
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-inject@npm:^4.0.4":
   version: 4.0.4
   resolution: "@rollup/plugin-inject@npm:4.0.4"
@@ -2388,14 +2412,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:^16.2.14":
-  version: 16.2.15
-  resolution: "@types/jsdom@npm:16.2.15"
+"@types/jsdom@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "@types/jsdom@npm:20.0.0"
   dependencies:
     "@types/node": "*"
-    "@types/parse5": ^6.0.3
     "@types/tough-cookie": "*"
-  checksum: e038335321bef42ebf220aaf597e186e2eec8de6107ce7a70de1c046a84c1fbb42d454e195a20383a6870b18c7ef6fa6b73812a626f88a4a2ef1f711d2e2e13c
+    parse5: ^7.0.0
+  checksum: 13e67d31347e02d46ec6a23919b3ce39d86136665922a2a6cb977e216a2f46c22d2f025d0586a64ab492ebaa5f43da669b6f173a5a8cfd3e3bb7c9d19b6cfa9e
   languageName: node
   linkType: hard
 
@@ -2475,13 +2499,6 @@ __metadata:
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
   checksum: fd6bce2b674b6efc3db4c7c3d336bd70c90838e8439de639b909ce22f3720d21344f52427f1d9e57b265fcb7f6c018699b99e5e0c208a1a4823014269a6bf35b
-  languageName: node
-  linkType: hard
-
-"@types/parse5@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "@types/parse5@npm:6.0.3"
-  checksum: ddb59ee4144af5dfcc508a8dcf32f37879d11e12559561e65788756b95b33e6f03ea027d88e1f5408f9b7bfb656bf630ace31a2169edf44151daaf8dd58df1b7
   languageName: node
   linkType: hard
 
@@ -2969,12 +2986,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/nft@npm:^0.20.1":
-  version: 0.20.1
-  resolution: "@vercel/nft@npm:0.20.1"
+"@vercel/nft@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@vercel/nft@npm:0.21.0"
   dependencies:
     "@mapbox/node-pre-gyp": ^1.0.5
     acorn: ^8.6.0
+    async-sema: ^3.1.1
     bindings: ^1.4.0
     estree-walker: 2.0.2
     glob: ^7.1.3
@@ -2985,7 +3003,7 @@ __metadata:
     rollup-pluginutils: ^2.8.2
   bin:
     nft: out/cli.js
-  checksum: 4c1c01ee1d9273b793fd2a580a82e91bf1afae8adc63105475c3c3df40c7599a074c44e79427ead77e6ece64c2c5d4841a9cfb0091f422fedb49cfdb5caa130c
+  checksum: 832e71f0770ce0f1a01da432ebceedc3a20bca1f6b99db1451134b889a96e69c23e9774f2eebeb507798f448de13770997bd851eecd80fff6b15fd1cfc5b1dda
   languageName: node
   linkType: hard
 
@@ -3629,7 +3647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.8.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
   version: 8.11.0
   resolution: "ajv@npm:8.11.0"
   dependencies:
@@ -3872,10 +3890,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"astral-regex@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "astral-regex@npm:2.0.0"
-  checksum: 876231688c66400473ba505731df37ea436e574dd524520294cc3bbc54ea40334865e01fa0d074d74d036ee874ee7e62f486ea38bc421ee8e6a871c06f011766
+"async-sema@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "async-sema@npm:3.1.1"
+  checksum: 07b8c51f6cab107417ecdd8126b7a9fe5a75151b7f69fdd420dcc8ee08f9e37c473a217247e894b56e999b088b32e902dbe41637e4e9b594d3f8dfcdddfadc5e
   languageName: node
   linkType: hard
 
@@ -4118,7 +4136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"c12@npm:^0.2.7, c12@npm:^0.2.8":
+"c12@npm:^0.2.7":
   version: 0.2.8
   resolution: "c12@npm:0.2.8"
   dependencies:
@@ -5521,6 +5539,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "entities@npm:4.3.1"
+  checksum: e8f6d2bac238494b2355e90551893882d2675142be7e7bdfcb15248ed0652a630678ba0e3a8dc750693e736cb6011f504c27dabeb4cd3330560092e88b105090
+  languageName: node
+  linkType: hard
+
 "entities@npm:~3.0.1":
   version: 3.0.1
   resolution: "entities@npm:3.0.1"
@@ -5652,6 +5677,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-android-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-android-64@npm:0.14.54"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-android-arm64@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-android-arm64@npm:0.14.50"
@@ -5662,6 +5694,13 @@ __metadata:
 "esbuild-android-arm64@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-android-arm64@npm:0.14.53"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-android-arm64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-android-arm64@npm:0.14.54"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -5680,6 +5719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-darwin-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-darwin-64@npm:0.14.54"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-darwin-arm64@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-darwin-arm64@npm:0.14.50"
@@ -5690,6 +5736,13 @@ __metadata:
 "esbuild-darwin-arm64@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-darwin-arm64@npm:0.14.53"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-arm64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-darwin-arm64@npm:0.14.54"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -5708,6 +5761,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-freebsd-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-freebsd-64@npm:0.14.54"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-freebsd-arm64@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-freebsd-arm64@npm:0.14.50"
@@ -5718,6 +5778,13 @@ __metadata:
 "esbuild-freebsd-arm64@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-freebsd-arm64@npm:0.14.53"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-arm64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-freebsd-arm64@npm:0.14.54"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -5736,6 +5803,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-32@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-32@npm:0.14.54"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-64@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-linux-64@npm:0.14.50"
@@ -5746,6 +5820,13 @@ __metadata:
 "esbuild-linux-64@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-linux-64@npm:0.14.53"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-64@npm:0.14.54"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -5764,6 +5845,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-arm64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-arm64@npm:0.14.54"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-arm@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-linux-arm@npm:0.14.50"
@@ -5774,6 +5862,13 @@ __metadata:
 "esbuild-linux-arm@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-linux-arm@npm:0.14.53"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-arm@npm:0.14.54"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5792,6 +5887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-mips64le@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-mips64le@npm:0.14.54"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-ppc64le@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-linux-ppc64le@npm:0.14.50"
@@ -5802,6 +5904,13 @@ __metadata:
 "esbuild-linux-ppc64le@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-linux-ppc64le@npm:0.14.53"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-ppc64le@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-ppc64le@npm:0.14.54"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -5820,6 +5929,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-linux-riscv64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-riscv64@npm:0.14.54"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "esbuild-linux-s390x@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-linux-s390x@npm:0.14.50"
@@ -5830,6 +5946,13 @@ __metadata:
 "esbuild-linux-s390x@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-linux-s390x@npm:0.14.53"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-s390x@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-linux-s390x@npm:0.14.54"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -5864,6 +5987,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-netbsd-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-netbsd-64@npm:0.14.54"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-openbsd-64@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-openbsd-64@npm:0.14.50"
@@ -5874,6 +6004,13 @@ __metadata:
 "esbuild-openbsd-64@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-openbsd-64@npm:0.14.53"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-openbsd-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-openbsd-64@npm:0.14.54"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -5892,6 +6029,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-sunos-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-sunos-64@npm:0.14.54"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-windows-32@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-windows-32@npm:0.14.50"
@@ -5902,6 +6046,13 @@ __metadata:
 "esbuild-windows-32@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-windows-32@npm:0.14.53"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-32@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-windows-32@npm:0.14.54"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -5920,6 +6071,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-windows-64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-windows-64@npm:0.14.54"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-windows-arm64@npm:0.14.50":
   version: 0.14.50
   resolution: "esbuild-windows-arm64@npm:0.14.50"
@@ -5930,6 +6088,13 @@ __metadata:
 "esbuild-windows-arm64@npm:0.14.53":
   version: 0.14.53
   resolution: "esbuild-windows-arm64@npm:0.14.53"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-arm64@npm:0.14.54":
+  version: 0.14.54
+  resolution: "esbuild-windows-arm64@npm:0.14.54"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -6076,6 +6241,80 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: cd62d3bc805c6c2ff2cfe62c2fbe6a6d617783d5095167df861be7ddba464281f719a5ded2e940ba21838abf58cce8259daffa08667515c4396ff7bf683f5b70
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.14.54":
+  version: 0.14.54
+  resolution: "esbuild@npm:0.14.54"
+  dependencies:
+    "@esbuild/linux-loong64": 0.14.54
+    esbuild-android-64: 0.14.54
+    esbuild-android-arm64: 0.14.54
+    esbuild-darwin-64: 0.14.54
+    esbuild-darwin-arm64: 0.14.54
+    esbuild-freebsd-64: 0.14.54
+    esbuild-freebsd-arm64: 0.14.54
+    esbuild-linux-32: 0.14.54
+    esbuild-linux-64: 0.14.54
+    esbuild-linux-arm: 0.14.54
+    esbuild-linux-arm64: 0.14.54
+    esbuild-linux-mips64le: 0.14.54
+    esbuild-linux-ppc64le: 0.14.54
+    esbuild-linux-riscv64: 0.14.54
+    esbuild-linux-s390x: 0.14.54
+    esbuild-netbsd-64: 0.14.54
+    esbuild-openbsd-64: 0.14.54
+    esbuild-sunos-64: 0.14.54
+    esbuild-windows-32: 0.14.54
+    esbuild-windows-64: 0.14.54
+    esbuild-windows-arm64: 0.14.54
+  dependenciesMeta:
+    "@esbuild/linux-loong64":
+      optional: true
+    esbuild-android-64:
+      optional: true
+    esbuild-android-arm64:
+      optional: true
+    esbuild-darwin-64:
+      optional: true
+    esbuild-darwin-arm64:
+      optional: true
+    esbuild-freebsd-64:
+      optional: true
+    esbuild-freebsd-arm64:
+      optional: true
+    esbuild-linux-32:
+      optional: true
+    esbuild-linux-64:
+      optional: true
+    esbuild-linux-arm:
+      optional: true
+    esbuild-linux-arm64:
+      optional: true
+    esbuild-linux-mips64le:
+      optional: true
+    esbuild-linux-ppc64le:
+      optional: true
+    esbuild-linux-riscv64:
+      optional: true
+    esbuild-linux-s390x:
+      optional: true
+    esbuild-netbsd-64:
+      optional: true
+    esbuild-openbsd-64:
+      optional: true
+    esbuild-sunos-64:
+      optional: true
+    esbuild-windows-32:
+      optional: true
+    esbuild-windows-64:
+      optional: true
+    esbuild-windows-arm64:
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 49e360b1185c797f5ca3a7f5f0a75121494d97ddf691f65ed1796e6257d318f928342a97f559bb8eced6a90cf604dd22db4a30e0dbbf15edd9dbf22459b639af
   languageName: node
   linkType: hard
 
@@ -7284,6 +7523,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-port-please@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "get-port-please@npm:2.6.1"
+  dependencies:
+    fs-memo: ^1.2.0
+  checksum: 258b33f7e36c1b36994ea616b0965556d941aa78bf649a74f8074b12f2f9fb676c96be4eed55fac6fe2710183eb8c621312d74f00967a1e40a984d052c5e9056
+  languageName: node
+  linkType: hard
+
 "get-port@npm:^5.1.1":
   version: 5.1.1
   resolution: "get-port@npm:5.1.1"
@@ -7552,19 +7800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"h3@npm:^0.7.10":
-  version: 0.7.12
-  resolution: "h3@npm:0.7.12"
-  dependencies:
-    cookie-es: ^0.5.0
-    destr: ^1.1.1
-    radix3: ^0.1.2
-    ufo: ^0.8.5
-  checksum: cde4a733910a06a36fb9a26222a624bdd51314bd4a82c7f3830405d76f152cbaf59bbf8438207d76ce5e49a8d23807ba14055965bad64f9e11c598002aeafd1a
-  languageName: node
-  linkType: hard
-
-"h3@npm:^0.7.14":
+"h3@npm:^0.7.12, h3@npm:^0.7.14":
   version: 0.7.14
   resolution: "h3@npm:0.7.14"
   dependencies:
@@ -8020,7 +8256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:^5.2.0":
+"ioredis@npm:^5.2.2":
   version: 5.2.2
   resolution: "ioredis@npm:5.2.2"
   dependencies:
@@ -8748,6 +8984,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"listhen@npm:^0.2.15":
+  version: 0.2.15
+  resolution: "listhen@npm:0.2.15"
+  dependencies:
+    clipboardy: ^3.0.0
+    colorette: ^2.0.19
+    defu: ^6.0.0
+    get-port-please: ^2.6.1
+    http-shutdown: ^1.2.2
+    selfsigned: ^2.0.1
+    ufo: ^0.8.5
+  checksum: 6190a0dec7b150698c26b08b429888e6d86a4f81121cd0bc59fe0180097a9ed4e9839bc8bfbe10d1bc7d8a176958fb9ade161e50977275ac73fa536d7656075a
+  languageName: node
+  linkType: hard
+
 "load-json-file@npm:^4.0.0":
   version: 4.0.0
   resolution: "load-json-file@npm:4.0.0"
@@ -8925,13 +9176,6 @@ __metadata:
   dependencies:
     lodash._reinterpolate: ^3.0.0
   checksum: 863e025478b092997e11a04e9d9e735875eeff1ffcd6c61742aa8272e3c2cddc89ce795eb9726c4e74cef5991f722897ff37df7738a125895f23fc7d12a7bb59
-  languageName: node
-  linkType: hard
-
-"lodash.truncate@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.truncate@npm:4.4.2"
-  checksum: b463d8a382cfb5f0e71c504dcb6f807a7bd379ff1ea216669aa42c52fc28c54e404bfbd96791aa09e6df0de2c1d7b8f1b7f4b1a61f324d38fe98bc535aeee4f5
   languageName: node
   linkType: hard
 
@@ -9620,24 +9864,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitropack@npm:^0.4.12":
-  version: 0.4.12
-  resolution: "nitropack@npm:0.4.12"
+"nitropack@npm:^0.4.13":
+  version: 0.4.13
+  resolution: "nitropack@npm:0.4.13"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
     "@netlify/functions": ^1.0.0
     "@rollup/plugin-alias": ^3.1.9
-    "@rollup/plugin-commonjs": ^22.0.1
+    "@rollup/plugin-commonjs": ^22.0.2
     "@rollup/plugin-inject": ^4.0.4
     "@rollup/plugin-json": ^4.1.0
     "@rollup/plugin-node-resolve": ^13.3.0
     "@rollup/plugin-replace": ^4.0.0
     "@rollup/plugin-wasm": ^5.2.0
     "@rollup/pluginutils": ^4.2.1
-    "@types/jsdom": ^16.2.14
-    "@vercel/nft": ^0.20.1
+    "@types/jsdom": ^20.0.0
+    "@vercel/nft": ^0.21.0
     archiver: ^5.3.1
-    c12: ^0.2.8
+    c12: ^0.2.9
     chalk: ^5.0.1
     chokidar: ^3.5.3
     consola: ^2.15.3
@@ -9645,48 +9889,47 @@ __metadata:
     defu: ^6.0.0
     destr: ^1.1.1
     dot-prop: ^7.2.0
-    esbuild: ^0.14.49
+    esbuild: ^0.14.54
     escape-string-regexp: ^5.0.0
     etag: ^1.8.1
     fs-extra: ^10.1.0
     globby: ^13.1.2
     gzip-size: ^7.0.0
-    h3: ^0.7.10
+    h3: ^0.7.14
     hookable: ^5.1.1
     http-proxy: ^1.18.1
     is-primitive: ^3.0.1
     jiti: ^1.14.0
     klona: ^2.0.5
-    listhen: ^0.2.13
+    listhen: ^0.2.15
     mime: ^3.0.0
-    mlly: ^0.5.4
+    mlly: ^0.5.7
     mri: ^1.2.0
     node-fetch-native: ^0.1.4
-    ohash: ^0.1.0
+    ohash: ^0.1.5
     ohmyfetch: ^0.4.18
-    pathe: ^0.3.2
+    pathe: ^0.3.3
     perfect-debounce: ^0.1.3
     pkg-types: ^0.3.3
     pretty-bytes: ^6.0.0
     radix3: ^0.1.2
-    rollup: ^2.76.0
+    rollup: ^2.77.2
     rollup-plugin-terser: ^7.0.2
-    rollup-plugin-visualizer: ^5.6.0
-    scule: ^0.2.1
+    rollup-plugin-visualizer: ^5.7.1
+    scule: ^0.3.2
     semver: ^7.3.7
     serve-placeholder: ^2.0.1
     serve-static: ^1.15.0
     source-map-support: ^0.5.21
     std-env: ^3.1.1
-    table: ^6.8.0
     ufo: ^0.8.5
     unenv: ^0.5.2
-    unimport: ^0.4.4
-    unstorage: ^0.5.4
+    unimport: ^0.6.5
+    unstorage: ^0.5.6
   bin:
     nitro: dist/cli.mjs
     nitropack: dist/cli.mjs
-  checksum: 4f402457b558188253a3fde9bb130901e30b393854ca9f870e9a62940075c67f9a218efa4cad8cded5d1526f7fc24ca1ae091ee784a6da62d3dcbdf11fb95b7b
+  checksum: bf501d8d85e0be7227ef228f6e721ecf4208ba983f6cf772e6e71913e5133f67b501d7c46b78227b2245311840a781359fdf31ad56b38ce0d5c0c4180e597fba
   languageName: node
   linkType: hard
 
@@ -10113,7 +10356,7 @@ __metadata:
     knitwork: ^0.1.2
     magic-string: ^0.26.2
     mlly: ^0.5.7
-    nitropack: ^0.4.12
+    nitropack: ^0.4.13
     nuxi: ^3.0.0-rc.6
     ohash: ^0.1.5
     ohmyfetch: ^0.4.18
@@ -10227,13 +10470,6 @@ __metadata:
     define-properties: ^1.1.3
     es-abstract: ^1.19.1
   checksum: 0f17e99741ebfbd0fa55ce942f6184743d3070c61bd39221afc929c8422c4907618c8da694c6915bc04a83ab3224260c779ba37fc07bb668bdc5f33b66a902a4
-  languageName: node
-  linkType: hard
-
-"ohash@npm:^0.1.0":
-  version: 0.1.4
-  resolution: "ohash@npm:0.1.4"
-  checksum: 859ac69ea02201f7aef4c5ee6d3b9ef009c9e58c24fb4fa67477e7bc431fa7a2bf74d8b814472da55a8e87c318f0c36081dddc729b71aa09a7e336381d4be636
   languageName: node
   linkType: hard
 
@@ -10601,6 +10837,15 @@ __metadata:
     parse-path: ^5.0.0
     protocols: ^2.0.1
   checksum: 3e26852706bebe9fac409909316716dee52883d2fb5c82d65577effba1507abb7bc42bb59ce0ba6c8659168fb99acf89000bd8fe096ed3ad7124fa85227436d7
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "parse5@npm:7.0.0"
+  dependencies:
+    entities: ^4.3.0
+  checksum: 7da5d61cc18eb36ffa71fc861e65cbfd1f23d96483a6631254e627be667dbc9c93ac0b0e6cb17a13a2e4033dab19bfb2f76f38e5936cfb57240ed49036a83fcc
   languageName: node
   linkType: hard
 
@@ -11775,7 +12020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-visualizer@npm:^5.6.0, rollup-plugin-visualizer@npm:^5.7.1":
+"rollup-plugin-visualizer@npm:^5.7.1":
   version: 5.7.1
   resolution: "rollup-plugin-visualizer@npm:5.7.1"
   dependencies:
@@ -11800,7 +12045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.75.6, rollup@npm:^2.76.0, rollup@npm:^2.77.0":
+"rollup@npm:^2.75.6, rollup@npm:^2.77.0":
   version: 2.77.0
   resolution: "rollup@npm:2.77.0"
   dependencies:
@@ -12155,17 +12400,6 @@ __metadata:
   version: 4.0.0
   resolution: "slash@npm:4.0.0"
   checksum: da8e4af73712253acd21b7853b7e0dbba776b786e82b010a5bfc8b5051a1db38ed8aba8e1e8f400dd2c9f373be91eb1c42b66e91abb407ff42b10feece5e1d2d
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "slice-ansi@npm:4.0.0"
-  dependencies:
-    ansi-styles: ^4.0.0
-    astral-regex: ^2.0.0
-    is-fullwidth-code-point: ^3.0.0
-  checksum: 4a82d7f085b0e1b070e004941ada3c40d3818563ac44766cca4ceadd2080427d337554f9f99a13aaeb3b4a94d9964d9466c807b3d7b7541d1ec37ee32d308756
   languageName: node
   linkType: hard
 
@@ -12599,19 +12833,6 @@ __metadata:
   version: 5.3.3
   resolution: "tabbable@npm:5.3.3"
   checksum: 1aa56e1bb617cc10616c407f4e756f0607f3e2d30f9803664d70b85db037ca27e75918ed1c71443f3dc902e21dc9f991ce4b52d63a538c9b69b3218d3babcd70
-  languageName: node
-  linkType: hard
-
-"table@npm:^6.8.0":
-  version: 6.8.0
-  resolution: "table@npm:6.8.0"
-  dependencies:
-    ajv: ^8.0.1
-    lodash.truncate: ^4.4.2
-    slice-ansi: ^4.0.0
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-  checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
   languageName: node
   linkType: hard
 
@@ -13172,24 +13393,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unimport@npm:^0.4.4":
-  version: 0.4.7
-  resolution: "unimport@npm:0.4.7"
-  dependencies:
-    "@rollup/pluginutils": ^4.2.1
-    escape-string-regexp: ^5.0.0
-    fast-glob: ^3.2.11
-    local-pkg: ^0.4.2
-    magic-string: ^0.26.2
-    mlly: ^0.5.5
-    pathe: ^0.3.2
-    scule: ^0.2.1
-    strip-literal: ^0.4.0
-    unplugin: ^0.7.2
-  checksum: 7cdb4b657b7145556ce9b422916fc9f5ed87a60925859b8adb040bbca1cc09cd8c3e0d72a9aa8defbd6cae693139fa138554b8a72c4f13cd11d5c4fc557e81bc
-  languageName: node
-  linkType: hard
-
 "unimport@npm:^0.6.5":
   version: 0.6.5
   resolution: "unimport@npm:0.6.5"
@@ -13284,7 +13487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unplugin@npm:^0.7.0, unplugin@npm:^0.7.2":
+"unplugin@npm:^0.7.0":
   version: 0.7.2
   resolution: "unplugin@npm:0.7.2"
   dependencies:
@@ -13336,21 +13539,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unstorage@npm:^0.5.4":
-  version: 0.5.5
-  resolution: "unstorage@npm:0.5.5"
+"unstorage@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "unstorage@npm:0.5.6"
   dependencies:
     anymatch: ^3.1.2
     chokidar: ^3.5.3
     destr: ^1.1.1
-    h3: ^0.7.10
-    ioredis: ^5.2.0
+    h3: ^0.7.12
+    ioredis: ^5.2.2
     listhen: ^0.2.13
     mri: ^1.2.0
     ohmyfetch: ^0.4.18
     ufo: ^0.8.5
-    ws: ^8.8.0
-  checksum: a054364ec1d23cc53199a58553e597c5c8e8a33f621be8ccf083fbe035fc4b2b152e15e0599a3b1398e03f4ca7bceeed33ee23c6ae70fc4ea60726de775b447f
+    ws: ^8.8.1
+  checksum: 2cb0c9b4e5561fbce1a30d0ff724758fed7887f7db9f5d905a3bebb42c7b77b763bf672e9b11cbb82df6bcc6e37d3e2ed8b9bc7214cbb011541ed81a4779b931
   languageName: node
   linkType: hard
 
@@ -14103,7 +14306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.8.0":
+"ws@npm:^8.8.1":
   version: 8.8.1
   resolution: "ws@npm:8.8.1"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9864,9 +9864,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitropack@npm:^0.4.13":
-  version: 0.4.13
-  resolution: "nitropack@npm:0.4.13"
+"nitropack@npm:^0.4.14":
+  version: 0.4.14
+  resolution: "nitropack@npm:0.4.14"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
     "@netlify/functions": ^1.0.0
@@ -9929,7 +9929,7 @@ __metadata:
   bin:
     nitro: dist/cli.mjs
     nitropack: dist/cli.mjs
-  checksum: bf501d8d85e0be7227ef228f6e721ecf4208ba983f6cf772e6e71913e5133f67b501d7c46b78227b2245311840a781359fdf31ad56b38ce0d5c0c4180e597fba
+  checksum: 86d4163a6d4dfa3919b7dd48156abbc3af9f6ad8d87aa296e490828d7bc90101546fdadd5ec2f79c31949ad2d1832ae99a39eb0094f9d7334d5c9daa9ede2925
   languageName: node
   linkType: hard
 
@@ -10356,7 +10356,7 @@ __metadata:
     knitwork: ^0.1.2
     magic-string: ^0.26.2
     mlly: ^0.5.7
-    nitropack: ^0.4.13
+    nitropack: ^0.4.14
     nuxi: ^3.0.0-rc.6
     ohash: ^0.1.5
     ohmyfetch: ^0.4.18


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Update nitropack to latest releast ([changelog](https://github.com/unjs/nitro/blob/main/CHANGELOG.md)). 

One major improvement is that with the latest nitropack, we can use new `defineRenderHandler` that allows caching, response handling and assets (such as `favicon.ico`) fallback. And enhanced in parallel to nuxt releases.

[edge-only] Breaking change: `nuxt:app:response({ response })` nitro hook will be changed to `render:response(response, { event })`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

