### PR TITLE
perf(nuxt): don't prefetch all global components

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -130,6 +130,18 @@ export default defineNuxtModule<ComponentsOptions>({
       }
     })
 
+    // Do not prefetch global components chunks
+    nuxt.hook('build:manifest', (manifest) => {
+      const sourceFiles = getComponents().filter(c => c.global).map(c => relative(nuxt.options.srcDir, c.filePath))
+
+      for (const key in manifest) {
+        if (manifest[key].isEntry) {
+          manifest[key].dynamicImports =
+            manifest[key].dynamicImports?.filter(i => !sourceFiles.includes(i))
+        }
+      }
+    })
+
     // Scan components and add to plugin
     nuxt.hook('app:templates', async () => {
       const newComponents = await scanComponents(componentDirs, nuxt.options.srcDir!)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -380,6 +380,13 @@ describe('prefetching', () => {
   it('should prefetch components', async () => {
     await expectNoClientErrors('/prefetch/components')
   })
+  it('should not prefetch certain dynamic imports by default', async () => {
+    const html = await $fetch('/auth')
+    // should not prefetch global components
+    expect(html).not.toMatch(/<link [^>]*\/_nuxt\/TestGlobal[^>]*\.js"/)
+    // should not prefetch all other pages
+    expect(html).not.toMatch(/<link [^>]*\/_nuxt\/navigate-to[^>]*\.js"/)
+  })
 })
 
 if (process.env.NUXT_TEST_DEV) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #6876

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes global components from being prefetched by default. (They will still be preloaded if they are used on the page being rendered on the server.)

### 👉 Migration

This isn't a breaking change as such, but users who are heavily using dynamic/global components, such as with a catchall page rendering CMS content or page building libraries, will likely want to use the [`prefetchComponents`](https://v3.nuxtjs.org/api/composables/prefetch-components) and [`preloadComponents`](https://v3.nuxtjs.org/api/composables/preload-components#preloadcomponents) utilities. (At the moment they do the same thing, but should semantically match the difference between link preload/prefetch.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

