### PR TITLE
refactor(vite): reuse resolved server entry from context

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -3,7 +3,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolveModule } from '@nuxt/kit'
+import { logger, resolveModule, resolvePath } from '@nuxt/kit'
 import { joinURL, withoutLeadingSlash, withTrailingSlash } from 'ufo'
 import { ViteBuildContext, ViteOptions } from './vite'
 import { wpfs } from './utils/wpfs'
@@ -14,7 +14,7 @@ import { ssrStylesPlugin } from './plugins/ssr-styles'
 export async function buildServer (ctx: ViteBuildContext) {
   const useAsyncEntry = ctx.nuxt.options.experimental.asyncEntry ||
     (ctx.nuxt.options.vite.devBundler === 'vite-node' && ctx.nuxt.options.dev)
-  ctx.entry = resolve(ctx.nuxt.options.appDir, useAsyncEntry ? 'entry.async' : 'entry')
+  ctx.entry = await resolvePath(resolve(ctx.nuxt.options.appDir, useAsyncEntry ? 'entry.async' : 'entry'))
 
   const _resolve = (id: string) => resolveModule(id, { paths: ctx.nuxt.options.modulesDir })
   const serverConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -123,11 +123,6 @@ function createViteNodeMiddleware (ctx: ViteBuildContext, invalidates: Set<strin
 }
 
 export async function initViteNodeServer (ctx: ViteBuildContext) {
-  let entryPath = resolve(ctx.nuxt.options.appDir, 'entry.async.mjs')
-  if (!fse.existsSync(entryPath)) {
-    entryPath = resolve(ctx.nuxt.options.appDir, 'entry.async')
-  }
-
   const host = ctx.nuxt.options.server.host || 'localhost'
   const port = ctx.nuxt.options.server.port || '3000'
   const protocol = ctx.nuxt.options.server.https ? 'https' : 'http'
@@ -136,7 +131,7 @@ export async function initViteNodeServer (ctx: ViteBuildContext) {
   const viteNodeServerOptions = {
     baseURL: `${protocol}://${host}:${port}/__nuxt_vite_node__`,
     root: ctx.nuxt.options.srcDir,
-    entryPath,
+    entryPath: ctx.entry,
     base: ctx.ssrServer!.config.base || '/_nuxt/'
   }
   process.env.NUXT_VITE_NODE_OPTIONS = JSON.stringify(viteNodeServerOptions)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are [already resolving the entrypoint for the app](https://github.com/nuxt/framework/blob/de6252099052b5eae6af7cb187e9549dba79a412/packages/vite/src/server.ts#L15-L17), so I think we can remove this extra code. I see that the `.mjs` extension by default in vite node creation was added to fix a bug, so instead I'm moving that logic to the vite server creation so we can share that path (for example) in warming up the app. I'm not sure this makes a difference, but thought it would be better to keep logic central.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

