### PR TITLE
fix(vite): remove `/@fs` from external ids

### DIFF
--- a/packages/vite/src/dev-bundler.ts
+++ b/packages/vite/src/dev-bundler.ts
@@ -51,13 +51,13 @@ async function transformRequest (opts: TransformOptions, id: string) {
   // On Windows, we prefix absolute paths with `/@fs/` to skip node resolution algorithm
   id = id.replace(/^\/?(?=\w:)/, '/@fs/')
 
-  // Vite will add ?v=123 to bypass browser cache
-  // Remove for externals
-  const withoutVersionQuery = id.replace(/\?v=\w+$/, '')
-  if (await opts.isExternal(withoutVersionQuery)) {
-    const path = builtinModules.includes(withoutVersionQuery.split('node:').pop())
-      ? withoutVersionQuery
-      : isAbsolute(withoutVersionQuery) ? pathToFileURL(withoutVersionQuery).href : withoutVersionQuery
+  // Remove query and @fs/ for external modules
+  const externalId = id.replace(/\?v=\w+$|^\/@fs/, '')
+
+  if (await opts.isExternal(externalId)) {
+    const path = builtinModules.includes(externalId.split('node:').pop())
+      ? externalId
+      : isAbsolute(externalId) ? pathToFileURL(externalId).href : externalId
     return {
       code: `(global, module, _, exports, importMeta, ssrImport, ssrDynamicImport, ssrExportAll) =>
 ${genDynamicImport(path, { wrapper: false })}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #6527

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Regression might have appeared with #6355. When checking for external paths, `@fs/` prefix should be omited as is a vite-specific prefix. Windows paths are still safe since with have `pathToFileURL` for generating import statements.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

