### PR TITLE
fix(nuxt): don't try to set cookie after redirect

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -9,9 +9,9 @@ import { useNuxtApp } from '#app'
 
 type _CookieOptions = Omit<CookieSerializeOptions & CookieParseOptions, 'decode' | 'encode'>
 
-export interface CookieOptions<T=any> extends _CookieOptions {
+export interface CookieOptions<T = any> extends _CookieOptions {
   decode?(value: string): T
-  encode?(value: T): string;
+  encode?(value: T): string
   default?: () => T | Ref<T>
 }
 
@@ -38,8 +38,12 @@ export function useCookie <T = string> (name: string, _opts?: CookieOptions<T>):
         writeServerCookie(useRequestEvent(nuxtApp), name, cookie.value, opts)
       }
     }
-    nuxtApp.hooks.hookOnce('app:rendered', writeFinalCookieValue)
-    nuxtApp.hooks.hookOnce('app:redirected', writeFinalCookieValue)
+    const unhook = nuxtApp.hooks.hookOnce('app:rendered', writeFinalCookieValue)
+    nuxtApp.hooks.hookOnce('app:redirected', (...args) => {
+      // don't write cookie subsequently when app:rendered is called
+      unhook()
+      return writeFinalCookieValue(...args)
+    })
   }
 
   return cookie as CookieRef<T>

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -42,7 +42,7 @@ export function useCookie <T = string> (name: string, _opts?: CookieOptions<T>):
     nuxtApp.hooks.hookOnce('app:redirected', (...args) => {
       // don't write cookie subsequently when app:rendered is called
       unhook()
-      return writeFinalCookieValue(...args)
+      return writeFinalCookieValue()
     })
   }
 

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -39,7 +39,7 @@ export function useCookie <T = string> (name: string, _opts?: CookieOptions<T>):
       }
     }
     const unhook = nuxtApp.hooks.hookOnce('app:rendered', writeFinalCookieValue)
-    nuxtApp.hooks.hookOnce('app:redirected', (...args) => {
+    nuxtApp.hooks.hookOnce('app:redirected', () => {
       // don't write cookie subsequently when app:rendered is called
       unhook()
       return writeFinalCookieValue()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5183

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were trying to set headers after redirect when cookies were used. Alternatively we could check writableEnded but I think it's better to have warning surface in this kind of way.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

