### PR TITLE
fix(nuxi): properly detect hash and tag for upgrade changelog

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -21,6 +21,16 @@ async function getNuxtVersion (paths: string | string[]): Promise<string|null> {
   }
 }
 
+const nuxtVersionToGitIdentifier = (version: string) => {
+  const parts = version.split('.')
+  // match the git identifier in the release, for example: 3.0.0-rc.8-27677607.a3a8706
+  if (parts.length > 4) {
+    return parts.pop()
+  }
+  // match github tag, for example 3.0.0-rc.8
+  return `v${version}`
+}
+
 export default defineNuxtCommand({
   meta: {
     name: 'upgrade',
@@ -66,8 +76,8 @@ export default defineNuxtCommand({
       consola.success('You\'re already using the latest version of nuxt.')
     } else {
       consola.success('Successfully upgraded nuxt from', currentVersion, 'to', upgradedVersion)
-      const commitA = currentVersion.split('.').pop()
-      const commitB = upgradedVersion.split('.').pop()
+      const commitA = nuxtVersionToGitIdentifier(currentVersion)
+      const commitB = nuxtVersionToGitIdentifier(upgradedVersion)
       if (commitA && commitB) {
         consola.info('Changelog:', `https://github.com/nuxt/framework/compare/${commitA}...${commitB}`)
       }

--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -5,7 +5,7 @@ import { resolve } from 'pathe'
 import { resolveModule } from '../utils/cjs'
 import { getPackageManager, packageManagerLocks } from '../utils/packageManagers'
 import { rmRecursive, touchFile } from '../utils/fs'
-import { cleanupNuxtDirs } from '../utils/nuxt'
+import { cleanupNuxtDirs, nuxtVersionToGitIdentifier } from '../utils/nuxt'
 import { defineNuxtCommand } from './index'
 
 async function getNuxtVersion (paths: string | string[]): Promise<string|null> {
@@ -19,16 +19,6 @@ async function getNuxtVersion (paths: string | string[]): Promise<string|null> {
   } catch {
     return null
   }
-}
-
-const nuxtVersionToGitIdentifier = (version: string) => {
-  const parts = version.split('.')
-  // match the git identifier in the release, for example: 3.0.0-rc.8-27677607.a3a8706
-  if (parts.length > 4) {
-    return parts.pop()
-  }
-  // match github tag, for example 3.0.0-rc.8
-  return `v${version}`
 }
 
 export default defineNuxtCommand({

--- a/packages/nuxi/src/utils/nuxt.ts
+++ b/packages/nuxi/src/utils/nuxt.ts
@@ -27,6 +27,16 @@ export async function cleanupNuxtDirs (rootDir: string) {
   ].map(dir => resolve(rootDir, dir)))
 }
 
+export function nuxtVersionToGitIdentifier (version: string) {
+  // match the git identifier in the release, for example: 3.0.0-rc.8-27677607.a3a8706
+  const id = /\.([0-9a-f]{7})$/.exec(version)
+  if (id?.[1]) {
+    return id[1]
+  }
+  // match github tag, for example 3.0.0-rc.8
+  return `v${version}`
+}
+
 export function resolveNuxtManifest (nuxt: Nuxt): NuxtProjectManifest {
   const manifest: NuxtProjectManifest = {
     _hash: null,


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When upgrading RC versions, the Changelog link is assuming that nuxt was installed using a version with a git commit as the suffix. 

For versions that don't have this, only the last digit is used, so the user gets messages like this:

```
ℹ Cleaning up generated nuxt files and caches...                                                                                                                                                20:39:36
ℹ Upgraded nuxt version: 3.0.0-rc.8                                                                                                                                                         20:39:36
✔ Successfully upgraded nuxt from 3.0.0-rc.6 to 3.0.0-rc.8                                                                                                                                    20:39:36
ℹ Changelog: https://github.com/nuxt/framework/compare/6...8
```

This PR fixes the behaviour and links the changelog correctly.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

