### PR TITLE
feat(nuxt): support experimental flag to render no client-side js

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -97,6 +97,7 @@ export async function initNitro (nuxt: Nuxt) {
     },
     replace: {
       'process.env.NUXT_NO_SSR': nuxt.options.ssr === false,
+      'process.env.NUXT_NO_SCRIPTS': !!nuxt.options.experimental.noScripts,
       'process.env.NUXT_INLINE_STYLES': !!nuxt.options.experimental.inlineSSRStyles,
       'process.dev': nuxt.options.dev,
       __VUE_PROD_DEVTOOLS__: false

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -82,6 +82,7 @@ async function initNuxt (nuxt: Nuxt) {
     addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromClient }), { server: false })
   }
 
+  // TODO: [Experimental] Avoid emitting assets when flag is enabled
   if (nuxt.options.experimental.noScripts) {
     nuxt.hook('build:manifest', async (manifest) => {
       for (const file in manifest) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -5,6 +5,8 @@ import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, 
 // Temporary until finding better placement
 /* eslint-disable import/no-restricted-paths */
 import escapeRE from 'escape-string-regexp'
+import fse from 'fs-extra'
+import { withoutLeadingSlash } from 'ufo'
 import pagesModule from '../pages/module'
 import metaModule from '../head/module'
 import componentsModule from '../components/module'
@@ -78,6 +80,17 @@ async function initNuxt (nuxt: Nuxt) {
     addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromClient }), { server: false })
     addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromServer }), { client: false })
     addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromClient }), { server: false })
+  }
+
+  if (nuxt.options.experimental.noScripts) {
+    nuxt.hook('build:manifest', async (manifest) => {
+      for (const file in manifest) {
+        if (manifest[file].resourceType === 'script') {
+          await fse.rm(resolve(nuxt.options.buildDir, 'dist/client', withoutLeadingSlash(nuxt.options.app.buildAssetsDir), manifest[file].file), { force: true })
+          manifest[file].file = ''
+        }
+      }
+    })
   }
 
   // Transpile layers within node_modules

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -40,8 +40,6 @@ const getServerEntry = () => import('#build/dist/server/server.mjs').then(r => r
 // @ts-ignore
 const getSSRStyles = (): Promise<Record<string, () => Promise<string[]>>> => import('#build/dist/server/styles.mjs').then(r => r.default || r)
 
-const JS_HINT_RE = /<[^>]+(\.m?js"|as="script")[^>]*>/g
-
 // -- SSR Renderer --
 const getSSRRenderer = lazyCachedFunction(async () => {
   // Load client manifest
@@ -192,7 +190,7 @@ export default defineRenderHandler(async (event) => {
   return response
 })
 
-function lazyCachedFunction<T> (fn: () => Promise<T>): () => Promise<T> {
+function lazyCachedFunction <T> (fn: () => Promise<T>): () => Promise<T> {
   let res: Promise<T> | null = null
   return () => {
     if (res === null) {

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -152,7 +152,7 @@ export default defineRenderHandler(async (event) => {
     htmlAttrs: normalizeChunks([renderedMeta.htmlAttrs]),
     head: normalizeChunks([
       renderedMeta.headTags,
-      process.env.NUXT_NO_SCRIPTS ? _rendered.renderResourceHints().replace(JS_HINT_RE, '') : _rendered.renderResourceHints(),
+      _rendered.renderResourceHints(),
       _rendered.renderStyles(),
       inlinedStyles,
       ssrContext.styles
@@ -167,9 +167,8 @@ export default defineRenderHandler(async (event) => {
       _rendered.html
     ],
     bodyAppend: normalizeChunks([
-      ...process.env.NUXT_NO_SCRIPTS
-        ? []
-        : [`<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`, _rendered.renderScripts()],
+      process.env.NUXT_NO_SCRIPTS ? '' : `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`,
+      process.env.NUXT_NO_SCRIPTS ? '' : _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts
     ])

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -61,7 +61,7 @@ export default defineUntypedSchema({
      * @type {boolean | ((id?: string) => boolean)}
      */
     inlineSSRStyles: {
-      $resolve(val, get) {
+      $resolve (val, get) {
         if (val === false || get('dev') || get('ssr') === false || get('builder') === '@nuxt/webpack-builder') {
           return false
         }
@@ -69,5 +69,10 @@ export default defineUntypedSchema({
         return val ?? true
       }
     },
+
+    /**
+     * Turn off rendering of Nuxt scripts and JS resource hints.
+     */
+    noScripts: false,
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/7156

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows turning off all Nuxt-injected JS (preload/prefetch `<link>` and `<script>`). It does not affect user code, which can still inject scripts. It does remove all scripts from buildDir, though perhaps this could be reconsidered in future? (wdyt @pi0?)

> **Warning**
> This will only be advisable for the very small minority of sites that would not benefit from client-side JS.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

