### PR TITLE
refactor(nuxt): remove unused `meta:register` hook

### DIFF
--- a/docs/content/3.api/4.advanced/1.hooks.md
+++ b/docs/content/3.api/4.advanced/1.hooks.md
@@ -12,7 +12,6 @@ Hook                   | Arguments           | Environment     | Description
 `app:error`            | `err`               | Server & Client | Called when a fatal error occurs.
 `app:error:cleared`    | `{ redirect? }`     | Server & Client | Called when a fatal error occurs.
 `app:data:refresh`     | `keys?`             | Server & Client | (internal)
-`meta:register`        | `metaRenderers`     | Server & Client | (internal)
 `vue:setup`            | -                   | Server & Client | (internal)
 `vue:error`            | `err, target, info` | Server & Client | Called when a vue error propages to the root component. [Learn More](https://vuejs.org/api/composition-api-lifecycle.html#onerrorcaptured).
 `app:rendered`         | `renderContext`     | Server          | Called when SSR rendering is done.

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -33,7 +33,6 @@ export interface RuntimeNuxtHooks {
   'app:data:refresh': (keys?: string[]) => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
-  'meta:register': (metaRenderers: Array<(nuxt: NuxtApp) => NuxtMeta | Promise<NuxtMeta>>) => HookResult
   'vue:setup': () => void
   'vue:error': (...args: Parameters<Parameters<typeof onErrorCaptured>[0]>) => HookResult
 }
@@ -70,7 +69,7 @@ interface _NuxtApp {
     data: Ref<any>
     pending: Ref<boolean>
     error: Ref<any>
-   }>,
+  }>,
 
   ssrContext?: NuxtSSRContext
   payload: {
@@ -92,7 +91,7 @@ interface _NuxtApp {
   provide: (name: string, value: any) => void
 }
 
-export interface NuxtApp extends _NuxtApp { }
+export interface NuxtApp extends _NuxtApp {}
 
 export const NuxtPluginIndicator = '__nuxt_plugin'
 export interface Plugin<Injections extends Record<string, any> = Record<string, any>> {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/7125

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes a hook that was only used for Nuxt Bridge integration: https://github.com/nuxt/framework/pull/664.

It might be useful to reconsider adding back some kind of hook implementation in future but for now it's unused and can be removed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

