### PR TITLE
fix(webpack): promisify webpack dev/hot handlers using `h3.promisifyHandler`

### DIFF
--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -35,6 +35,7 @@ export default defineBuildConfig({
     'terser-webpack-plugin',
     'css-minimizer-webpack-plugin',
     'webpack-dev-middleware',
+    'h3',
     'webpack-hot-middleware',
     'postcss',
     'consola',

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -4,6 +4,7 @@ import type { Compiler, Configuration, Stats } from 'webpack'
 import type { TSConfig } from 'pkg-types'
 import type { InlineConfig as ViteInlineConfig, ViteDevServer } from 'vite'
 import type { Manifest } from 'vue-bundle-renderer'
+import type { Middleware } from 'h3'
 import type { ModuleContainer } from './module'
 import type { NuxtTemplate, Nuxt, NuxtApp } from './nuxt'
 import type { Preset as ImportPreset, Import } from 'unimport'
@@ -159,7 +160,7 @@ export interface NuxtHooks {
   'build:compile': (options: { name: string, compiler: Compiler }) => HookResult
   'build:compiled': (options: { name: string, compiler: Compiler, stats: Stats }) => HookResult
   'build:resources': (mfs?: Compiler['outputFileSystem']) => HookResult
-  'server:devMiddleware': (middleware: (req: IncomingMessage, res: ServerResponse, next: (err?: any) => any) => any) => HookResult
+  'server:devMiddleware': (middleware: Middleware) => HookResult
   'bundler:change': (shortPath: string) => void
   'bundler:error': () => void
   'bundler:done': () => void

--- a/packages/webpack/build.config.ts
+++ b/packages/webpack/build.config.ts
@@ -10,6 +10,7 @@ export default defineBuildConfig({
     'unplugin',
     'webpack-virtual-modules',
     'postcss',
+    'h3',
     'postcss-loader',
     'vue-loader',
     'css-loader',

--- a/packages/webpack/build.config.ts
+++ b/packages/webpack/build.config.ts
@@ -10,7 +10,6 @@ export default defineBuildConfig({
     'unplugin',
     'webpack-virtual-modules',
     'postcss',
-    'h3',
     'postcss-loader',
     'vue-loader',
     'css-loader',
@@ -20,6 +19,7 @@ export default defineBuildConfig({
     'vue'
   ],
   externals: [
-    '@nuxt/schema'
+    '@nuxt/schema',
+    'h3'
   ]
 })

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -64,8 +64,8 @@ function clientHMR (ctx: WebpackConfigContext) {
   // Add HMR support
   const app = (config.entry as any).app as any
   app.unshift(
-      // https://github.com/glenjamin/webpack-hot-middleware#config
-      `webpack-hot-middleware/client?${hotMiddlewareClientOptionsStr}`
+    // https://github.com/glenjamin/webpack-hot-middleware#config
+    `webpack-hot-middleware/client?${hotMiddlewareClientOptionsStr}`
   )
 
   config.plugins = config.plugins || []

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import pify from 'pify'
 import webpack from 'webpack'
+import { promisifyHandler } from 'h3'
 import webpackDevMiddleware, { API, OutputFileSystem } from 'webpack-dev-middleware'
 import webpackHotMiddleware from 'webpack-hot-middleware'
 import type { Compiler, Watching } from 'webpack'
@@ -97,9 +98,10 @@ async function createDevMiddleware (compiler: Compiler) {
   await nuxt.callHook('webpack:hotMiddleware', hotMiddleware)
 
   // Register devMiddleware on server
-  await nuxt.callHook('server:devMiddleware', async (req: IncomingMessage, res: ServerResponse, next: (error?: any) => void) => {
-    for (const mw of [devMiddleware, hotMiddleware]) {
-      await mw?.(req, res, next)
+  const handlers = [promisifyHandler(devMiddleware), promisifyHandler(hotMiddleware)]
+  await nuxt.callHook('server:devMiddleware', async (req, res, next) => {
+    for (const mw of handlers) {
+      await mw?.(req, res)
     }
     next()
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7236

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently the first `next()` call from webpack devMiddleware short-circuits second next call from hotMiddleware meaning we currently get a 404 for webpack HMR endpoint.

I think it's a non-breaking change to update schema type for devMiddleware (as CompatibilityEvent should be backwards compatible).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

