### PR TITLE
fix(vite): dedupe `vue` in client bundle

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -26,10 +26,7 @@ export default {
       })
     },
     resolve: {
-      extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
-      resolve: {
-        dedupe: ['vue']
-      }
+      extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue']
     },
     publicDir: {
       $resolve: (val, get) => val ?? resolve(get('srcDir'), get('dir').public)

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -26,7 +26,10 @@ export default {
       })
     },
     resolve: {
-      extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue']
+      extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
+      resolve: {
+        dedupe: ['vue']
+      }
     },
     publicDir: {
       $resolve: (val, get) => val ?? resolve(get('srcDir'), get('dir').public)

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -44,9 +44,7 @@ export async function buildClient (ctx: ViteBuildContext) {
         '#build/plugins': resolve(ctx.nuxt.options.buildDir, 'plugins/client'),
         '#internal/nitro': resolve(ctx.nuxt.options.buildDir, 'nitro.client.mjs')
       },
-      resolve: {
-        dedupe: ['vue']
-      }
+      dedupe: ['vue']
     },
     build: {
       manifest: true,

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -43,6 +43,9 @@ export async function buildClient (ctx: ViteBuildContext) {
       alias: {
         '#build/plugins': resolve(ctx.nuxt.options.buildDir, 'plugins/client'),
         '#internal/nitro': resolve(ctx.nuxt.options.buildDir, 'nitro.client.mjs')
+      },
+      resolve: {
+        dedupe: ['vue']
       }
     },
     build: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #6720, also see https://github.com/nuxt/framework/issues/4084

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enables vite's dedupe functionality for vue, where we definitely want to ensure we have a single instance bundled. A previous issue with this plugin (where it emitted CJS code) seems to have been resolved in Vite 3.

**Edit**: enabling only for client.

~~It injects the following code in the server bundle:~~

https://github.com/vitejs/vite/blob/9e9cd23763c96020cdf1807334368e038f61ad01/packages/vite/src/node/plugins/ssrRequireHook.ts#L53-L71

~~We can alternatively enable this only for the client bundle. WDYT @pi0?~~

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

