### PR TITLE
feat(webpack, vite): default to `.js` extension for client

### DIFF
--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -122,8 +122,8 @@ export default {
      * ```
      */
     filenames: {
-      app: ({ isDev }) => isDev ? `[name].mjs` : `[contenthash:7].mjs`,
-      chunk: ({ isDev }) => isDev ? `[name].mjs` : `[contenthash:7].mjs`,
+      app: ({ isDev }) => isDev ? `[name].js` : `[contenthash:7].js`,
+      chunk: ({ isDev }) => isDev ? `[name].js` : `[contenthash:7].js`,
       css: ({ isDev }) => isDev ? '[name].css' : 'css/[contenthash:7].css',
       img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[name].[contenthash:7].[ext]',
       font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[name].[contenthash:7].[ext]',

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -37,14 +37,6 @@ export async function buildClient (ctx: ViteBuildContext) {
       }
     },
     build: {
-      rollupOptions: {
-        output: {
-          // https://github.com/vitejs/vite/tree/main/packages/vite/src/node/build.ts#L464-L478
-          assetFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].[ext]')),
-          chunkFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].mjs')),
-          entryFileNames: ctx.nuxt.options.dev ? 'entry.mjs' : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].mjs'))
-        }
-      },
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client')
     },
@@ -71,6 +63,16 @@ export async function buildClient (ctx: ViteBuildContext) {
   if (!ctx.nuxt.options.dev) {
     clientConfig.server.hmr = false
   }
+
+  // We want to respect users' own rollup output options
+  ctx.config.build.rollupOptions = defu(ctx.config.build.rollupOptions, {
+    output: {
+      // https://github.com/vitejs/vite/tree/main/packages/vite/src/node/build.ts#L464-L478
+      assetFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].[ext]')),
+      chunkFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js')),
+      entryFileNames: ctx.nuxt.options.dev ? 'entry.js' : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js'))
+    }
+  })
 
   if (clientConfig.server.hmr !== false) {
     const hmrPortDefault = 24678 // Vite's default HMR port


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/pull/6232#issuecomment-1199214638
https://github.com/nuxt/framework/discussions/6168

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Now that we have updated `vue-bundle-renderer`, we can output`.js` files on client-side, for better support with CDN/web servers.

This PR also allows users to configure their output filenames on vite. (Previously it always overrode them.)

```js
import { defineNuxtConfig } from 'nuxt'

export default defineNuxtConfig({
  vite: {
    build: {
      rollupOptions: {
        output: {
          chunkFileNames: '_nuxt/[hash].mjs'
        }
      }
    }
  }
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

