### PR TITLE
fix(nuxt): ensure component helper methods do not create side-effects

### DIFF
--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -7,7 +7,7 @@ import MagicString from 'magic-string'
 import { pascalCase } from 'scule'
 
 interface LoaderOptions {
-  getComponents(): Component[]
+  getComponents (): Component[]
   mode: 'server' | 'client'
   sourcemap?: boolean
   transform?: ComponentsOptions['transform']
@@ -76,11 +76,11 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => {
           }
           if (lazy) {
             imports.add(genImport('vue', [{ name: 'defineAsyncComponent', as: '__defineAsyncComponent' }]))
-            imports.add(`const ${identifier}_lazy = __defineAsyncComponent(${genDynamicImport(component.filePath)})`)
-            return isClientOnly ? `createClientOnly(${identifier}_lazy)` : `${identifier}_lazy`
+            imports.add(`const ${identifier}_lazy = /*#__PURE__*/ __defineAsyncComponent(${genDynamicImport(component.filePath)})`)
+            return isClientOnly ? `/*#__PURE__*/ createClientOnly(${identifier}_lazy)` : `${identifier}_lazy`
           } else {
             imports.add(genImport(component.filePath, [{ name: component.export, as: identifier }]))
-            return isClientOnly ? `createClientOnly(${identifier})` : identifier
+            return isClientOnly ? `/*#__PURE__*/ createClientOnly(${identifier})` : identifier
           }
         }
         // no matched


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #6781

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Lazy components (defined with `defineAsyncComponent`) were marked as having a side effect, so were persisting into the routes bundle. We should certainly not be including async component _statements_ within the entry bundle, which _also had_ the effect of marking them as dependencies of the entry rather than the page they correspond to (resulting in over-prefetching - see https://github.com/nuxt/framework/issues/6638).

---

Note that I encountered this when debugging what I believe to be an upstream rollup bug that I'm still looking into, which is difficult to reproduce but essentially boils down to two modules which each contain:

```js
defineAsyncComponent(() => __vitePreload(() => import('./Text.3d3cd0e1.js'),true?"__VITE_PRELOAD__":void 0,import.meta.url));
const meta = undefined;
```

being transformed into:

```js
defineAsyncComponent(() => __vitePreload(() => import('./Text.3d3cd0e1.js'),true?"__VITE_PRELOAD__":void 0,import.meta$1.url));
const meta$1 = undefined;

defineAsyncComponent(() => __vitePreload(() => import('./Text.3d3cd0e1.js'),true?"__VITE_PRELOAD__":void 0,import.meta.url));
const meta = undefined;
```

(This seems like an over-zealous search + replace on the part of rollup.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

