### PR TITLE
fix(schema): sync types of vite v3.x

### DIFF
--- a/packages/schema/src/types/global/vite.ts
+++ b/packages/schema/src/types/global/vite.ts
@@ -20,15 +20,18 @@ export interface ViteHot {
 
 export interface ViteGlobOptions {
   as?: string
+  eager?: boolean
+  import?: string
+  query?: string | Record<string, string | number | boolean>
+  exhaustive?: boolean
 }
 
 export interface ViteImportMeta {
+  url: string
+
   /** Vite client HMR API - see https://vitejs.dev/guide/api-hmr.html */
   readonly hot?: ViteHot
 
   /** vite glob import utility - https://vitejs.dev/guide/features.html#glob-import */
-  glob?(pattern: string, options?: ViteGlobOptions): Record<string, () => Promise<Record<string, any>>>
-
-  /** vite glob import utility - https://vitejs.dev/guide/features.html#glob-import */
-  globEager?(pattern: string, options?: ViteGlobOptions): Record<string, Record<string, any>>
+  glob (glob: string | string[], options?: ViteGlobOptions): Record<string, () => Promise<Record<string, any>>>
 }

--- a/packages/schema/src/types/global/vite.ts
+++ b/packages/schema/src/types/global/vite.ts
@@ -27,8 +27,6 @@ export interface ViteGlobOptions {
 }
 
 export interface ViteImportMeta {
-  url: string
-
   /** Vite client HMR API - see https://vitejs.dev/guide/api-hmr.html */
   readonly hot?: ViteHot
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

1. `globEager` is [deprecated](https://vitejs.dev/guide/migration.html#general-changes)
2. add some types according to [latest types](https://github.com/vitejs/vite/blob/main/packages/vite/types/importGlob.d.ts)
3. `glob` will always exists in `import.meta`, I think there is no need to set it as an optional field here?
If we try to use optional chain in the code, it will break this feature in Vite 3:
```ts
// Works in Vite 2 but not in Vite 3
const result = import.meta.glob?.('assets/images/svg/**/*.svg')
console.log(result) // `undefined` in Vite 3

// Works fine
const result = import.meta.glob('assets/images/svg/**/*.svg')
console.log(result) // { '.../...svg': () => import(...) }
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

