### PR TITLE
feat(nuxt): allow `useAppConfig` with specific key

### DIFF
--- a/docs/content/2.guide/2.features/10.app-config.md
+++ b/docs/content/2.guide/2.features/10.app-config.md
@@ -42,7 +42,7 @@ console.log(themeConfig)
 ```
 
 ::alert{type=warning}
-Destructuring `appConfig` causes it to loose reactivity. Always use `computed` or provide key to access a sub-key.
+Destructuring `appConfig` causes it to lose reactivity. Always use `computed` or provide key to access a sub-key.
 ::
 
 <!-- TODO: Document module author for extension -->

--- a/docs/content/2.guide/2.features/10.app-config.md
+++ b/docs/content/2.guide/2.features/10.app-config.md
@@ -23,13 +23,27 @@ export default defineAppConfig({
 })
 ```
 
-When adding `theme` to the `app.config`, Nuxt uses Vite or Webpack to bundle the code. We can universally access `theme` in both server and browser using [useAppConfig](/api/composables/use-app-config) composable.
+When adding `theme` to the `app.config`, Nuxt uses Vite or Webpack to bundle the code to both Server and client bundles.
+
+In order to access the runtime config value, we can  [useAppConfig](/api/composables/use-app-config) composable. Returned value is a reactive object.
 
 ```js
 const appConfig = useAppConfig()
 
 console.log(appConfig.theme)
 ```
+
+Or if you need to access a sub-key:
+
+```js
+const themeConfig = useAppConfig('theme')
+
+console.log(themeConfig)
+```
+
+::alert{type=warning}
+Destructuring `appConfig` causes it to loose reactivity. Always use `computed` or provide key to access a sub-key.
+::
 
 <!-- TODO: Document module author for extension -->
 

--- a/docs/content/3.api/1.composables/use-app-config.md
+++ b/docs/content/3.api/1.composables/use-app-config.md
@@ -8,9 +8,11 @@ Access [app config](/guide/features/app-config):
 **Usage:**
 
 ```js
+// Access whole app config (reactive object)
 const appConfig = useAppConfig()
 
-console.log(appConfig)
+// Access sub key of app-config (still reactive)
+const themeConfig = useAppConfig('theme')
 ```
 
 ::ReadMore{link="/guide/features/app-config"}

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from '@nuxt/schema'
-import { reactive, computed } from 'vue'
+import { reactive, toRef } from 'vue'
 import { useNuxtApp } from './nuxt'
 // @ts-ignore
 import __appConfig from '#build/app.config.mjs'
@@ -13,7 +13,7 @@ export function useAppConfig (key?: string): AppConfig {
     nuxtApp._appConfig = reactive(__appConfig) as AppConfig
   }
   if (key) {
-    return computed(() => nuxtApp._appConfig[key])
+    return reactive(toRef(nuxtApp._appConfig, key))
   }
   return nuxtApp._appConfig
 }

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from '@nuxt/schema'
-import { reactive } from 'vue'
+import { reactive, computed } from 'vue'
 import { useNuxtApp } from './nuxt'
 // @ts-ignore
 import __appConfig from '#build/app.config.mjs'
@@ -7,10 +7,13 @@ import __appConfig from '#build/app.config.mjs'
 // Workaround for vite HMR with virtual modules
 export const _getAppConfig = () => __appConfig as AppConfig
 
-export function useAppConfig (): AppConfig {
+export function useAppConfig (key?: string): AppConfig {
   const nuxtApp = useNuxtApp()
   if (!nuxtApp._appConfig) {
     nuxtApp._appConfig = reactive(__appConfig) as AppConfig
+  }
+  if (key) {
+    return computed(() => nuxtApp._appConfig[key])
   }
   return nuxtApp._appConfig
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: #6333

`useAppConfig` returns a reactive object but it is super easy to loose reactivity when restructuring it's interface like `const theme = useAppConfig().theme` is not reactive anymore to accept HMR.

This PR adds a simple addition using computed for one top-level key.

Todo:
- [ ] Type support
- [ ] Reactivity without `.value`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

