### PR TITLE
fix(nuxt): don't set asyncData to existing payload on CSR if `initialCache` is disabled

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -8,20 +8,20 @@ export type PickFrom<T, K extends Array<string>> = T extends Array<any>
   ? T
   : T extends Record<string, any>
   ? keyof T extends K[number]
-    ? T // Exact same keys as the target, skip Pick
-    : Pick<T, K[number]>
+  ? T // Exact same keys as the target, skip Pick
+  : Pick<T, K[number]>
   : T
 
 export type KeysOf<T> = Array<keyof T extends string ? keyof T : string>
 export type KeyOfRes<Transform extends _Transform> = KeysOf<ReturnType<Transform>>
 
-type MultiWatchSources = (WatchSource<unknown> | object)[];
+type MultiWatchSources = (WatchSource<unknown> | object)[]
 
 export interface AsyncDataOptions<
   DataT,
   Transform extends _Transform<DataT, any> = _Transform<DataT, DataT>,
   PickKeys extends KeyOfRes<_Transform> = KeyOfRes<Transform>
-  > {
+> {
   server?: boolean
   lazy?: boolean
   default?: () => DataT | Ref<DataT> | null
@@ -112,10 +112,10 @@ export function useAsyncData<
     }
   }
 
-  const useInitialCache = () => options.initialCache && nuxt.payload.data[key] !== undefined
+  const useInitialCache = () => (nuxt.isHydrating || options.initialCache) && nuxt.payload.data[key] !== undefined
 
   const asyncData = {
-    data: ref(nuxt.payload.data[key] ?? options.default?.() ?? null),
+    data: ref(useInitialCache() ? nuxt.payload.data[key] : options.default?.() ?? null),
     pending: ref(!useInitialCache()),
     error: ref(nuxt.payload._errors[key] ?? null)
   } as AsyncData<DataT, DataE>

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -8,8 +8,8 @@ export type PickFrom<T, K extends Array<string>> = T extends Array<any>
   ? T
   : T extends Record<string, any>
   ? keyof T extends K[number]
-  ? T // Exact same keys as the target, skip Pick
-  : Pick<T, K[number]>
+    ? T // Exact same keys as the target, skip Pick
+    : Pick<T, K[number]>
   : T
 
 export type KeysOf<T> = Array<keyof T extends string ? keyof T : string>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #4702

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were ignoring `initialCache` setting if data was already present in payload. I've exempted us from respecting `initialCache` if we are hydrating. (In this case, `server: false` should be used rather than `initialCache: false`.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

