### PR TITLE
fix(types): lock rollup to 2.77

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
     "nuxi": "link:./packages/nuxi",
     "nuxt": "link:./packages/nuxt",
     "nuxt3": "link:./packages/nuxt",
-    "vite": "~3.0.7",
-    "unbuild": "^0.8.8"
+    "rollup": "~2.77.3",
+    "unbuild": "^0.8.8",
+    "vite": "~3.0.7"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^10.0.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -44,7 +44,7 @@
     "postcss": "^8.4.16",
     "postcss-import": "^14.1.0",
     "postcss-url": "^10.1.3",
-    "rollup": "^2.78.0",
+    "rollup": "~2.77.3",
     "rollup-plugin-visualizer": "^5.7.1",
     "ufo": "^0.8.5",
     "unplugin": "^0.9.0",

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "@docus/twitter",
     "vitest",
     "unplugin",
-    "vue-tsc"
+    "vue-tsc",
+    "rollup"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,7 +1809,7 @@ __metadata:
     postcss: ^8.4.16
     postcss-import: ^14.1.0
     postcss-url: ^10.1.3
-    rollup: ^2.78.0
+    rollup: ~2.77.3
     rollup-plugin-visualizer: ^5.7.1
     ufo: ^0.8.5
     unbuild: latest
@@ -11828,7 +11828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:>=2.75.6 <2.77.0 || ~2.77.0, rollup@npm:^2.77.2, rollup@npm:^2.77.3":
+"rollup@npm:~2.77.3":
   version: 2.77.3
   resolution: "rollup@npm:2.77.3"
   dependencies:
@@ -11839,20 +11839,6 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: b179c68249584565ddb5664a241e8e48c293b2207718d885b08ee25797d98857a383f06b544bb89819407da5a71557f4713309a278f61c4778bb32b1d3321a1c
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.78.0":
-  version: 2.78.0
-  resolution: "rollup@npm:2.78.0"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 01b5a7ae082d2a14201c973ee973099f0899cc87b65063d5ca5a77c05eeefb3b51e14b1346cf1a0fc879ac2cbb87239d4f960917bfc30b7c52f5dce50a7f56e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See https://github.com/rollup/rollup/pull/4600#issuecomment-1212736862

Vite locked Rollup to below v2.77 due to type misalignment and planned to upgrade to Rollup 2.78 in Vite 3.1 with https://github.com/vitejs/vite/pull/9634