### PR TITLE
fix(vite, nuxt): resolve relative to `srcDir` rather than `rootDir`

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -146,7 +146,7 @@ export default defineNuxtModule<ComponentsOptions>({
       if (!['add', 'unlink'].includes(event)) {
         return
       }
-      const fPath = resolve(nuxt.options.rootDir, path)
+      const fPath = resolve(nuxt.options.srcDir, path)
       if (componentDirs.find(dir => fPath.startsWith(dir.path))) {
         await nuxt.callHook('builder:generateApp')
       }

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -53,7 +53,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       vuePlugin(ctx.config.vue),
       viteJsxPlugin(),
       devStyleSSRPlugin({
-        rootDir: ctx.nuxt.options.rootDir,
+        srcDir: ctx.nuxt.options.srcDir,
         buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, ctx.nuxt.options.app.buildAssetsDir)
       }),
       ctx.nuxt.options.experimental.viteNode

--- a/packages/vite/src/plugins/cache-dir.ts
+++ b/packages/vite/src/plugins/cache-dir.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'pathe'
 import type { Plugin } from 'vite'
 
-export function cacheDirPlugin (rootDir, name: string) {
+export function cacheDirPlugin (rootDir: string, name: string) {
   const optimizeCacheDir = resolve(rootDir, 'node_modules/.cache/vite', name)
   return <Plugin> {
     name: 'nuxt:cache-dir',

--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -3,7 +3,7 @@ import { Plugin } from 'vite'
 import { isCSS } from '../utils'
 
 export interface DevStyleSSRPluginOptions {
-  rootDir: string
+  srcDir: string
   buildAssetsURL: string
 }
 
@@ -18,8 +18,8 @@ export function devStyleSSRPlugin (options: DevStyleSSRPluginOptions): Plugin {
       }
 
       let moduleId = id
-      if (moduleId.startsWith(options.rootDir)) {
-        moduleId = moduleId.slice(options.rootDir.length)
+      if (moduleId.startsWith(options.srcDir)) {
+        moduleId = moduleId.slice(options.srcDir.length)
       }
 
       // When dev `<style>` is injected, remove the `<link>` styles from manifest

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -7,7 +7,7 @@ import { getViteNodeOptions } from './vite-node-shared.mjs'
 const viteNodeOptions = getViteNodeOptions()
 
 const runner = new ViteNodeRunner({
-  root: viteNodeOptions.rootDir,
+  root: viteNodeOptions.root,
   base: viteNodeOptions.base,
   async fetchModule (id) {
     return await $fetch('/module/' + encodeURI(id), {

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -7,7 +7,7 @@ import { getViteNodeOptions } from './vite-node-shared.mjs'
 const viteNodeOptions = getViteNodeOptions()
 
 const runner = new ViteNodeRunner({
-  root: viteNodeOptions.root,
+  root: viteNodeOptions.root, // Equals to Nuxt `srcDir`
   base: viteNodeOptions.base,
   async fetchModule (id) {
     return await $fetch('/module/' + encodeURI(id), {

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -143,7 +143,7 @@ export async function initViteNodeServer (ctx: ViteBuildContext) {
   // Serialize and pass vite-node runtime options
   const viteNodeServerOptions = {
     baseURL: `${protocol}://${host}:${port}/__nuxt_vite_node__`,
-    rootDir: ctx.nuxt.options.rootDir,
+    root: ctx.nuxt.options.srcDir,
     entryPath,
     base: ctx.ssrServer.config.base || '/_nuxt/'
   }

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -143,7 +143,7 @@ export async function initViteNodeServer (ctx: ViteBuildContext) {
   // Serialize and pass vite-node runtime options
   const viteNodeServerOptions = {
     baseURL: `${protocol}://${host}:${port}/__nuxt_vite_node__`,
-    root: ctx.ssrServer.config.root,
+    root: ctx.nuxt.options.srcDir,
     entryPath,
     base: ctx.ssrServer.config.base || '/_nuxt/'
   }

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -143,7 +143,7 @@ export async function initViteNodeServer (ctx: ViteBuildContext) {
   // Serialize and pass vite-node runtime options
   const viteNodeServerOptions = {
     baseURL: `${protocol}://${host}:${port}/__nuxt_vite_node__`,
-    root: ctx.nuxt.options.srcDir,
+    root: ctx.ssrServer.config.root,
     entryPath,
     base: ctx.ssrServer.config.base || '/_nuxt/'
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With a custom `srcDir`, various things were not working, including scanning of new components.

This also makes a couple of changes to vite-node, to match the non-vite node implementation where `root` is set to `srcDir` and not `rootDir` but would value @antfu's verdict on these.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

