### PR TITLE
feat(nuxt): `app.config` improvements

### DIFF
--- a/docs/content/3.api/1.composables/update-app-config.md
+++ b/docs/content/3.api/1.composables/update-app-config.md
@@ -1,0 +1,20 @@
+# `updateAppConfig`
+
+::StabilityEdge
+::
+
+Updates [app config](/guide/features/app-config):
+
+**Usage:**
+
+```js
+const appConfig = useAppConfig() // { foo: 'bar' }
+
+const newAppConfig = { foo: 'baz' }
+
+updateAppConfig(newAppConfig)
+
+console.log(appConfig) // { foo: 'baz' }
+```
+
+::ReadMore{link="/guide/features/app-config"}

--- a/docs/content/3.api/1.composables/update-app-config.md
+++ b/docs/content/3.api/1.composables/update-app-config.md
@@ -3,7 +3,7 @@
 ::StabilityEdge
 ::
 
-Updates [app config](/guide/features/app-config):
+Updates [app config](/guide/features/app-config) using deep assignment. Existing (nested) properties will be preserved. 
 
 **Usage:**
 

--- a/docs/content/3.api/1.composables/update-app-config.md
+++ b/docs/content/3.api/1.composables/update-app-config.md
@@ -3,7 +3,7 @@
 ::StabilityEdge
 ::
 
-Updates [app config](/guide/features/app-config) using deep assignment. Existing (nested) properties will be preserved. 
+Updates [app config](/guide/features/app-config) using deep assignment. Existing (nested) properties will be preserved.
 
 **Usage:**
 

--- a/examples/advanced/config-extends/app.config.ts
+++ b/examples/advanced/config-extends/app.config.ts
@@ -1,5 +1,20 @@
 export default defineAppConfig({
   foo: 'user',
   bar: 'user',
-  baz: 'base'
+  baz: 'base',
+  array: [
+    'user',
+    'user',
+    'user'
+  ],
+  arrayNested: {
+    nested: {
+      key: 'user',
+      array: [
+        'user',
+        'user',
+        'user'
+      ]
+    }
+  }
 })

--- a/examples/advanced/config-extends/app.config.ts
+++ b/examples/advanced/config-extends/app.config.ts
@@ -6,15 +6,5 @@ export default defineAppConfig({
     'user',
     'user',
     'user'
-  ],
-  arrayNested: {
-    nested: {
-      key: 'user',
-      array: [
-        'user',
-        'user',
-        'user'
-      ]
-    }
-  }
+  ]
 })

