### PR TITLE
docs(api): fix `useAsyncData` signature

### DIFF
--- a/docs/content/3.api/1.composables/use-async-data.md
+++ b/docs/content/3.api/1.composables/use-async-data.md
@@ -18,19 +18,25 @@ function useAsyncData(
 type AsyncDataOptions<DataT> = {
   server?: boolean
   lazy?: boolean
-  default?: () => DataT | Ref<DataT>
+  default?: () => DataT | Ref<DataT> | null
   transform?: (input: DataT) => DataT
   pick?: string[]
   watch?: WatchSource[]
   initialCache?: boolean
 }
 
-type AsyncData<DataT> = {
-  data: Ref<DataT>
-  pending: Ref<boolean>
-  refresh: () => Promise<void>
-  error: Ref<any>
+interface RefreshOptions {
+  _initial?: boolean
 }
+
+type AsyncData<DataT, ErrorT> = {
+  data: Ref<DataT | null>
+  pending: Ref<boolean>
+  refresh: (opts?: RefreshOptions) => Promise<void>
+  error: Ref<ErrorT | null>
+}
+
+
 ```
 
 ## Params


### PR DESCRIPTION
Update signature acording to https://github.com/nuxt/framework/blob/80a66dc5af74b9532f32f77bb463131bd9fb6058/packages/nuxt/src/app/composables/asyncData.ts#L20-L43

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed that the signature in the documentation was different from the actual one and made the changes.

In particular, documented that `data` now may be `null`, after https://github.com/nuxt/framework/commit/f350a70775016a8bde92670b4856d5d1edb1e7e0

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

