### PR TITLE
fix(nuxt): interopDefault for page component imports

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -237,7 +237,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
         alias: `${metaImportName}?.alias || []`,
-        component: genDynamicImport(file)
+        component: genDynamicImport(file, { interopDefault: true })
       }
     }))
   }

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -34,10 +34,9 @@ export default {
     /**
      * Split server bundle into multiple chunks and dynamically import them
      *
-     * Note: Enabling this flag can cause hydration issues in some platform.
      *
      * @see https://github.com/nuxt/framework/issues/6432
      */
-     viteServerDynamicImports: false,
+     viteServerDynamicImports: true,
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6204

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vue-router has a built-in feature to interop default export of component imports (Source code: [here](https://github.com/vuejs/router/blob/df836529db63360f0bf9810ccd4e8911846aef45/packages/router/src/utils/index.ts#L10) and [here](https://github.com/vuejs/router/blob/df836529db63360f0bf9810ccd4e8911846aef45/packages/router/src/navigationGuards.ts#L317))

`isESModule` utility in `vue-router` normally works when importing in native esm (`obj[Symbol.toStringTag] === 'Module'`) or with esm-compatible chunks (`obj.__esModule`). But this can be broken if there is a second transform build step (in this case was recent change in netlify builder) that converts component dynamic imports to simple `{ default: [getter] }` without `__esModule` flag.

This PR, enables a more direct approach to resolve default component page exports passed to `vue-router` using `interopDefault: true` passed to `knitwork.genDynamicImport` that appends `.then(m => m.default || m)` to router component imports.

Since this change seems to fix the root-cause of regression, i'm setting default value of `viteServerDynamicImports` introduced in #6433 to `true` but keep it to opt-out until we sure issues are fixed.

PS: Thanks to @orinokai and @danielroe that help along with long journey of debugging!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

