### PR TITLE
fix(vite): warmup server entries with `ssr` condition

### DIFF
--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -3,7 +3,8 @@ import type { ViteDevServer } from 'vite'
 
 export async function warmupViteServer (
   server: ViteDevServer,
-  entries: string[]
+  entries: string[],
+  isServer: boolean
 ) {
   const warmedUrls = new Set<String>()
 
@@ -13,7 +14,7 @@ export async function warmupViteServer (
     }
     warmedUrls.add(url)
     try {
-      await server.transformRequest(url)
+      await server.transformRequest(url, { ssr: isServer })
     } catch (e) {
       logger.debug('Warmup for %s failed with: %s', url, e)
     }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -102,7 +102,7 @@ export async function bundle (nuxt: Nuxt) {
     })
 
     const start = Date.now()
-    warmupViteServer(server, [join('/@fs/', ctx.entry)])
+    warmupViteServer(server, [join('/@fs/', ctx.entry)], env.isServer)
       .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
       .catch(logger.error)
   })


### PR DESCRIPTION
### 🔗 Linked issue

#6647

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Without this fix, we were actually adding some overhead to transform server assets without ssr condition.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

