### PR TITLE
perf(nuxt): cache `createClientOnly` wrapper using weakmap

### DIFF
--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -18,7 +18,15 @@ export default defineComponent({
   }
 })
 
+
+const cache = new WeakMap()
+
 export function createClientOnly (component) {
+
+  if(cache.has(component)) {
+    return cache.get(component)
+  }
+
   const clone = { ...component }
 
   if (clone.render) {
@@ -52,6 +60,8 @@ export function createClientOnly (component) {
             }
       })
   }
+
+  cache.set(component, clone)
 
   return clone
 }

--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -18,12 +18,10 @@ export default defineComponent({
   }
 })
 
-
 const cache = new WeakMap()
 
 export function createClientOnly (component) {
-
-  if(cache.has(component)) {
+  if (cache.has(component)) {
     return cache.get(component)
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
PR https://github.com/nuxt/framework/pull/7243 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi ! this PR is based on PR #7243 and @antfu suggestion to use a WeakMap. This avoid to recreate another client only component when a `.client` component is called multiple times.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

