### PR TITLE
fix(nuxt): fallback to static error page on server error

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -45,12 +45,19 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
 
   // HTML response
   const url = withQuery('/__nuxt_error', errorObject)
-  const html = await $fetch(url).catch(async (error) => {
-    console.error('[nitro] Error while generating error response', error)
+  let html = await $fetch(url).catch(() => null)
+
+  if (!html) {
     // Fallback to static rendered error page
-    const { template } = await importModule('@nuxt/ui-templates/templates/error-dev.mjs')
-    return template(errorObject)
-  })
+    console.log('Rendering fallback...')
+    const { template } = process.dev
+      ? await importModule('@nuxt/ui-templates/templates/error-dev.mjs')
+      : await importModule('@nuxt/ui-templates/templates/error-500.mjs')
+    html = template({
+      ...errorObject,
+      description: errorObject.message
+    })
+  }
 
   event.res.setHeader('Content-Type', 'text/html;charset=UTF-8')
   event.res.end(html)

--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -1,7 +1,6 @@
 import { withQuery } from 'ufo'
 import type { NitroErrorHandler } from 'nitropack'
 import type { H3Error } from 'h3'
-import { importModule } from '@nuxt/kit'
 import { normalizeError, isJsonRequest } from '#internal/nitro/utils'
 
 export default <NitroErrorHandler> async function errorhandler (error: H3Error, event) {
@@ -50,8 +49,10 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
   // Fallback to static rendered error page
   if (!html) {
     const { template } = process.dev
-      ? await importModule('@nuxt/ui-templates/templates/error-dev.mjs')
-      : await importModule('@nuxt/ui-templates/templates/error-500.mjs')
+      // @ts-ignore
+      ? await import('@nuxt/ui-templates/templates/error-dev.mjs')
+      // @ts-ignore
+      : await import('@nuxt/ui-templates/templates/error-500.mjs')
     if (process.dev) {
       // TODO: Support `message` in tempalte
       (errorObject as any).description = errorObject.message

--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -44,7 +44,8 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
   }
 
   // HTML response (via SSR)
-  let html = await $fetch(withQuery('/__nuxt_error', errorObject)).catch(() => null)
+  const isErrorPage = event.req.url?.startsWith('/__nuxt_error')
+  let html = !isErrorPage ? await $fetch(withQuery('/__nuxt_error', errorObject)).catch(() => null) : null
 
   // Fallback to static rendered error page
   if (!html) {

--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -54,7 +54,7 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
       // @ts-ignore
       : await import('@nuxt/ui-templates/templates/error-500.mjs')
     if (process.dev) {
-      // TODO: Support `message` in tempalte
+      // TODO: Support `message` in template
       (errorObject as any).description = errorObject.message
     }
     html = template(errorObject)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -181,7 +181,6 @@ describe('errors', () => {
     const error = await res.json()
     delete error.stack
     expect(error).toMatchObject({
-      description: process.env.NUXT_TEST_DEV ? expect.stringContaining('<pre>') : '',
       message: 'This is a custom error',
       statusCode: 500,
       statusMessage: 'Internal Server Error',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Part of #6683
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When there is a server error, the `/__nuxt_error` might also fail to render, we fallback to use static HTML render in this case.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

