### PR TITLE
fix(nuxi): pass value of `https` through to vite-node

### DIFF
--- a/docs/content/3.api/5.commands/dev.md
+++ b/docs/content/3.api/5.commands/dev.md
@@ -21,3 +21,7 @@ Option        | Default          | Description
 The port and host can also be set via NUXT_PORT, PORT, NUXT_HOST or HOST environment variables.
 
 This command sets `process.env.NODE_ENV` to `development`.
+
+::alert{type="info"}
+If you are using a self-signed certificate in development, you will need to set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your environment.
+::

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -94,6 +94,7 @@ export default defineNuxtCommand({
         const address = listener.server.address() as AddressInfo
         currentNuxt.options.server.port = address.port
         currentNuxt.options.server.host = address.address
+        currentNuxt.options.server.https = Boolean(args.https)
 
         await Promise.all([
           writeTypes(currentNuxt).catch(console.error),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/7218

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR passes the value of `https` through to vite-node (which was reading it). Note that if users are using a _self-signed_ certificate then they will also need to set `NODE_TLS_REJECT_UNAUTHORIZED=0`, for example:

```bash
NODE_TLS_REJECT_UNAUTHORIZED=0 yarn dev --https --ssl-cert localhost.pem --ssl-key localhost-key.pem
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

