### PR TITLE
fix(kit)!: handle prerelease constraint

### DIFF
--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -11,8 +11,9 @@ export async function checkNuxtCompatibility (constraints: NuxtCompatibility, nu
   // Nuxt version check
   if (constraints.nuxt) {
     const nuxtVersion = getNuxtVersion(nuxt)
-    const nuxtSemanticVersion = nuxtVersion.split('-').shift()
-    if (!satisfies(nuxtSemanticVersion, constraints.nuxt)) {
+    const nuxtSemanticVersion = nuxtVersion
+      .replace(/-[0-9]+\.[0-9a-f]{7}/, '') // Remove edge prefix
+    if (!satisfies(nuxtSemanticVersion, constraints.nuxt, { includePrerelease: true })) {
       issues.push({
         name: 'nuxt',
         message: `Nuxt version \`${constraints.nuxt}\` is required but currently using \`${nuxtVersion}\``


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #6699

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows modules to use constraints like `^3.0.0-rc.9`. Previously prerelease section were being ignored.

**Breaking change:** (module authors)

If your module was previously using `defineNuxtModule` from `@nuxt/kit` and constraint as `^3.0.0` it needs to be updated to `^3.0.0-rc.8` in order to work again. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

