### PR TITLE
refactor(nuxt)!: remove `null` handling for `titleTemplate`

### DIFF
--- a/packages/nuxt/src/head/runtime/lib/vueuse-head.plugin.ts
+++ b/packages/nuxt/src/head/runtime/lib/vueuse-head.plugin.ts
@@ -15,20 +15,10 @@ export default defineNuxtPlugin((nuxtApp) => {
     headReady = true
   })
 
-  const titleTemplate = ref<MetaObject['titleTemplate']>()
-
   nuxtApp._useHead = (_meta: MetaObject | ComputedGetter<MetaObject>) => {
     const meta = ref<MetaObject>(_meta)
-    if ('titleTemplate' in meta.value) {
-      titleTemplate.value = meta.value.titleTemplate
-    }
-
     const headObj = computed(() => {
       const overrides: MetaObject = { meta: [] }
-      // cast a null titleTemplate to an empty string so @vueuse/head ignores it
-      if (titleTemplate.value === null) {
-        overrides.titleTemplate = ''
-      }
       if (meta.value.charset) {
         overrides.meta!.push({ key: 'charset', charset: meta.value.charset })
       }

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -27,7 +27,7 @@ const config = useRuntimeConfig()
 
 // reset title template example
 useHead({
-  titleTemplate: null
+  titleTemplate: ''
 })
 
 const foo = useFoo()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

follow on from #6296

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems we have a little leftover `titleTemplate` handling. I think we don't need this - was there a reason we left it in?

### 👉 Migration

If you were previously using `titleTemplate: null` you should update this to `titleTemplate: ''`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

