### PR TITLE
fix(nuxt): use `vue-devtools-stub` to mock `@vue/devtools-api` for both cjs + esm

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -68,6 +68,7 @@
     "untyped": "^0.4.5",
     "vue": "^3.2.37",
     "vue-bundle-renderer": "^0.4.2",
+    "vue-devtools-stub": "^0.1.0",
     "vue-router": "^4.1.3"
   },
   "devDependencies": {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -82,7 +82,7 @@ export async function initNitro (nuxt: Nuxt) {
       '@vue/compiler-core': 'unenv/runtime/mock/proxy',
       '@vue/compiler-dom': 'unenv/runtime/mock/proxy',
       '@vue/compiler-ssr': 'unenv/runtime/mock/proxy',
-      '@vue/devtools-api': 'unenv/runtime/mock/proxy-cjs',
+      '@vue/devtools-api': 'vue-devtools-stub',
 
       // Paths
       '#paths': resolve(distDir, 'core/runtime/nitro/paths'),

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -24,9 +24,7 @@
 import { setupDevtoolsPlugin } from '@vue/devtools-api'
 import { useRuntimeConfig } from '#imports'
 
-if (useRuntimeConfig().enableDevtools) {
-  setupDevtoolsPlugin()
-}
+setupDevtoolsPlugin()
 
 const config = useRuntimeConfig()
 

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -21,7 +21,12 @@
 </template>
 
 <script setup>
+import { setupDevtoolsPlugin } from '@vue/devtools-api'
 import { useRuntimeConfig } from '#imports'
+
+if (useRuntimeConfig().enableDevtools) {
+  setupDevtoolsPlugin()
+}
 
 const config = useRuntimeConfig()
 

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -24,7 +24,7 @@
 import { setupDevtoolsPlugin } from '@vue/devtools-api'
 import { useRuntimeConfig } from '#imports'
 
-setupDevtoolsPlugin()
+setupDevtoolsPlugin({}, () => {})
 
 const config = useRuntimeConfig()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10191,6 +10191,7 @@ __metadata:
     untyped: ^0.4.5
     vue: ^3.2.37
     vue-bundle-renderer: ^0.4.2
+    vue-devtools-stub: ^0.1.0
     vue-meta: next
     vue-router: ^4.1.3
   bin:
@@ -13681,6 +13682,13 @@ __metadata:
     vue-demi-fix: bin/vue-demi-fix.js
     vue-demi-switch: bin/vue-demi-switch.js
   checksum: b5e348d2e9e83207a69fe1362fcfbf99dab34db9591202f2a2f394b9693860c506d865440b7ee8f0277d67e5e7a4b0ff5326a1b8b955a4b98261b1e1df13e189
+  languageName: node
+  linkType: hard
+
+"vue-devtools-stub@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "vue-devtools-stub@npm:0.1.0"
+  checksum: 3f19fa2ab6d7f65de459f6c10d8f1d682dcd4ac55934c37617423d4a70efb98aa0a35f290120ec0c429ddcc0bdb7458836f87763ee0b8acfe007e4869f67dbbb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/4325

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When `@vue/devtools-api` is imported in an ESM module (as in pinia), our cjs proxy doesn't work. Thanks to @pi0, we now have a standalone stub we can use that works in both ESM + CJS contexts.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

