### PR TITLE
chore: bump rc version for edge versions

### DIFF
--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process'
 import { $fetch } from 'ohmyfetch'
 import { resolve } from 'pathe'
 import { globby } from 'globby'
+import { inc } from 'semver'
 
 interface Dep {
   name: string,
@@ -107,7 +108,9 @@ async function main () {
   nuxtPkg.data.dependencies.nitropack = `npm:nitropack-edge@^${latestNitro}`
 
   for (const pkg of workspace.packages.filter(p => !p.data.private)) {
-    workspace.setVersion(pkg.data.name, `${pkg.data.version}-${date}.${commit}`)
+    // TODO: Set release type based on changelog after ^4.0.0
+    const newVersion = inc(pkg.data.version, 'prerelease', 'rc')
+    workspace.setVersion(pkg.data.name, `${newVersion}-${date}.${commit}`)
     const newname = pkg.data.name === 'nuxt' ? 'nuxt3' : (pkg.data.name + '-edge')
     workspace.rename(pkg.data.name, newname)
   }

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -108,7 +108,7 @@ async function main () {
   nuxtPkg.data.dependencies.nitropack = `npm:nitropack-edge@^${latestNitro}`
 
   for (const pkg of workspace.packages.filter(p => !p.data.private)) {
-    // TODO: Set release type based on changelog after ^4.0.0
+    // TODO: Set release type based on changelog after 3.0.0
     const newVersion = inc(pkg.data.version, 'prerelease', 'rc')
     workspace.setVersion(pkg.data.name, `${newVersion}-${date}.${commit}`)
     const newname = pkg.data.name === 'nuxt' ? 'nuxt3' : (pkg.data.name + '-edge')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently versions of edge channel are `{latestRC}-{hash}`. While they are actually for next RC. 

Remarks:
- We should change `prerelease` to semver type based on changelog after 3.0.0 
- As a related issue we should adjust version when internally developing framework. Needs few code bytes to kit to make happen (we were doing similar thing in Nuxt2)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

