### PR TITLE
fix(vite): update render if it is invalidated

### DIFF
--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -22,7 +22,7 @@ export default async (ssrContext) => {
 
   // Execute SSR bundle on demand
   const start = performance.now()
-  render = render || (await runner.executeFile(viteNodeOptions.entryPath)).default
+  render = (updates.has(viteNodeOptions.entryPath) || !render) ? (await runner.executeFile(viteNodeOptions.entryPath)).default : render
   if (updates.size) {
     const time = Math.round((performance.now() - start) * 1000) / 1000
     consola.success(`Vite server hmr ${updates.size} files`, time ? `in ${time}ms` : '')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/7345

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I may be misunderstanding the implementation here, but it seems that we were not updating the render function when it was invalidated. This PR ensures that if the entry is invalidated, we fetch it fresh from the runner.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

