### PR TITLE
fix(nuxt): do not apply import protection to top-level resolution

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,4 +1,4 @@
-import { normalize, resolve } from 'pathe'
+import { join, normalize, resolve } from 'pathe'
 import { createHooks } from 'hookable'
 import type { Nuxt, NuxtOptions, NuxtConfig, ModuleContainer, NuxtHooks } from '@nuxt/schema'
 import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, addVitePlugin, addWebpackPlugin, tryResolveModule } from '@nuxt/kit'
@@ -62,6 +62,8 @@ async function initNuxt (nuxt: Nuxt) {
   // Add import protection
   const config = {
     rootDir: nuxt.options.rootDir,
+    // Exclude top-level resolutions by plugins
+    exclude: [join(nuxt.options.rootDir, 'index.html')],
     patterns: vueAppPatterns(nuxt)
   }
   addVitePlugin(ImportProtectionPlugin.vite(config))

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -32,6 +32,7 @@ export const ImportProtectionPlugin = createUnplugin(function (options: ImportPr
     enforce: 'pre',
     resolveId (id, importer) {
       if (!importer) { return }
+      if (isAbsolute(id)) { id = relative(options.rootDir, id) }
       if (importersToExclude.some(p => typeof p === 'string' ? importer === p : p.test(importer))) { return }
 
       const invalidImports = options.patterns.filter(([pattern]) => pattern instanceof RegExp ? pattern.test(id) : pattern === id)

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import { createUnplugin } from 'unplugin'
 import { logger } from '@nuxt/kit'
-import { isAbsolute, relative, resolve } from 'pathe'
+import { isAbsolute, join, relative, resolve } from 'pathe'
 import type { Nuxt } from '@nuxt/schema'
 import escapeRE from 'escape-string-regexp'
 
@@ -32,7 +32,12 @@ export const ImportProtectionPlugin = createUnplugin(function (options: ImportPr
     enforce: 'pre',
     resolveId (id, importer) {
       if (!importer) { return }
-      if (isAbsolute(id)) { id = relative(options.rootDir, id) }
+      if (id.startsWith('.')) {
+        id = join(importer, '..', id)
+      }
+      if (isAbsolute(id)) {
+        id = relative(options.rootDir, id)
+      }
       if (importersToExclude.some(p => typeof p === 'string' ? importer === p : p.test(importer))) { return }
 
       const invalidImports = options.patterns.filter(([pattern]) => pattern instanceof RegExp ? pattern.test(id) : pattern === id)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #2886

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We can avoid triggering import protection from a top-level `this.resolve` call (i.e. within another vite plugin), as there may be valid use cases for this, like tailwind resolving the nuxt.config file.

**Relevant vite section**:

https://github.com/vitejs/vite/blob/757a92f1c7c4fa961ed963edd245df77382dfde6/packages/vite/src/node/server/pluginContainer.ts#L562-L566

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

