### PR TITLE
docs: fix typo in `defineEventHandler` example

### DIFF
--- a/docs/content/2.guide/2.features/9.server-routes.md
+++ b/docs/content/2.guide/2.features/9.server-routes.md
@@ -266,7 +266,7 @@ export default defineEventHandler(async (event) => {
 Create a new file in `server/api/test.get.ts`:
 
 ```ts [server/api/test.get.ts]
-export default async defineEventHandler(async (event) => {
+export default defineEventHandler(async (event) => {
   const data = await useStorage().getItem('redis:test')
   return data
 })


### PR DESCRIPTION
```
export default anync( should delete ) defineEventHandler(async (event) => {
  const data = await useStorage().getItem('redis:test')
  return data
})
```
This function should not be called with async。

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

