### PR TITLE
fix(kit, nuxi): semver regexp to support `nuxt-edge` current releases (bridge)

### DIFF
--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -12,7 +12,7 @@ export async function checkNuxtCompatibility (constraints: NuxtCompatibility, nu
   if (constraints.nuxt) {
     const nuxtVersion = getNuxtVersion(nuxt)
     const nuxtSemanticVersion = nuxtVersion
-      .replace(/-[0-9]+\.[0-9a-f]{7}/, '') // Remove edge prefix
+      .replace(/-[0-9]+\.[0-9a-f]{7,8}/, '') // Remove edge prefix
     if (!satisfies(nuxtSemanticVersion, constraints.nuxt, { includePrerelease: true })) {
       issues.push({
         name: 'nuxt',

--- a/packages/nuxi/src/utils/nuxt.ts
+++ b/packages/nuxi/src/utils/nuxt.ts
@@ -29,7 +29,7 @@ export async function cleanupNuxtDirs (rootDir: string) {
 
 export function nuxtVersionToGitIdentifier (version: string) {
   // match the git identifier in the release, for example: 3.0.0-rc.8-27677607.a3a8706
-  const id = /\.([0-9a-f]{7})$/.exec(version)
+  const id = /\.([0-9a-f]{7,8})$/.exec(version)
   if (id?.[1]) {
     return id[1]
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

[<!-- Please ensure there is an open issue and mention its number as #123 -->](https://github.com/nuxt/framework/issues/7192)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It closes https://github.com/nuxt/framework/issues/7192 with updated regExp, which match both `nuxt3`/`nuxt-edge` releases

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

