### PR TITLE
fix(vite): remove client manifest.json from public dir

### DIFF
--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -52,4 +52,8 @@ export async function writeManifest (ctx: ViteBuildContext, css: string[] = []) 
 
   await fse.writeFile(resolve(serverDist, 'client.manifest.json'), JSON.stringify(manifest, null, 2), 'utf8')
   await fse.writeFile(resolve(serverDist, 'client.manifest.mjs'), 'export default ' + JSON.stringify(manifest, null, 2), 'utf8')
+
+  if (!ctx.nuxt.options.dev) {
+    fse.removeSync(resolve(clientDist, 'manifest.json'))
+  }
 }

--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -54,6 +54,6 @@ export async function writeManifest (ctx: ViteBuildContext, css: string[] = []) 
   await fse.writeFile(resolve(serverDist, 'client.manifest.mjs'), 'export default ' + JSON.stringify(manifest, null, 2), 'utf8')
 
   if (!ctx.nuxt.options.dev) {
-    fse.removeSync(resolve(clientDist, 'manifest.json'))
+    await fse.rm(resolve(clientDist, 'manifest.json'), { force: true })
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #7020

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, vite manifest gets accidentally included in public assets dir. It is not used and the data within it is incorrect (i.e. non-normalised)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

