### PR TITLE
fix(vite): sanitize client asset chunk names

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -8,6 +8,9 @@ import { getPort } from 'get-port-please'
 import { joinURL, withLeadingSlash, withoutLeadingSlash, withTrailingSlash } from 'ufo'
 import escapeRE from 'escape-string-regexp'
 import defu from 'defu'
+import { sanitizeFilePath } from 'mlly'
+import { filename } from 'pathe/utils'
+import type { OutputOptions } from 'rollup'
 import { cacheDirPlugin } from './plugins/cache-dir'
 import { wpfs } from './utils/wpfs'
 import type { ViteBuildContext, ViteOptions } from './vite'
@@ -76,14 +79,16 @@ export async function buildClient (ctx: ViteBuildContext) {
   }
 
   // We want to respect users' own rollup output options
-  ctx.config.build!.rollupOptions = defu(ctx.config.build!.rollupOptions!, {
+  clientConfig.build!.rollupOptions = defu(clientConfig.build!.rollupOptions!, {
     output: {
       // https://github.com/vitejs/vite/tree/main/packages/vite/src/node/build.ts#L464-L478
-      assetFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].[ext]')),
+      assetFileNames: ctx.nuxt.options.dev
+        ? undefined
+        : chunk => withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, `${sanitizeFilePath(filename(chunk.name!))}.[hash].[ext]`)),
       chunkFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js')),
       entryFileNames: ctx.nuxt.options.dev ? 'entry.js' : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js'))
-    }
-  })
+    } as OutputOptions
+  }) as any
 
   if (clientConfig.server && clientConfig.server.hmr !== false) {
     const hmrPortDefault = 24678 // Vite's default HMR port


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #7035

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This sanitizes asset filenames as well as chunks, and also fixes an issue where we were mutating the shared config (and therefore affecting server) but not the client.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