--- a/examples/advanced/config-extends/base/app.config.ts
+++ b/examples/advanced/config-extends/base/app.config.ts
@@ -1,7 +1,7 @@
 export default defineAppConfig({
   bar: 'base',
   baz: 'base',
-  array: [
+  array: () => [
     'base',
     'base',
     'base'

--- a/examples/advanced/config-extends/base/app.config.ts
+++ b/examples/advanced/config-extends/base/app.config.ts
@@ -1,4 +1,18 @@
 export default defineAppConfig({
   bar: 'base',
-  baz: 'base'
+  baz: 'base',
+  array: [
+    'base',
+    'base',
+    'base'
+  ],
+  arrayNested: {
+    nested: {
+      array: [
+        'base',
+        'base',
+        'base'
+      ]
+    }
+  }
 })

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -21,10 +21,18 @@ if (process.dev) {
     const appConfig = useAppConfig()
     if (newConfig && appConfig) {
       deepAssign(appConfig, newConfig)
-      for (const key in appConfig) {
-        if (!(key in newConfig)) {
-          delete (appConfig as any)[key]
-        }
+      deepDelete(appConfig, newConfig)
+    }
+  }
+
+  function deepDelete (obj: any, newObj: any) {
+    for (const key in obj) {
+      if (!(key in newObj)) {
+        delete (obj as any)[key]
+      }
+
+      if (typeof obj[key] === 'object' && newObj[key]) {
+        deepDelete(obj[key], newObj[key])
       }
     }
   }

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -18,6 +18,7 @@ function deepDelete (obj: any, newObj: any) {
     }
   }
 }
+
 function deepAssign (obj: any, newObj: any) {
   for (const key in newObj) {
     const val = newObj[key]

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -7,12 +7,55 @@ import __appConfig from '#build/app.config.mjs'
 // Workaround for vite HMR with virtual modules
 export const _getAppConfig = () => __appConfig as AppConfig
 
+function deepDelete (obj: any, newObj: any) {
+  for (const key in obj) {
+    if (!(key in newObj)) {
+      delete (obj as any)[key]
+    }
+
+    if (typeof obj[key] === 'object' && newObj[key]) {
+      deepDelete(obj[key], newObj[key])
+    }
+  }
+}
+function deepAssign (obj: any, newObj: any) {
+  for (const key in newObj) {
+    const val = newObj[key]
+    if (val !== null && typeof val === 'object') {
+      deepAssign(obj[key], val)
+    } else {
+      obj[key] = val
+    }
+  }
+}
+
 export function useAppConfig (): AppConfig {
   const nuxtApp = useNuxtApp()
   if (!nuxtApp._appConfig) {
     nuxtApp._appConfig = reactive(__appConfig) as AppConfig
   }
   return nuxtApp._appConfig
+}
+
+/**
+ * Deep assign the current appConfig with the new one.
+ *
+ * Will preserve existing properties.
+ */
+export function updateAppConfig (appConfig: Partial<AppConfig>) {
+  const nuxtApp = useNuxtApp()
+  if (!nuxtApp._appConfig) {
+    nuxtApp._appConfig = reactive(__appConfig) as AppConfig
+  }
+  deepAssign(nuxtApp._appConfig, appConfig)
+}
+
+/**
+ * Overwrites the current app config with the new one.
+ */
+export function setAppConfig (appConfig: AppConfig) {
+  const nuxtApp = useNuxtApp()
+  nuxtApp._appConfig = appConfig
 }
 
 // HMR Support
@@ -22,29 +65,6 @@ if (process.dev) {
     if (newConfig && appConfig) {
       deepAssign(appConfig, newConfig)
       deepDelete(appConfig, newConfig)
-    }
-  }
-
-  function deepDelete (obj: any, newObj: any) {
-    for (const key in obj) {
-      if (!(key in newObj)) {
-        delete (obj as any)[key]
-      }
-
-      if (typeof obj[key] === 'object' && newObj[key]) {
-        deepDelete(obj[key], newObj[key])
-      }
-    }
-  }
-
-  function deepAssign (obj: any, newObj: any) {
-    for (const key in newObj) {
-      const val = newObj[key]
-      if (val !== null && typeof val === 'object') {
-        deepAssign(obj[key], val)
-      } else {
-        obj[key] = val
-      }
     }
   }
 

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -44,19 +44,8 @@ export function useAppConfig (): AppConfig {
  * Will preserve existing properties.
  */
 export function updateAppConfig (appConfig: Partial<AppConfig>) {
-  const nuxtApp = useNuxtApp()
-  if (!nuxtApp._appConfig) {
-    nuxtApp._appConfig = reactive(__appConfig) as AppConfig
-  }
-  deepAssign(nuxtApp._appConfig, appConfig)
-}
-
-/**
- * Overwrites the current app config with the new one.
- */
-export function setAppConfig (appConfig: AppConfig) {
-  const nuxtApp = useNuxtApp()
-  nuxtApp._appConfig = appConfig
+  const _appConfig = useAppConfig()
+  deepAssign(_appConfig, appConfig)
 }
 
 // HMR Support

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -4,16 +4,19 @@ import { useNuxtApp } from './nuxt'
 // @ts-ignore
 import __appConfig from '#build/app.config.mjs'
 
+type DeepPartial<T> = T extends Function ? T : T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> } : T
+
 // Workaround for vite HMR with virtual modules
 export const _getAppConfig = () => __appConfig as AppConfig
 
 function deepDelete (obj: any, newObj: any) {
   for (const key in obj) {
+    const val = newObj[key]
     if (!(key in newObj)) {
       delete (obj as any)[key]
     }
 
-    if (typeof obj[key] === 'object' && newObj[key]) {
+    if (val !== null && typeof val === 'object') {
       deepDelete(obj[key], newObj[key])
     }
   }
@@ -43,7 +46,7 @@ export function useAppConfig (): AppConfig {
  *
  * Will preserve existing properties.
  */
-export function updateAppConfig (appConfig: Partial<AppConfig>) {
+export function updateAppConfig (appConfig: DeepPartial<AppConfig>) {
   const _appConfig = useAppConfig()
   deepAssign(_appConfig, appConfig)
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -207,13 +207,13 @@ export const appConfigTemplate: NuxtTemplate = {
   write: true,
   getContents: ({ app, nuxt }) => {
     return `
-import { defuArrayFn } from 'defu'
+import { defuFn } from 'defu'
 
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 
 ${app.configs.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id)}`).join('\n')}
 
-export default defuArrayFn(${app.configs.map((_id: string, index: number) => `cfg${index}`).concat(['inlineConfig']).join(', ')})
+export default defuFn(${app.configs.map((_id: string, index: number) => `cfg${index}`).concat(['inlineConfig']).join(', ')})
 `
   }
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -207,12 +207,20 @@ export const appConfigTemplate: NuxtTemplate = {
   write: true,
   getContents: ({ app, nuxt }) => {
     return `
-import defu from 'defu'
+import { createDefu } from 'defu'
 
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 
 ${app.configs.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id)}`).join('\n')}
-export default defu(${app.configs.map((_id: string, index: number) => `cfg${index}`).concat(['inlineConfig']).join(', ')})
+
+const merge = createDefu((obj, key, value) => {
+  if (obj[key] && Array.isArray(obj[key])) {
+    obj[key] = value
+    return true
+  }
+})
+
+export default merge(${app.configs.map((_id: string, index: number) => `cfg${index}`).concat(['inlineConfig']).join(', ')})
 `
   }
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -207,20 +207,13 @@ export const appConfigTemplate: NuxtTemplate = {
   write: true,
   getContents: ({ app, nuxt }) => {
     return `
-import { createDefu } from 'defu'
+import { defuArrayFn } from 'defu'
 
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 
 ${app.configs.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id)}`).join('\n')}
 
-const merge = createDefu((obj, key, value) => {
-  if (obj[key] && Array.isArray(obj[key])) {
-    obj[key] = value
-    return true
-  }
-})
-
-export default merge(${app.configs.map((_id: string, index: number) => `cfg${index}`).concat(['inlineConfig']).join(', ')})
+export default defuArrayFn(${app.configs.map((_id: string, index: number) => `cfg${index}`).concat(['inlineConfig']).join(', ')})
 `
   }
 }

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -51,6 +51,8 @@ const appPreset = defineUnimportPreset({
     'createError',
     'defineNuxtLink',
     'useAppConfig',
+    'setAppConfig',
+    'updateAppConfig',
     'defineAppConfig',
     'preloadComponents',
     'prefetchComponents'

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -51,7 +51,6 @@ const appPreset = defineUnimportPreset({
     'createError',
     'defineNuxtLink',
     'useAppConfig',
-    'setAppConfig',
     'updateAppConfig',
     'defineAppConfig',
     'preloadComponents',


### PR DESCRIPTION
### 🔗 Linked issue

#6832

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves:
- [X] Use defu.arrayFn to allow overrriding arrays in multi-layer format
   - In c54292b17f56609e81fecea29eafcbf01f303ea9 I implemented it how it was made in [@nuxt-themes/kit](https://github.com/nuxt-themes/config/blob/main/src/utils.ts#L47-L53)
   - In 1b07424dce819355e2d479bf73639cb70e2e3289 I implemented it using `arrayFn` as suggested in #6832
      - Leads to strange behaviors with HMR (array keys going `null` when going from a play array to function format)
   - I would say that overwriting is **expected** behavior in this kind of config, and that `function` format seem to introduce a bit of overhead for the user to understand when reading config files.
- [X] Fixed an issue in which deep keys were not properly deleted on HMR, as seen [here](https://github.com/nuxt/framework/blob/main/packages/nuxt/src/app/config.ts#L24-L28).
	- This portion of codes properly deepAssign on changes, but does not delete existing keys
	- [Reproduction](https://stackblitz.com/edit/nuxt-starter-rsskjr?file=package.json,app.vue,app.config.ts)
- [X] Implement [updateAppConfig](https://github.com/nuxt/framework/commit/bdd222a85341de5cccb18cd29002efe30629e33c#diff-421426fc478e91dfcb94a9b4a10fa8c38e6c30a0546606fe7a6baaf05837adf8R45-R51) composable

Few notes about this:

I've seen appConfig merging occurs in built template [here](https://github.com/nuxt/framework/blob/main/packages/nuxt/src/core/templates.ts#L205-L218), considering that, what is the proper way to implement features that needs to have access to the fully merged app config file inside Nuxt?

In #6832, there is mentions to:
> - Use untyped to (auto)generate types from appConfig instead of defu
> - Support _schema (global config) [needs new issue to track]

I would love to help on these issues but need guidance on how to resolve the whole appConfig object from Nuxt side, in order to generate typings from it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.

