### PR TITLE
feat(nuxt): filter support for `clearNuxtData`

### DIFF
--- a/docs/content/3.api/3.utils/clear-nuxt-data.md
+++ b/docs/content/3.api/3.utils/clear-nuxt-data.md
@@ -10,7 +10,7 @@ This method is useful if you want to invalidate the data fetching for another pa
 ## Type
 
 ```ts
-clearNuxtData (keys?: string | string[]): void
+clearNuxtData (keys?: string | string[] | ((key: string) => boolean)): void
 ```
 
 ## Parameters

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -254,9 +254,14 @@ export function refreshNuxtData (keys?: string | string[]): Promise<void> {
   return useNuxtApp().callHook('app:data:refresh', _keys)
 }
 
-export function clearNuxtData (keys?: string | string[]): void {
+export function clearNuxtData (keys?: string | string[] | ((key: string) => boolean)): void {
   const nuxtApp = useNuxtApp()
-  const _keys = keys ? Array.from(keys).filter(key => key && typeof key === 'string') : Object.keys(nuxtApp.payload.data)
+  const _allKeys = Object.keys(nuxtApp.payload.data)
+  const _keys: string[] = !keys
+    ? _allKeys
+    : typeof keys === 'function'
+      ? _allKeys.filter(keys)
+      : Array.isArray(keys) ? keys : [keys]
 
   for (const key of _keys) {
     if (key in nuxtApp.payload.data) {


### PR DESCRIPTION
### 🔗 Linked issue

Continuation of  https://github.com/nuxt/framework/pull/5227

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Uncovered use case: 
Remove cache for several unknown keys. Example: you have app with posts and filter for posts. Each query for posts saved in cache in uniq key, like `posts.list-{param1:1}`, `posts.list-{param2:2}`, `posts.list-{param1:1,param2:3}` (nuxt-trpc works llike that). In this case you may want clear data for all keys `posts.list-*`. 
May be `clearNuxtData` should also accept function to filter keys?
```ts
clearNuxtData(key => key.startsWith('posts.list'))
```
Or provide another method to get all keys in cache and filter it manually:
```ts
clearNuxtData(
  getNuxtDataKeys().filter(key => key.startsWith('posts.list'))
)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

