### PR TITLE
fix(nuxi): ensure `nuxi upgrade` runs in rootDir

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -1,19 +1,18 @@
 import { execSync } from 'node:child_process'
-import { promises as fsp } from 'node:fs'
 import consola from 'consola'
 import { resolve } from 'pathe'
+import { readPackageJSON } from 'pkg-types'
 import { getPackageManager, packageManagerLocks } from '../utils/packageManagers'
 import { rmRecursive, touchFile } from '../utils/fs'
 import { cleanupNuxtDirs } from '../utils/nuxt'
-import { getNearestPackage, resolveModule } from '../utils/cjs'
+import { getNearestPackage } from '../utils/cjs'
 import { defineNuxtCommand } from './index'
 
-async function getNuxtVersion (paths: string | string[]): Promise<string|null> {
+async function getNuxtVersion (path: string): Promise<string|null> {
   try {
-    const pkgJson = resolveModule('nuxt/package.json', paths)
-    const pkg = pkgJson && JSON.parse(await fsp.readFile(pkgJson, 'utf8'))
+    const pkg = await readPackageJSON('nuxt', { url: path })
     if (!pkg.version) {
-      consola.warn('Cannot find any installed nuxt versions in ', paths)
+      consola.warn('Cannot find any installed nuxt versions in ', path)
     }
     return pkg.version || null
   } catch {

--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -58,16 +58,7 @@ export default defineNuxtCommand({
     await cleanupNuxtDirs(rootDir)
 
     // Check installed nuxt version again
-    let upgradedVersion = await getNuxtVersion(rootDir)
-    // The above will occasionally fail when running in a non cwd, seems to be a caching issue (fetches last versions module)
-    if (!upgradedVersion) {
-      try {
-        // fallback to fetching version from package.json
-        upgradedVersion = getNearestPackage(rootDir).devDependencies?.nuxt || '[unknown]'
-      } catch {
-        upgradedVersion = '[unknown]'
-      }
-    }
+    let upgradedVersion = await getNuxtVersion(rootDir) || '[unknown]'
     consola.info('Upgraded nuxt version:', upgradedVersion)
 
     if (upgradedVersion === currentVersion) {

--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -5,7 +5,6 @@ import { readPackageJSON } from 'pkg-types'
 import { getPackageManager, packageManagerLocks } from '../utils/packageManagers'
 import { rmRecursive, touchFile } from '../utils/fs'
 import { cleanupNuxtDirs } from '../utils/nuxt'
-import { getNearestPackage } from '../utils/cjs'
 import { defineNuxtCommand } from './index'
 
 async function getNuxtVersion (path: string): Promise<string|null> {
@@ -58,7 +57,7 @@ export default defineNuxtCommand({
     await cleanupNuxtDirs(rootDir)
 
     // Check installed nuxt version again
-    let upgradedVersion = await getNuxtVersion(rootDir) || '[unknown]'
+    const upgradedVersion = await getNuxtVersion(rootDir) || '[unknown]'
     consola.info('Upgraded nuxt version:', upgradedVersion)
 
     if (upgradedVersion === currentVersion) {


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using `nuxi update` command with a custom path, it won't honour that path when running the package manager install, instead, it will always run in the `cwd`.

This is apparent in a monorepo or sub-path nuxt installs.

For example, run in this repo `yarn nuxi upgrade ../some-nuxt-app --force` and you'll see it modifies the frameworks package.json and lock.

In providing the proper path, a new issue appears where the `getNuxtVersion` fails. It seems like a cache issue where it's resolving to the old version path, leading to a failure to read the file, as it didn't exist. 

**Exception**
```
 ERROR  ENOENT: no such file or directory, open '/home/harlan/forks/nuxt-app/node_modules/.pnpm/nuxt@3.0.0-rc.6/node_modules/nuxt/package.json'                                                 19:49:21
```

**Logs**
```
➜  nuxt3-fork git:(main) ✗ yarn nuxi upgrade ../nuxt-app --force
Nuxt CLI v3.0.0-rc.8                                                                                                                                                                                                                                                                                                                              19:54:50
ℹ Package Manager: pnpm 7.9.0                                                                                                                                                                   19:54:50
ℹ Current nuxt version: 3.0.0-rc.6                                                                                                                                                              19:54:50
ℹ Removing lock-file and node_modules...                                                                                                                                                        19:54:50
ℹ Installing latest Nuxt 3 RC...                                                                                                                                                                19:54:51
 WARN  deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
Packages: +579
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/harlan/.local/share/pnpm/store/v3
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 612, reused 571, downloaded 0, added 579, done

devDependencies:
+ nuxt 3.0.0-rc.8
ℹ Cleaning up generated nuxt files and caches...                                                                                                                                                19:55:07
ℹ Upgraded nuxt version: [unknown]                                                                                                                                                              19:55:07
✔ Successfully upgraded nuxt from 3.0.0-rc.6 to [unknown]                                                                                                                                       19:55:07
ℹ Changelog: https://github.com/nuxt/framework/compare/v3.0.0-rc.6...v[unknown]  
```

As a work-around I've set it up to read from the package.json's dependency, which should be fairly safe.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

