### PR TITLE
feat(kit): add `addImportsSources` utility

### DIFF
--- a/packages/kit/src/imports.ts
+++ b/packages/kit/src/imports.ts
@@ -1,4 +1,5 @@
 import { Import } from 'unimport'
+import { ImportPresetWithDeprecation } from '@nuxt/schema'
 import { useNuxt } from './context'
 import { assertNuxtCompatibility } from './compatibility'
 
@@ -31,3 +32,14 @@ export function addImportsDir (dirs: string | string[]) {
  * @deprecated Please use `addImportsDir` instead with nuxt>=3.0.0-rc.9
  */
 export const addAutoImportDir = addImportsDir
+
+export function addImportsSources (presets: ImportPresetWithDeprecation | ImportPresetWithDeprecation[]) {
+  assertNuxtCompatibility({ bridge: true })
+
+  // TODO: Use imports:* when widely adopted
+  useNuxt().hook('autoImports:sources', (_presets: ImportPresetWithDeprecation[]) => {
+    for (const preset of (Array.isArray(presets) ? presets : [presets])) {
+      _presets.push(preset)
+    }
+  }, { allowDeprecated: true })
+}

--- a/packages/kit/src/imports.ts
+++ b/packages/kit/src/imports.ts
@@ -1,5 +1,5 @@
-import { Import } from 'unimport'
-import { ImportPresetWithDeprecation } from '@nuxt/schema'
+import type { Import } from 'unimport'
+import type { ImportPresetWithDeprecation } from '@nuxt/schema'
 import { useNuxt } from './context'
 import { assertNuxtCompatibility } from './compatibility'
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -152,7 +152,7 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.hooks.deprecateHooks({
     'autoImports:sources': {
       to: 'imports:sources',
-      message: '`autoImports:sources` hook is deprecated. Use `addImportsSources()` from `@nuxt/kit` or `imports:dirs` with `nuxt>=3.0.0-rc.9`.'
+      message: '`autoImports:sources` hook is deprecated. Use `addImportsSources()` from `@nuxt/kit` or `imports:dirs` with `nuxt>=3.0.0-rc.10`.'
     },
     'autoImports:dirs': {
       to: 'imports:dirs',

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -152,7 +152,7 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.hooks.deprecateHooks({
     'autoImports:sources': {
       to: 'imports:sources',
-      message: '`autoImports:sources` hook is deprecated. Use `imports:sources` with `nuxt>=3.0.0-rc.9`.'
+      message: '`autoImports:sources` hook is deprecated. Use `addImportsSources()` from `@nuxt/kit` or `imports:dirs` with `nuxt>=3.0.0-rc.9`.'
     },
     'autoImports:dirs': {
       to: 'imports:dirs',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Context: https://github.com/nuxt/framework/pull/7158

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for auto-imports sources. With deprecation of `autoImports:sources` hook there is not an easy tool for module authors to add sources without manually passing `allowDeprecated` themselves.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

