### PR TITLE
chore: add `dev:preview` for playground preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cleanup": "rimraf 'packages/**/node_modules' 'examples/**/node_modules' 'node_modules'",
     "dev": "yarn run nuxi dev playground",
     "dev:build": "yarn run nuxi build playground",
-    "dev:start": "yarn run nuxi start playground",
+    "dev:preview": "yarn run nuxi preview playground",
     "example": "yarn workspace example-$0 dev",
     "example:build": "yarn workspace example-$0 build",
     "lint": "eslint --ext .vue,.ts,.js,.mjs .",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cleanup": "rimraf 'packages/**/node_modules' 'examples/**/node_modules' 'node_modules'",
     "dev": "yarn run nuxi dev playground",
     "dev:build": "yarn run nuxi build playground",
+    "dev:start": "yarn run nuxi start playground",
     "example": "yarn workspace example-$0 dev",
     "example:build": "yarn workspace example-$0 build",
     "lint": "eslint --ext .vue,.ts,.js,.mjs .",


### PR DESCRIPTION
Add `playground` preview
See the packaged preview
```ts
"dev:start": "yarn run nuxi start playground",
```

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

