### PR TITLE
feat(nuxt): allow extending routes with custom alias

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -236,7 +236,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         ...Object.fromEntries(Object.entries(route).map(([key, value]) => [key, JSON.stringify(value)])),
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
-        alias: `${metaImportName}?.alias || []`,
+        alias: `[].concat(${metaImportName}?.alias || [], ${JSON.stringify(route.alias || [])})`,
         component: genDynamicImport(file, { interopDefault: true })
       }
     }))

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -232,11 +232,17 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const file = normalize(route.file)
       const metaImportName = genSafeVariableName(file) + 'Meta'
       metaImports.add(genImport(`${file}?macro=true`, [{ name: 'meta', as: metaImportName }]))
+
+      let aliasCode = `${metaImportName}?.alias || []`
+      if (Array.isArray(route.alias) && route.alias.length) {
+        aliasCode = `${JSON.stringify(route.alias)}.concat(${aliasCode})`
+      }
+
       return {
         ...Object.fromEntries(Object.entries(route).map(([key, value]) => [key, JSON.stringify(value)])),
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
-        alias: `[].concat(${metaImportName}?.alias || [], ${JSON.stringify(route.alias || [])})`,
+        alias: aliasCode,
         component: genDynamicImport(file, { interopDefault: true })
       }
     }))

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -42,6 +42,7 @@ export type NuxtPage = {
   path: string
   file: string
   meta?: Record<string, any>
+  alias?: string[]
   children?: NuxtPage[]
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add capability to setup alias in hook pages:extend or module like
I made sure we could keep `definedMeta` alias and **`pages:extend`** alias at the same time

Issue #7059 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

