### PR TITLE
feat(nuxi): auto cleanup with project manifest changes

### DIFF
--- a/packages/nuxi/src/commands/cleanup.ts
+++ b/packages/nuxi/src/commands/cleanup.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { cleanupNuxtDirs } from '../utils/fs'
+import { cleanupNuxtDirs } from '../utils/nuxt'
 import { defineNuxtCommand } from './index'
 
 export default defineNuxtCommand({

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -11,6 +11,7 @@ import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
 import { importModule } from '../utils/cjs'
 import { overrideEnv } from '../utils/env'
+import { writeNuxtManifest, loadNuxtManifest, cleanupNuxtDirs } from '../utils/nuxt'
 import { defineNuxtCommand } from './index'
 
 export default defineNuxtCommand({
@@ -73,6 +74,13 @@ export default defineNuxtCommand({
         currentNuxt = await loadNuxt({ rootDir, dev: true, ready: false })
         if (!isRestart) {
           showURL()
+        }
+
+        // Check if we need cache invalidation
+        const previousManifest = await loadNuxtManifest(currentNuxt.options.buildDir)
+        const newManifest = await writeNuxtManifest(currentNuxt)
+        if (previousManifest && newManifest && previousManifest._hash !== newManifest._hash) {
+          await cleanupNuxtDirs(currentNuxt.options.rootDir)
         }
 
         await currentNuxt.ready()

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -76,7 +76,7 @@ export default defineNuxtCommand({
           showURL()
         }
 
-        // Check if we need cache invalidation
+        // Write manifest and also check if we need cache invalidation
         if (!isRestart) {
           const previousManifest = await loadNuxtManifest(currentNuxt.options.buildDir)
           const newManifest = await writeNuxtManifest(currentNuxt)

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -77,10 +77,12 @@ export default defineNuxtCommand({
         }
 
         // Check if we need cache invalidation
-        const previousManifest = await loadNuxtManifest(currentNuxt.options.buildDir)
-        const newManifest = await writeNuxtManifest(currentNuxt)
-        if (previousManifest && newManifest && previousManifest._hash !== newManifest._hash) {
-          await cleanupNuxtDirs(currentNuxt.options.rootDir)
+        if (!isRestart) {
+          const previousManifest = await loadNuxtManifest(currentNuxt.options.buildDir)
+          const newManifest = await writeNuxtManifest(currentNuxt)
+          if (previousManifest && newManifest && previousManifest._hash !== newManifest._hash) {
+            await cleanupNuxtDirs(currentNuxt.options.rootDir)
+          }
         }
 
         await currentNuxt.ready()

--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -4,7 +4,8 @@ import consola from 'consola'
 import { resolve } from 'pathe'
 import { resolveModule } from '../utils/cjs'
 import { getPackageManager, packageManagerLocks } from '../utils/packageManagers'
-import { cleanupNuxtDirs, rmRecursive, touchFile } from '../utils/fs'
+import { rmRecursive, touchFile } from '../utils/fs'
+import { cleanupNuxtDirs } from '../utils/nuxt'
 import { defineNuxtCommand } from './index'
 
 async function getNuxtVersion (paths: string | string[]): Promise<string|null> {

--- a/packages/nuxi/src/utils/fs.ts
+++ b/packages/nuxi/src/utils/fs.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'node:fs'
-import { dirname, resolve } from 'pathe'
+import { dirname } from 'pathe'
 import consola from 'consola'
 
 // Check if a file exists
@@ -27,18 +27,6 @@ export async function rmRecursive (paths: string[]) {
 export async function touchFile (path: string) {
   const time = new Date()
   await fsp.utimes(path, time, time).catch(() => {})
-}
-
-export async function cleanupNuxtDirs (rootDir: string) {
-  consola.info('Cleaning up generated nuxt files and caches...')
-
-  await rmRecursive([
-    '.nuxt',
-    '.output',
-    'dist',
-    'node_modules/.vite',
-    'node_modules/.cache'
-  ].map(dir => resolve(rootDir, dir)))
 }
 
 export function findup<T> (rootDir: string, fn: (dir: string) => T | undefined): T | null {

--- a/packages/nuxi/src/utils/nuxt.ts
+++ b/packages/nuxi/src/utils/nuxt.ts
@@ -1,6 +1,5 @@
 import { promises as fsp } from 'node:fs'
-import { dirname } from 'node:path'
-import { resolve } from 'pathe'
+import { resolve, dirname } from 'pathe'
 import consola from 'consola'
 import { hash } from 'ohash'
 import type { Nuxt } from '@nuxt/schema'

--- a/packages/nuxi/src/utils/nuxt.ts
+++ b/packages/nuxi/src/utils/nuxt.ts
@@ -1,0 +1,59 @@
+import { promises as fsp } from 'node:fs'
+import { dirname } from 'node:path'
+import { resolve } from 'pathe'
+import consola from 'consola'
+import { hash } from 'ohash'
+import type { Nuxt } from '@nuxt/schema'
+import { rmRecursive } from './fs'
+
+export interface NuxtProjectManifest {
+  _hash: string
+  project: {
+    rootDir: string
+  },
+  versions: {
+    nuxt: string
+  }
+}
+
+export async function cleanupNuxtDirs (rootDir: string) {
+  consola.info('Cleaning up generated nuxt files and caches...')
+
+  await rmRecursive([
+    '.nuxt',
+    '.output',
+    'dist',
+    'node_modules/.vite',
+    'node_modules/.cache'
+  ].map(dir => resolve(rootDir, dir)))
+}
+
+export function resolveNuxtManifest (nuxt: Nuxt): NuxtProjectManifest {
+  const manifest: NuxtProjectManifest = {
+    _hash: null,
+    project: {
+      rootDir: nuxt.options.rootDir
+    },
+    versions: {
+      nuxt: nuxt._version
+    }
+  }
+  manifest._hash = hash(manifest)
+  return manifest
+}
+
+export async function writeNuxtManifest (nuxt: Nuxt): Promise<NuxtProjectManifest> {
+  const manifest = resolveNuxtManifest(nuxt)
+  const manifestPath = resolve(nuxt.options.buildDir, 'nuxt.json')
+  await fsp.mkdir(dirname(manifestPath), { recursive: true })
+  await fsp.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
+  return manifest
+}
+
+export async function loadNuxtManifest (buildDir: string): Promise<NuxtProjectManifest | null> {
+  const manifestPath = resolve(buildDir, 'nuxt.json')
+  const manifest: NuxtProjectManifest | null = await fsp.readFile(manifestPath, 'utf-8')
+    .then(data => JSON.parse(data) as NuxtProjectManifest)
+    .catch(() => null)
+  return manifest
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #6668 and adds basic manifest implementing #6670

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a major change in a project happens (such as updating nuxt or renaming directory) we most likely need to invalidate caches to avoid unpredictable behavior. This PR does two things:

- Write a basic `nuxt.json` to `buildDir`/`.nuxt` only for `nuxi dev` (1)
- Checks manifest hash (full hash) against the previous build and call `nuxi cleanup` in case of hash mismatches.

Remarks:
- I've not included more extensive manifest info and hashes unless we find initial change is not enough. As mentioned by @danielroe in #6668, bundlers (vite and webpack) also handle cache invalidation for dependencies
- We probably need to generate two separate manifests for dev and prod (https://github.com/nuxt/framework/issues/6671)
- It only invalidates caches for `nuxi dev` and not `nuxi build` because i don't believe we saw any cache issue on `nuxi build`. We can add later on to both commands and utils are already refactored to prepare for this.

(1) Sample `.nuxt/nuxt.json`:

```json
{
  "_hash": "AQBCqiYugT",
  "project": {
    "rootDir": "/Users/pooya/Code/framework/playground"
  },
  "versions": {
    "nuxt": "3.0.0-rc.8"
  }
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

