### PR TITLE
feat(vite, webpack): allow client-side sourcemaps in production

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -167,17 +167,16 @@ export default defineNuxtModule<ComponentsOptions>({
 
     nuxt.hook('vite:extendConfig', (config, { isClient, isServer }) => {
       const mode = isClient ? 'client' : 'server'
-      const sourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap[mode]
 
       config.plugins = config.plugins || []
       config.plugins.push(loaderPlugin.vite({
-        sourcemap,
+        sourcemap: nuxt.options.sourcemap[mode],
         getComponents,
         mode
       }))
       if (nuxt.options.experimental.treeshakeClientOnly && isServer) {
         config.plugins.push(TreeShakeTemplatePlugin.vite({
-          sourcemap,
+          sourcemap: nuxt.options.sourcemap[mode],
           getComponents
         }))
       }
@@ -185,16 +184,15 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('webpack:config', (configs) => {
       configs.forEach((config) => {
         const mode = config.name === 'client' ? 'client' : 'server'
-        const sourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap[mode]
         config.plugins = config.plugins || []
         config.plugins.push(loaderPlugin.webpack({
-          sourcemap,
+          sourcemap: nuxt.options.sourcemap[mode],
           getComponents,
           mode
         }))
         if (nuxt.options.experimental.treeshakeClientOnly && mode === 'server') {
           config.plugins.push(TreeShakeTemplatePlugin.webpack({
-            sourcemap,
+            sourcemap: nuxt.options.sourcemap[mode],
             getComponents
           }))
         }

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -9,7 +9,7 @@ import { TreeShakeTemplatePlugin } from './tree-shake'
 
 const isPureObjectOrString = (val: any) => (!Array.isArray(val) && typeof val === 'object') || typeof val === 'string'
 const isDirectory = (p: string) => { try { return statSync(p).isDirectory() } catch (_e) { return false } }
-function compareDirByPathLength ({ path: pathA }: { path: string}, { path: pathB }: { path: string}) {
+function compareDirByPathLength ({ path: pathA }: { path: string }, { path: pathB }: { path: string }) {
   return pathB.split(/[\\/]/).filter(Boolean).length - pathA.split(/[\\/]/).filter(Boolean).length
 }
 
@@ -165,31 +165,36 @@ export default defineNuxtModule<ComponentsOptions>({
       }
     })
 
-    nuxt.hook('vite:extendConfig', (config, { isClient }) => {
+    nuxt.hook('vite:extendConfig', (config, { isClient, isServer }) => {
+      const mode = isClient ? 'client' : 'server'
+      const sourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap[mode]
+
       config.plugins = config.plugins || []
       config.plugins.push(loaderPlugin.vite({
-        sourcemap: !!nuxt.options.sourcemap,
+        sourcemap,
         getComponents,
-        mode: isClient ? 'client' : 'server'
+        mode
       }))
-      if (nuxt.options.experimental.treeshakeClientOnly) {
+      if (nuxt.options.experimental.treeshakeClientOnly && isServer) {
         config.plugins.push(TreeShakeTemplatePlugin.vite({
-          sourcemap: !!nuxt.options.sourcemap,
+          sourcemap,
           getComponents
         }))
       }
     })
     nuxt.hook('webpack:config', (configs) => {
       configs.forEach((config) => {
+        const mode = config.name === 'client' ? 'client' : 'server'
+        const sourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap[mode]
         config.plugins = config.plugins || []
         config.plugins.push(loaderPlugin.webpack({
-          sourcemap: !!nuxt.options.sourcemap,
+          sourcemap,
           getComponents,
-          mode: config.name === 'client' ? 'client' : 'server'
+          mode
         }))
-        if (nuxt.options.experimental.treeshakeClientOnly) {
+        if (nuxt.options.experimental.treeshakeClientOnly && mode === 'server') {
           config.plugins.push(TreeShakeTemplatePlugin.webpack({
-            sourcemap: !!nuxt.options.sourcemap,
+            sourcemap,
             getComponents
           }))
         }

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -168,13 +168,13 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       config.plugins = config.plugins || []
       config.plugins.push(loaderPlugin.vite({
-        sourcemap: nuxt.options.sourcemap,
+        sourcemap: !!nuxt.options.sourcemap,
         getComponents,
         mode: isClient ? 'client' : 'server'
       }))
       if (nuxt.options.experimental.treeshakeClientOnly) {
         config.plugins.push(TreeShakeTemplatePlugin.vite({
-          sourcemap: nuxt.options.sourcemap,
+          sourcemap: !!nuxt.options.sourcemap,
           getComponents
         }))
       }
@@ -183,13 +183,13 @@ export default defineNuxtModule<ComponentsOptions>({
       configs.forEach((config) => {
         config.plugins = config.plugins || []
         config.plugins.push(loaderPlugin.webpack({
-          sourcemap: nuxt.options.sourcemap,
+          sourcemap: !!nuxt.options.sourcemap,
           getComponents,
           mode: config.name === 'client' ? 'client' : 'server'
         }))
         if (nuxt.options.experimental.treeshakeClientOnly) {
           config.plugins.push(TreeShakeTemplatePlugin.webpack({
-            sourcemap: nuxt.options.sourcemap,
+            sourcemap: !!nuxt.options.sourcemap,
             getComponents
           }))
         }

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -58,7 +58,7 @@ export async function initNitro (nuxt: Nuxt) {
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200.html', '/404.html'] : [])
     },
-    sourceMap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'client',
+    sourceMap: typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap.server,
     externals: {
       inline: [
         ...(nuxt.options.dev

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -58,7 +58,7 @@ export async function initNitro (nuxt: Nuxt) {
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200.html', '/404.html'] : [])
     },
-    sourcemap: nuxt.options.sourcemap,
+    sourceMap: nuxt.options.sourcemap,
     externals: {
       inline: [
         ...(nuxt.options.dev

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -58,7 +58,7 @@ export async function initNitro (nuxt: Nuxt) {
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200.html', '/404.html'] : [])
     },
-    sourceMap: nuxt.options.sourcemap,
+    sourceMap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'client',
     externals: {
       inline: [
         ...(nuxt.options.dev

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -58,7 +58,7 @@ export async function initNitro (nuxt: Nuxt) {
         .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200.html', '/404.html'] : [])
     },
-    sourceMap: typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap.server,
+    sourceMap: nuxt.options.sourcemap.server,
     externals: {
       inline: [
         ...(nuxt.options.dev

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -76,10 +76,12 @@ async function initNuxt (nuxt: Nuxt) {
     const removeFromClient = ['onServerPrefetch', 'onRenderTracked', 'onRenderTriggered']
 
     // Add tree-shaking optimisations for SSR - build time only
-    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'client', treeShake: removeFromServer }), { client: false })
-    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'server', treeShake: removeFromClient }), { server: false })
-    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'client', treeShake: removeFromServer }), { client: false })
-    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'server', treeShake: removeFromClient }), { server: false })
+    const serverSourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap.server
+    const clientSourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap.client
+    addVitePlugin(TreeShakePlugin.vite({ sourcemap: serverSourcemap, treeShake: removeFromServer }), { client: false })
+    addVitePlugin(TreeShakePlugin.vite({ sourcemap: clientSourcemap, treeShake: removeFromClient }), { server: false })
+    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: serverSourcemap, treeShake: removeFromServer }), { client: false })
+    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: clientSourcemap, treeShake: removeFromClient }), { server: false })
   }
 
   // TODO: [Experimental] Avoid emitting assets when flag is enabled

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -68,20 +68,18 @@ async function initNuxt (nuxt: Nuxt) {
   addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Add unctx transform
-  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: !!nuxt.options.sourcemap }))
-  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: !!nuxt.options.sourcemap }))
+  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
+  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
 
   if (!nuxt.options.dev) {
     const removeFromServer = ['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated', 'onBeforeUnmount']
     const removeFromClient = ['onServerPrefetch', 'onRenderTracked', 'onRenderTriggered']
 
     // Add tree-shaking optimisations for SSR - build time only
-    const serverSourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap.server
-    const clientSourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap.client
-    addVitePlugin(TreeShakePlugin.vite({ sourcemap: serverSourcemap, treeShake: removeFromServer }), { client: false })
-    addVitePlugin(TreeShakePlugin.vite({ sourcemap: clientSourcemap, treeShake: removeFromClient }), { server: false })
-    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: serverSourcemap, treeShake: removeFromServer }), { client: false })
-    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: clientSourcemap, treeShake: removeFromClient }), { server: false })
+    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap.server, treeShake: removeFromServer }), { client: false })
+    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap.client, treeShake: removeFromClient }), { server: false })
+    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap.server, treeShake: removeFromServer }), { client: false })
+    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap.client, treeShake: removeFromClient }), { server: false })
   }
 
   // TODO: [Experimental] Avoid emitting assets when flag is enabled

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -68,18 +68,18 @@ async function initNuxt (nuxt: Nuxt) {
   addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Add unctx transform
-  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: nuxt.options.sourcemap }))
-  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: nuxt.options.sourcemap }))
+  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: !!nuxt.options.sourcemap }))
+  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: !!nuxt.options.sourcemap }))
 
   if (!nuxt.options.dev) {
     const removeFromServer = ['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated', 'onBeforeUnmount']
     const removeFromClient = ['onServerPrefetch', 'onRenderTracked', 'onRenderTriggered']
 
     // Add tree-shaking optimisations for SSR - build time only
-    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromServer }), { client: false })
-    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromClient }), { server: false })
-    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromServer }), { client: false })
-    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap, treeShake: removeFromClient }), { server: false })
+    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'client', treeShake: removeFromServer }), { client: false })
+    addVitePlugin(TreeShakePlugin.vite({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'server', treeShake: removeFromClient }), { server: false })
+    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'client', treeShake: removeFromServer }), { client: false })
+    addWebpackPlugin(TreeShakePlugin.webpack({ sourcemap: nuxt.options.sourcemap && nuxt.options.sourcemap !== 'server', treeShake: removeFromClient }), { server: false })
   }
 
   // TODO: [Experimental] Avoid emitting assets when flag is enabled

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -68,8 +68,8 @@ async function initNuxt (nuxt: Nuxt) {
   addWebpackPlugin(ImportProtectionPlugin.webpack(config))
 
   // Add unctx transform
-  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
-  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
+  addVitePlugin(UnctxTransformPlugin(nuxt).vite({ sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
+  addWebpackPlugin(UnctxTransformPlugin(nuxt).webpack({ sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
 
   if (!nuxt.options.dev) {
     const removeFromServer = ['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated', 'onBeforeUnmount']

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -91,8 +91,8 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
       })
     } else {
       // Transform to inject imports in production mode
-      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
-      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
+      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
+      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
     }
 
     const regenerateImports = async () => {

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -91,8 +91,8 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
       })
     } else {
       // Transform to inject imports in production mode
-      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.sourcemap }))
-      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.sourcemap }))
+      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: !!nuxt.options.sourcemap }))
+      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: !!nuxt.options.sourcemap }))
     }
 
     const regenerateImports = async () => {

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -91,8 +91,8 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
       })
     } else {
       // Transform to inject imports in production mode
-      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: !!nuxt.options.sourcemap }))
-      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: !!nuxt.options.sourcemap }))
+      addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
+      addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean) }))
     }
 
     const regenerateImports = async () => {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -88,7 +88,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
       dev: nuxt.options.dev,
-      sourcemap: nuxt.options.sourcemap,
+      sourcemap: !!nuxt.options.sourcemap,
       macros: {
         definePageMeta: 'meta'
       }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -88,7 +88,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
       dev: nuxt.options.dev,
-      sourcemap: !!nuxt.options.sourcemap,
+      sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean),
       macros: {
         definePageMeta: 'meta'
       }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -88,7 +88,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const macroOptions: TransformMacroPluginOptions = {
       dev: nuxt.options.dev,
-      sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean),
+      sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client,
       macros: {
         definePageMeta: 'meta'
       }

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -26,10 +26,11 @@ export default defineUntypedSchema({
   /**
    * Whether to generate sourcemaps.
    *
+   * @type {boolean | 'server' | 'client'}
    * @version 3
    */
   sourcemap: {
-    $resolve: (val, get) => val ?? get('dev'),
+    $resolve: (val, get) => val ?? get('dev') ? true : 'server',
   },
   /**
    * Shared build configuration.

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -26,11 +26,19 @@ export default defineUntypedSchema({
   /**
    * Whether to generate sourcemaps.
    *
-   * @type {boolean | 'server' | 'client'}
+   * @type {boolean | { server?: boolean, client?: boolean }}
    * @version 3
    */
   sourcemap: {
-    $resolve: (val, get) => val ?? (get('dev') ? true : 'server'),
+    $resolve: (val, get) => {
+      if (typeof val === 'boolean') {
+        return { server: val, client: val }
+      }
+      return defu(val, {
+        server: true,
+        client: get('dev')
+      })
+    },
   },
   /**
    * Shared build configuration.

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -28,7 +28,9 @@ export default defineUntypedSchema({
    *
    * @version 3
    */
-  sourcemap: true,
+  sourcemap: {
+    $resolve: (val, get) => val ?? get('dev'),
+  },
   /**
    * Shared build configuration.
    * @version 2

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -30,7 +30,7 @@ export default defineUntypedSchema({
    * @version 3
    */
   sourcemap: {
-    $resolve: (val, get) => val ?? get('dev') ? true : 'server',
+    $resolve: (val, get) => val ?? (get('dev') ? true : 'server'),
   },
   /**
    * Shared build configuration.

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -26,7 +26,7 @@ export type NuxtConfigLayer = ConfigLayer<NuxtConfig & {
 
 /** Normalized Nuxt options available as `nuxt.options.*` */
 export interface NuxtOptions extends ConfigSchema {
-  sourcemap: Exclude<ConfigSchema['sourcemap'], boolean>
+  sourcemap: Required<Exclude<ConfigSchema['sourcemap'], boolean>>
   _layers: NuxtConfigLayer[]
 }
 

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -26,6 +26,7 @@ export type NuxtConfigLayer = ConfigLayer<NuxtConfig & {
 
 /** Normalized Nuxt options available as `nuxt.options.*` */
 export interface NuxtOptions extends ConfigSchema {
+  sourcemap: Exclude<ConfigSchema['sourcemap'], boolean>
   _layers: NuxtConfigLayer[]
 }
 
@@ -53,11 +54,11 @@ export interface ViteConfig extends ViteUserConfig {
 
 type RuntimeConfigNamespace = Record<string, any>
 
-export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
+export interface PublicRuntimeConfig extends RuntimeConfigNamespace {}
 
 // TODO: remove before release of 3.0.0
 /** @deprecated use RuntimeConfig interface */
-export interface PrivateRuntimeConfig extends RuntimeConfigNamespace { }
+export interface PrivateRuntimeConfig extends RuntimeConfigNamespace {}
 
 export interface RuntimeConfig extends PrivateRuntimeConfig, RuntimeConfigNamespace {
   public: PublicRuntimeConfig
@@ -80,4 +81,4 @@ export interface NuxtAppConfig {
   keepalive: boolean | KeepAliveProps
 }
 
-export interface AppConfig { }
+export interface AppConfig {}

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -52,7 +52,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       dedupe: ['vue']
     },
     build: {
-      sourcemap: ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'client',
+      sourcemap: ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'server',
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -52,6 +52,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       dedupe: ['vue']
     },
     build: {
+      sourcemap: ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'client',
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -52,7 +52,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       dedupe: ['vue']
     },
     build: {
-      sourcemap: ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'server',
+      sourcemap: typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.client,
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -51,7 +51,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       dedupe: ['vue']
     },
     build: {
-      sourcemap: typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.client,
+      sourcemap: ctx.nuxt.options.sourcemap.client,
       manifest: true,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -80,7 +80,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       ]
     },
     build: {
-      sourcemap: ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'client',
+      sourcemap: typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.server,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
       ssr: ctx.nuxt.options.ssr ?? true,
       rollupOptions: {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -80,6 +80,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       ]
     },
     build: {
+      sourcemap: ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'client',
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
       ssr: ctx.nuxt.options.ssr ?? true,
       rollupOptions: {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -81,7 +81,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       ]
     },
     build: {
-      sourcemap: typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.server,
+      sourcemap: ctx.nuxt.options.sourcemap.server,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
       ssr: ctx.nuxt.options.ssr ?? true,
       rollupOptions: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -51,7 +51,6 @@ export async function bundle (nuxt: Nuxt) {
         },
         css: resolveCSSOptions(nuxt),
         build: {
-          sourcemap: nuxt.options.sourcemap,
           rollupOptions: {
             output: { sanitizeFileName: sanitizeFilePath }
           },
@@ -60,7 +59,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         },
         plugins: [
-          composableKeysPlugin.vite({ sourcemap: nuxt.options.sourcemap, rootDir: nuxt.options.rootDir }),
+          composableKeysPlugin.vite({ sourcemap: !!nuxt.options.sourcemap, rootDir: nuxt.options.rootDir }),
           replace({
             ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),
             preventAssignment: true

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -59,7 +59,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         },
         plugins: [
-          composableKeysPlugin.vite({ sourcemap: !!nuxt.options.sourcemap, rootDir: nuxt.options.rootDir }),
+          composableKeysPlugin.vite({ sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean), rootDir: nuxt.options.rootDir }),
           replace({
             ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),
             preventAssignment: true

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -51,6 +51,7 @@ export async function bundle (nuxt: Nuxt) {
         },
         css: resolveCSSOptions(nuxt),
         build: {
+          sourcemap: nuxt.options.sourcemap,
           rollupOptions: {
             output: { sanitizeFileName: sanitizeFilePath }
           },

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -59,7 +59,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         },
         plugins: [
-          composableKeysPlugin.vite({ sourcemap: Object.values(nuxt.options.sourcemap).some(Boolean), rootDir: nuxt.options.rootDir }),
+          composableKeysPlugin.vite({ sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client, rootDir: nuxt.options.rootDir }),
           replace({
             ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),
             preventAssignment: true

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -22,7 +22,8 @@ export function client (ctx: WebpackConfigContext) {
 }
 
 function clientDevtool (ctx: WebpackConfigContext) {
-  if (!ctx.nuxt.options.sourcemap || ctx.nuxt.options.sourcemap === 'server') {
+  const enableClientSourcemap = typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.client
+  if (!enableClientSourcemap) {
     ctx.config.devtool = false
     return
   }

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -22,12 +22,13 @@ export function client (ctx: WebpackConfigContext) {
 }
 
 function clientDevtool (ctx: WebpackConfigContext) {
-  if (!ctx.isDev) {
-    ctx.config.devtool = ctx.nuxt.options.sourcemap ? 'source-map' : false
+  if (!ctx.nuxt.options.sourcemap || ctx.nuxt.options.sourcemap === 'server') {
+    ctx.config.devtool = false
     return
   }
 
-  if (!ctx.nuxt.options.sourcemap) {
+  if (!ctx.isDev) {
+    ctx.config.devtool = 'source-map'
     return
   }
 

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -23,7 +23,11 @@ export function client (ctx: WebpackConfigContext) {
 
 function clientDevtool (ctx: WebpackConfigContext) {
   if (!ctx.isDev) {
-    ctx.config.devtool = false
+    ctx.config.devtool = ctx.nuxt.options.sourcemap ? 'source-map' : false
+    return
+  }
+
+  if (!ctx.nuxt.options.sourcemap) {
     return
   }
 

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -22,8 +22,7 @@ export function client (ctx: WebpackConfigContext) {
 }
 
 function clientDevtool (ctx: WebpackConfigContext) {
-  const enableClientSourcemap = typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.client
-  if (!enableClientSourcemap) {
+  if (!ctx.nuxt.options.sourcemap.client) {
     ctx.config.devtool = false
     return
   }

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -27,7 +27,8 @@ function serverPreset (ctx: WebpackConfigContext) {
   const { config } = ctx
 
   config.output!.filename = 'server.mjs'
-  config.devtool = 'cheap-module-source-map'
+
+  config.devtool = ctx.nuxt.options.sourcemap ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
 
   config.optimization = {
     splitChunks: false,

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -28,8 +28,7 @@ function serverPreset (ctx: WebpackConfigContext) {
 
   config.output!.filename = 'server.mjs'
 
-  const enableServerSourcemap = typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.server
-  config.devtool = enableServerSourcemap ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
+  config.devtool = ctx.nuxt.options.sourcemap.server ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
 
   config.optimization = {
     splitChunks: false,

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -28,7 +28,8 @@ function serverPreset (ctx: WebpackConfigContext) {
 
   config.output!.filename = 'server.mjs'
 
-  config.devtool = ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'client' ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
+  const enableServerSourcemap = typeof ctx.nuxt.options.sourcemap === 'boolean' ? ctx.nuxt.options.sourcemap : ctx.nuxt.options.sourcemap.server
+  config.devtool = enableServerSourcemap ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
 
   config.optimization = {
     splitChunks: false,

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -28,7 +28,7 @@ function serverPreset (ctx: WebpackConfigContext) {
 
   config.output!.filename = 'server.mjs'
 
-  config.devtool = ctx.nuxt.options.sourcemap ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
+  config.devtool = ctx.nuxt.options.sourcemap && ctx.nuxt.options.sourcemap !== 'client' ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
 
   config.optimization = {
     splitChunks: false,

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -36,10 +36,10 @@ export async function bundle (nuxt: Nuxt) {
   // Configure compilers
   const compilers = webpackConfigs.map((config) => {
     config.plugins!.push(DynamicBasePlugin.webpack({
-      sourcemap: nuxt.options.sourcemap
+      sourcemap: nuxt.options.sourcemap === true || nuxt.options.sourcemap !== config.name
     }))
     config.plugins!.push(composableKeysPlugin.webpack({
-      sourcemap: nuxt.options.sourcemap,
+      sourcemap: nuxt.options.sourcemap === true || nuxt.options.sourcemap !== config.name,
       rootDir: nuxt.options.rootDir
     }))
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -35,12 +35,11 @@ export async function bundle (nuxt: Nuxt) {
 
   // Configure compilers
   const compilers = webpackConfigs.map((config) => {
-    const sourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap[config.name as 'client' | 'server']!
     config.plugins!.push(DynamicBasePlugin.webpack({
-      sourcemap
+      sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server']
     }))
     config.plugins!.push(composableKeysPlugin.webpack({
-      sourcemap,
+      sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server']!,
       rootDir: nuxt.options.rootDir
     }))
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -39,7 +39,7 @@ export async function bundle (nuxt: Nuxt) {
       sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server']
     }))
     config.plugins!.push(composableKeysPlugin.webpack({
-      sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server']!,
+      sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server'],
       rootDir: nuxt.options.rootDir
     }))
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -35,11 +35,12 @@ export async function bundle (nuxt: Nuxt) {
 
   // Configure compilers
   const compilers = webpackConfigs.map((config) => {
+    const sourcemap = typeof nuxt.options.sourcemap === 'boolean' ? nuxt.options.sourcemap : nuxt.options.sourcemap[config.name as 'client' | 'server']!
     config.plugins!.push(DynamicBasePlugin.webpack({
-      sourcemap: nuxt.options.sourcemap === true || nuxt.options.sourcemap !== config.name
+      sourcemap
     }))
     config.plugins!.push(composableKeysPlugin.webpack({
-      sourcemap: nuxt.options.sourcemap === true || nuxt.options.sourcemap !== config.name,
+      sourcemap,
       rootDir: nuxt.options.rootDir
     }))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7294

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR bundles a couple of changes to sourcemap handling:

1. fixes a bug where nitro sourcemaps were not respecting `sourcemap` config (a typo)
2. generates client-side sourcemaps for webpack/vite in production if sourcemap is set to true (or allows either falling back to previous behaviour with new option 'server' or generating _only_ client-side sourcemaps with 'client')
3. defaults to previous behaviour (generates all sourcemaps in dev, and only server-side sourcemaps in production)
4. fixes (unrelated) issue with https://github.com/nuxt/framework/pull/5750 where client-only components were being tree-shaken out of client build as well 🙈 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

