### PR TITLE
fix(kit): normalize (sort) aliases before resolving

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -2,6 +2,7 @@ import { promises as fsp, existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { basename, dirname, resolve, join, normalize, isAbsolute } from 'pathe'
 import { globby } from 'globby'
+import { normalizeAliases } from 'pathe/utils'
 import { tryUseNuxt, useNuxt } from './context'
 import { tryResolveModule } from './internal/cjs'
 import { isIgnored } from './ignore'
@@ -105,7 +106,7 @@ export function resolveAlias (path: string, alias?: Record<string, string>): str
   if (!alias) {
     alias = tryUseNuxt()?.options.alias || {}
   }
-  for (const key in alias) {
+  for (const key in normalizeAliases(alias)) {
     if (key === '@' && !path.startsWith('@/')) { continue } // Don't resolve @foo/bar
     if (path.startsWith(key)) {
       path = alias[key] + path.slice(key.length)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7008

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We've already improved Nitro alias handling with some utils from `pathe`: https://github.com/unjs/pathe/pull/34.

This PR does the same before resolving aliases with kit. (Meaning it can be used with Bridge also.) We can also look at normalizing aliases we pass to vite + webpack in a follow-up PR, but that probably needs a little more testing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

