### PR TITLE
feat!(schema): enable external vue by default

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -18,7 +18,7 @@ export default {
      * Externalize `vue`, `@vue/*` and `vue-router` when building.
      * @see https://github.com/nuxt/framework/issues/4084
      */
-    externalVue: false,
+    externalVue: true,
 
     /**
      * Tree shakes contents of client-only components from server bundle.
@@ -49,6 +49,6 @@ export default {
      *
      * @see https://github.com/nuxt/framework/issues/6432
      */
-     viteServerDynamicImports: true
+    viteServerDynamicImports: true
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4084

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enables external vue by default on edge releases. Instead, it can be disabled by setting `experimental.externalVue` to `false`. Before RC, we can then remove the flag entirely.

I have tested on a few projects (small + large projects, no monorepo, a module's playground) with no issues, but some issues might be expected, particularly in complex projects with multiple vue component libraries. Feedback is particularly welcome. Please feel free to tag me in a new issue if you encounter any problems.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

