### PR TITLE
fix(nuxt): allow `abortMiddleware` to receive a nuxt error or error options

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, inject } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, NavigationFailure, RouteLocationPathRaw } from 'vue-router'
 import { sendRedirect } from 'h3'
 import { hasProtocol, joinURL, parseURL } from 'ufo'
-import { useNuxtApp, useRuntimeConfig, useState } from '#app'
+import { useNuxtApp, useRuntimeConfig, useState, createError, showError, NuxtError } from '#app'
 
 export const useRouter = () => {
   return useNuxtApp()?.$router as Router
@@ -105,12 +105,16 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 }
 
 /** This will abort navigation within a Nuxt route middleware handler. */
-export const abortNavigation = (err?: Error | string) => {
+export const abortNavigation = (err?: string | Partial<NuxtError>) => {
   if (process.dev && !isProcessingMiddleware()) {
     throw new Error('abortNavigation() is only usable inside a route middleware handler.')
   }
   if (err) {
-    throw err instanceof Error ? err : new Error(err)
+    if (process.client) {
+      throw createError(err)
+    } else {
+      showError(createError(err))
+    }
   }
   return false
 }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, inject } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, NavigationFailure, RouteLocationPathRaw } from 'vue-router'
 import { sendRedirect } from 'h3'
 import { hasProtocol, joinURL, parseURL } from 'ufo'
-import { useNuxtApp, useRuntimeConfig, useState, createError, showError, NuxtError } from '#app'
+import { useNuxtApp, useRuntimeConfig, useState, createError, NuxtError } from '#app'
 
 export const useRouter = () => {
   return useNuxtApp()?.$router as Router
@@ -110,11 +110,7 @@ export const abortNavigation = (err?: string | Partial<NuxtError>) => {
     throw new Error('abortNavigation() is only usable inside a route middleware handler.')
   }
   if (err) {
-    if (process.client) {
-      throw createError(err)
-    } else {
-      showError(createError(err))
-    }
+    throw createError(err)
   }
   return false
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -212,6 +212,15 @@ describe('middlewares', () => {
     expect(html).toContain('Hello Nuxt 3!')
   })
 
+  it('should allow aborting navigation on server-side', async () => {
+    const res = await fetch('/?abort', {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+    expect(res.status).toEqual(401)
+  })
+
   it('should inject auth', async () => {
     const html = await $fetch('/auth')
 

--- a/test/fixtures/basic/middleware/abort.global.ts
+++ b/test/fixtures/basic/middleware/abort.global.ts
@@ -1,0 +1,7 @@
+export default defineNuxtRouteMiddleware((to) => {
+  if ('abort' in to.query) {
+    return abortNavigation({
+      statusCode: 401
+    })
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/5041

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is the last piece in the linked issue. It means we can respect a nuxt error thrown in middleware, namely set our own status code/message.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

