### PR TITLE
fix(webpack): don't parse styles for composable keys

### DIFF
--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -5,7 +5,7 @@ import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { hash } from 'ohash'
 import type { CallExpression } from 'estree'
-import { parseURL } from 'ufo'
+import { parseQuery, parseURL } from 'ufo'
 
 export interface ComposableKeysOptions {
   sourcemap: boolean
@@ -22,8 +22,8 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
     name: 'nuxt:composable-keys',
     enforce: 'post',
     transform (code, id) {
-      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      if (!pathname.match(/\.(m?[jt]sx?|vue)/)) { return }
+      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      if (!pathname.match(/\.(m?[jt]sx?|vue)/) || parseQuery(search).type === 'style') { return }
       if (!KEYED_FUNCTIONS_RE.test(code)) { return }
       const { 0: script = code, index: codeIndex = 0 } = code.match(/(?<=<script[^>]*>)[\S\s.]*?(?=<\/script>)/) || []
       const s = new MagicString(code)

--- a/test/fixtures/basic/pages/keyed-composables.vue
+++ b/test/fixtures/basic/pages/keyed-composables.vue
@@ -43,3 +43,10 @@ const { data: useLazyFetchTest2 } = await useLocalLazyFetch()
     {{ useLazyFetchTest1 === useLazyFetchTest2 }}
   </div>
 </template>
+
+<style scoped>
+body {
+  background-color: #000;
+  color: #fff;
+}
+</style>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7330

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With webpack, we have some code in a string in the style block, e.g.:

```
const code = ["\\nconst a ..."]
```

This wrongly gets parsed by the composable keys, and `\\n` breaks the parser.

But we shouldn't be parsing code from a style block for automatic useFetch/useState keys, anyway.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

