### PR TITLE
feat(nuxi): display nuxt and nitro versions for dev and build commands

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -4,6 +4,7 @@ import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
 import { clearDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
+import { showVersions } from '../utils/banner'
 import { defineNuxtCommand } from './index'
 
 export default defineNuxtCommand({
@@ -16,6 +17,7 @@ export default defineNuxtCommand({
     overrideEnv('production')
 
     const rootDir = resolve(args._[0] || '.')
+    showVersions(rootDir)
 
     const { loadNuxt, buildNuxt } = await loadKit(rootDir)
 

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -7,7 +7,7 @@ import type { Nuxt } from '@nuxt/schema'
 import consola from 'consola'
 import { withTrailingSlash } from 'ufo'
 import { setupDotenv } from 'c12'
-import { showBanner } from '../utils/banner'
+import { showBanner, showVersions } from '../utils/banner'
 import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
 import { importModule } from '../utils/cjs'
@@ -38,6 +38,8 @@ export default defineNuxtCommand({
     }
 
     const rootDir = resolve(args._[0] || '.')
+    showVersions(rootDir)
+
     await setupDotenv({ cwd: rootDir })
 
     const listener = await listen(serverHandler, {

--- a/packages/nuxi/src/commands/info.ts
+++ b/packages/nuxi/src/commands/info.ts
@@ -63,6 +63,7 @@ export default defineNuxtCommand({
       OperatingSystem: os.type(),
       NodeVersion: process.version,
       NuxtVersion: nuxtVersion,
+      NitroVersion: getDepVersion('nitropack'),
       PackageManager: packageManager,
       Builder: builder,
       UserConfig: Object.keys(nuxtConfig).map(key => '`' + key + '`').join(', '),

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -19,7 +19,7 @@ export function showVersions (cwd: string) {
     } catch { /* not found */ }
     return ''
   }
-  const pkgs = ['nitropacl', 'vite', 'webpack', 'vue']
+  const pkgs = ['nitropack', 'vite', 'webpack', 'vue']
   console.log(
     green(getPkgWithVersion('nuxt') || getPkgWithVersion('nuxt-edge') /* bridge */ || 'nuxt'),
     gray('running with'),

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -5,23 +5,23 @@ import { version } from '../../package.json'
 
 export function showBanner (_clear?: boolean) {
   if (_clear) { clear() }
-  console.log(gray(`nuxi@${version}`))
+  console.log(gray(`Nuxi ${version}`))
 }
 
 export function showVersions (cwd: string) {
   const _require = createRequire(cwd)
-  const getPkgWithVersion = (pkg: string) => {
+  const getPkgWithVersion = (pkg: string, name: string) => {
     try {
       const { version } = _require(`${pkg}/package.json`)
       if (version) {
-        return pkg + '@' + version
+        return name + ' ' + version
       }
     } catch { /* not found */ }
     return pkg
   }
   console.log(
-    green(getPkgWithVersion('nuxt')),
+    green(getPkgWithVersion('nuxt', 'Nuxt')),
     gray('running with'),
-    gray(getPkgWithVersion('nitropack'))
+    gray(getPkgWithVersion('nitropack', 'Nitro'))
   )
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -5,7 +5,7 @@ import { version } from '../../package.json'
 
 export function showBanner (_clear?: boolean) {
   if (_clear) { clear() }
-  console.log(green(`Nuxi ${version}`))
+  console.log(green(`nuxi ${version}`))
 }
 
 export function showVersions (cwd: string) {

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -17,12 +17,11 @@ export function showVersions (cwd: string) {
         return pkg + '@' + version
       }
     } catch { /* not found */ }
-    return ''
+    return pkg
   }
-  const pkgs = ['nitropack', 'vite', 'webpack', 'vue']
   console.log(
-    green(getPkgWithVersion('nuxt') || getPkgWithVersion('nuxt-edge') /* bridge */ || 'nuxt'),
+    green(getPkgWithVersion('nuxt')),
     gray('running with'),
-    gray(pkgs.map(pkg => getPkgWithVersion(pkg)).filter(Boolean).join(' ') || '-')
+    gray(getPkgWithVersion('nitropack'))
   )
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -5,20 +5,24 @@ import { version } from '../../package.json'
 
 export function showBanner (_clear?: boolean) {
   if (_clear) { clear() }
-  console.log(gray(`nuxi ${version}`))
+  console.log(gray(`nuxi@${version}`))
 }
 
 export function showVersions (cwd: string) {
   const _require = createRequire(cwd)
-  const versions = []
-  for (const pkg of ['nuxt', 'nitropack', 'vite', 'webpack']) {
+  const getPkgWithVersion = (pkg: string) => {
     try {
       const { version } = _require(`${pkg}/package.json`)
-      const fullName = pkg + '@' + version
-      versions.push(pkg === 'nuxt' ? green(fullName) : gray(fullName))
-    } catch {
-      // Not found
-    }
+      if (version) {
+        return pkg + '@' + version
+      }
+    } catch { /* not found */ }
+    return ''
   }
-  console.log(versions.join(' '))
+  const pkgs = ['vue', 'nitropack', 'vite', 'webpack']
+  console.log(
+    green(getPkgWithVersion('nuxt')),
+    gray('running with'),
+    gray(pkgs.map(pkg => getPkgWithVersion(pkg)).filter(Boolean).join(' '))
+  )
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -10,18 +10,17 @@ export function showBanner (_clear?: boolean) {
 
 export function showVersions (cwd: string) {
   const _require = createRequire(cwd)
-  const getPkgWithVersion = (pkg: string, name: string) => {
+  const getPkgVersion = (pkg: string) => {
     try {
       const { version } = _require(`${pkg}/package.json`)
-      if (version) {
-        return name + ' ' + version
-      }
+      return version || ''
     } catch { /* not found */ }
-    return pkg
+    return ''
   }
+  const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-edge')
+  const nitroVersion = getPkgVersion('nitropack')
   console.log(
-    green(getPkgWithVersion('nuxt', 'Nuxt')),
-    gray('running with'),
-    gray(getPkgWithVersion('nitropack', 'Nitro'))
+    green(`Nuxt ${nuxtVersion}`),
+    nitroVersion ? gray(`running with Nitro ${nitroVersion}`) : ''
   )
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -20,7 +20,7 @@ export function showVersions (cwd: string) {
   const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-edge')
   const nitroVersion = getPkgVersion('nitropack')
   console.log(gray(
-    `${green('Nuxt')} ${bold(nuxtVersion)}` +
+    green(`Nuxt ${bold(nuxtVersion)}`) +
     (nitroVersion ? ` with Nitro ${(bold(nitroVersion))}` : '')
   ))
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -21,8 +21,8 @@ export function showVersions (cwd: string) {
   }
   const pkgs = ['vue', 'nitropack', 'vite', 'webpack']
   console.log(
-    green(getPkgWithVersion('nuxt')),
+    green(getPkgWithVersion('nuxt') || getPkgWithVersion('nuxt-edge') /* bridge */ || 'nuxt'),
     gray('running with'),
-    gray(pkgs.map(pkg => getPkgWithVersion(pkg)).filter(Boolean).join(' '))
+    gray(pkgs.map(pkg => getPkgWithVersion(pkg)).filter(Boolean).join(' ') || '-')
   )
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -19,7 +19,7 @@ export function showVersions (cwd: string) {
     } catch { /* not found */ }
     return ''
   }
-  const pkgs = ['vue', 'nitropack', 'vite', 'webpack']
+  const pkgs = ['nitropacl', 'vite', 'webpack', 'vue']
   console.log(
     green(getPkgWithVersion('nuxt') || getPkgWithVersion('nuxt-edge') /* bridge */ || 'nuxt'),
     gray('running with'),

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -21,6 +21,6 @@ export function showVersions (cwd: string) {
   const nitroVersion = getPkgVersion('nitropack')
   console.log(
     green(`Nuxt ${nuxtVersion}`),
-    nitroVersion ? gray(`running with Nitro ${nitroVersion}`) : ''
+    nitroVersion ? gray(`with Nitro ${nitroVersion}`) : ''
   )
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -20,5 +20,5 @@ export function showVersions (cwd: string) {
       // Not found
     }
   }
-  console.log(gray(versions.join(' ')))
+  console.log(versions.join(' '))
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -1,8 +1,23 @@
+import { createRequire } from 'node:module'
 import clear from 'clear'
-import { green } from 'colorette'
+import { gray, green } from 'colorette'
 import { version } from '../../package.json'
 
 export function showBanner (_clear?: boolean) {
   if (_clear) { clear() }
-  console.log(green(`Nuxt CLI v${version}`))
+  console.log(green(`Nuxi ${version}`))
+}
+
+export function showVersions (cwd: string) {
+  const _require = createRequire(cwd)
+  const versions = []
+  for (const pkg of ['nuxt', 'nitropack', 'vite', 'webpack']) {
+    try {
+      const { version } = _require(`${pkg}/package.json`)
+      versions.push(pkg + '@' + version)
+    } catch {
+      // Not found
+    }
+  }
+  console.log(gray(versions.join(' ')))
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -1,11 +1,11 @@
 import { createRequire } from 'node:module'
 import clear from 'clear'
-import { gray, green } from 'colorette'
+import { bold, gray, green } from 'colorette'
 import { version } from '../../package.json'
 
 export function showBanner (_clear?: boolean) {
   if (_clear) { clear() }
-  console.log(gray(`Nuxi ${version}`))
+  console.log(gray(`Nuxi ${(bold(version))}`))
 }
 
 export function showVersions (cwd: string) {
@@ -19,8 +19,8 @@ export function showVersions (cwd: string) {
   }
   const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-edge')
   const nitroVersion = getPkgVersion('nitropack')
-  console.log(
-    green(`Nuxt ${nuxtVersion}`),
-    nitroVersion ? gray(`with Nitro ${nitroVersion}`) : ''
-  )
+  console.log(gray(
+    `${green('Nuxt')} ${bold(nuxtVersion)}` +
+    (nitroVersion ? ` with Nitro ${(bold(nitroVersion))}` : '')
+  ))
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -5,7 +5,7 @@ import { version } from '../../package.json'
 
 export function showBanner (_clear?: boolean) {
   if (_clear) { clear() }
-  console.log(green(`nuxi ${version}`))
+  console.log(gray(`nuxi ${version}`))
 }
 
 export function showVersions (cwd: string) {
@@ -14,7 +14,8 @@ export function showVersions (cwd: string) {
   for (const pkg of ['nuxt', 'nitropack', 'vite', 'webpack']) {
     try {
       const { version } = _require(`${pkg}/package.json`)
-      versions.push(pkg + '@' + version)
+      const fullName = pkg + '@' + version
+      versions.push(pkg === 'nuxt' ? green(fullName) : gray(fullName))
     } catch {
       // Not found
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #6935

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With this PR, we show (installed) versions of Nuxt (it can be different than Nuxi!) and Nitro.

<img width="328" alt="image" src="https://user-images.githubusercontent.com/5158436/187880531-49eacedb-79b8-4893-8e7a-cd29f99d1688.png">

Remarks: I used `_require` instead of getPkg or inference from `package.json` to ensure we show actually installed versions and use native resolver. This also reduces CLI entry dependencies. Later we should refactor this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

