### PR TITLE
feat(vite): allow disabling entry warmup

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -44,6 +44,11 @@ export default {
     },
 
     /**
+     * Warmup vite entrypoint caches on dev startup.
+     */
+    viteEntryWarmup: true,
+
+    /**
      * Split server bundle into multiple chunks and dynamically import them.
      *
      *

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -44,11 +44,6 @@ export default {
     },
 
     /**
-     * Warmup vite entrypoint caches on dev startup.
-     */
-    viteEntryWarmup: true,
-
-    /**
      * Split server bundle into multiple chunks and dynamically import them.
      *
      *

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -49,5 +49,9 @@ export interface ViteConfig extends ViteUserConfig {
    * Bundler for dev time server-side rendering.
    * @default 'vite-node'
    */
-  devBundler?: 'vite-node' | 'legacy'
+  devBundler?: 'vite-node' | 'legacy',
+  /**
+   * Warmup vite entrypoint caches on dev startup.
+   */
+  warmupEntry?: boolean
 }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -101,7 +101,7 @@ export async function bundle (nuxt: Nuxt) {
       }
     })
 
-    if (nuxt.options.experimental.viteEntryWarmup) {
+    if (nuxt.options.vite.warmupEntry !== false) {
       const start = Date.now()
       warmupViteServer(server, [join('/@fs/', ctx.entry)])
         .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -101,10 +101,12 @@ export async function bundle (nuxt: Nuxt) {
       }
     })
 
-    const start = Date.now()
-    warmupViteServer(server, [join('/@fs/', ctx.entry)])
-      .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
-      .catch(logger.error)
+    if (nuxt.options.experimental.viteEntryWarmup) {
+      const start = Date.now()
+      warmupViteServer(server, [join('/@fs/', ctx.entry)])
+        .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
+        .catch(logger.error)
+    }
   })
 
   await buildClient(ctx)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#6227

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR enables opting out from entry point warmup feature of vite using `vite.warmupEntry: false`.

This feature ensures that nuxt starts transforming entrypoint code before developer even initiates first request to any page, speeding up time from command to initial render. But as @antfu mentioned, there might be performance overhead in concurrency. 


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

