### PR TITLE
fix(nuxt): use shared state for asyncData

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -114,11 +114,16 @@ export function useAsyncData<
 
   const useInitialCache = () => (nuxt.isHydrating || options.initialCache) && nuxt.payload.data[key] !== undefined
 
-  const asyncData = {
-    data: ref(useInitialCache() ? nuxt.payload.data[key] : options.default?.() ?? null),
-    pending: ref(!useInitialCache()),
-    error: ref(nuxt.payload._errors[key] ?? null)
-  } as AsyncData<DataT, DataE>
+  // Create or use a shared asyncData entity
+  if (!nuxt._asyncData[key]) {
+    nuxt._asyncData[key] = {
+      data: ref(useInitialCache() ? nuxt.payload.data[key] : options.default?.() ?? null),
+      pending: ref(!useInitialCache()),
+      error: ref(nuxt.payload._errors[key] ?? null)
+    }
+  }
+  // TODO: Else, Soemhow check for confliciting keys with different defaults or fetcher
+  const asyncData = { ...nuxt._asyncData[key] } as AsyncData<DataT, DataE>
 
   asyncData.refresh = (opts = {}) => {
     // Avoid fetching same key more than once at a time

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define */
-import { getCurrentInstance, reactive } from 'vue'
+import { getCurrentInstance, reactive, Ref } from 'vue'
 import type { App, onErrorCaptured, VNode } from 'vue'
 import { createHooks, Hookable } from 'hookable'
 import type { RuntimeConfig, AppConfigInput } from '@nuxt/schema'
@@ -66,6 +66,11 @@ interface _NuxtApp {
   [key: string]: any
 
   _asyncDataPromises: Record<string, Promise<any> | undefined>
+  _asyncData: Record<string, {
+    data: Ref<any>
+    pending: Ref<boolean>
+    error: Ref<any>
+   }>,
 
   ssrContext?: NuxtSSRContext
   payload: {
@@ -113,6 +118,7 @@ export function createNuxtApp (options: CreateOptions) {
     }),
     isHydrating: process.client,
     _asyncDataPromises: {},
+    _asyncData: {},
     ...options
   } as any as NuxtApp
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -527,3 +527,21 @@ describe('app config', () => {
     expect(html).toContain(JSON.stringify(expectedAppConfig))
   })
 })
+
+describe('useAsyncData', () => {
+  it('single request resolves', async () => {
+    await expectNoClientErrors('/useAsyncData/single')
+  })
+
+  it('two requests resolve', async () => {
+    await expectNoClientErrors('/useAsyncData/double')
+  })
+
+  it('two requests resolve and sync', async () => {
+    await $fetch('/useAsyncData/refresh')
+  })
+
+  it('two requests made at once resolve and sync', async () => {
+    await expectNoClientErrors('/useAsyncData/promise-all')
+  })
+})

--- a/test/fixtures/basic/composables/asyncDataTests.ts
+++ b/test/fixtures/basic/composables/asyncDataTests.ts
@@ -1,0 +1,7 @@
+export const useSleep = () => useAsyncData('sleep', async () => {
+  await new Promise(resolve => setTimeout(resolve, 50))
+
+  return 'Slept!'
+})
+
+export const useCounter = () => useFetch('/api/useAsyncData/count')

--- a/test/fixtures/basic/pages/useAsyncData/double.vue
+++ b/test/fixtures/basic/pages/useAsyncData/double.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    Single
+    <div>
+      data1: {{ data1 }}
+      data2: {{ data2 }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { data: data1 } = await useSleep()
+const { data: data2 } = await useSleep()
+
+if (data1.value === null || data1.value === undefined || data1.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (data2.value === null || data2.value === undefined || data2.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (data1.value !== data2.value) {
+  throw new Error('AsyncData not synchronised')
+}
+</script>

--- a/test/fixtures/basic/pages/useAsyncData/promise-all.vue
+++ b/test/fixtures/basic/pages/useAsyncData/promise-all.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    Single
+    <div>
+      data1: {{ result1.data.value }}
+      data2: {{ result2.data.value }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const [result1, result2] = await Promise.all([useSleep(), useSleep()])
+
+if (result1.data.value === null || result1.data.value === undefined || result1.data.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (result2.data.value === null || result2.data.value === undefined || result2.data.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+
+if (result1.data.value !== result2.data.value) {
+  throw new Error('AsyncData not synchronised')
+}
+
+await result1.refresh()
+
+if (result1.data.value !== result2.data.value) {
+  throw new Error('AsyncData not synchronised')
+}
+</script>

--- a/test/fixtures/basic/pages/useAsyncData/refresh.vue
+++ b/test/fixtures/basic/pages/useAsyncData/refresh.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    Single
+    <div>
+      {{ data }} - {{ data2 }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { data, refresh } = await useCounter()
+const { data: data2, refresh: refresh2 } = await useCounter()
+
+let inital = data.value.count
+
+// Refresh on client and server side
+await refresh()
+
+if (data.value.count !== inital + 1) {
+  throw new Error('Data not refreshed?' + data.value.count + ' : ' + data2.value.count)
+}
+
+if (data.value.count !== data2.value.count) {
+  throw new Error('AsyncData not synchronised')
+}
+
+inital = data.value.count
+
+await refresh2()
+
+if (data.value.count !== inital + 1) {
+  throw new Error('data2 refresh not syncronised?')
+}
+
+if (data.value.count !== data2.value.count) {
+  throw new Error('AsyncData not synchronised')
+}
+
+</script>

--- a/test/fixtures/basic/pages/useAsyncData/single.vue
+++ b/test/fixtures/basic/pages/useAsyncData/single.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    Single
+    <div>
+      {{ data }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { data } = await useSleep()
+
+if (data.value === null || data.value === undefined || data.value.length <= 0) {
+  throw new Error('Data should never be null or empty.')
+}
+</script>

--- a/test/fixtures/basic/server/api/useAsyncData/count.ts
+++ b/test/fixtures/basic/server/api/useAsyncData/count.ts
@@ -1,0 +1,3 @@
+let counter = 0
+
+export default () => ({ count: counter++ })


### PR DESCRIPTION
### 🔗 Linked issue

#4758 #5078 #5738

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With the initial implementation of `useAyncData`, we were using a shared promise to avoid running two asyncData promises with the same key at the same time but the fetching state and data was not shared. It makes problems if someone tries to make a higher-order composable that **returns a new instance of asyncData with the same key**.

This PR resolves it using a shared `_asyncData` map in nuxtApp interface also adding tests from #5738 by @OhB00.

**Remarks:**

We probably can iterate over this. Normally each useAsyncData should be **unique** based on its key and a factory pattern shall be introduced for `createAsyncData` and `createFetch` (discussion: #7026)

I will follow up with more PRs to have proper changelog.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

