### PR TITLE
docs(head): enhance usehead and fix broken links

### DIFF
--- a/docs/content/2.guide/2.features/4.head-management.md
+++ b/docs/content/2.guide/2.features/4.head-management.md
@@ -6,7 +6,7 @@ Out-of-the-box, Nuxt provides good default values for `charset` and `viewport` m
 
 ## `useHead` Composable
 
-Within your `setup` function, you can call `useHead` with an object of meta properties with keys corresponding to meta tags: `title`, `titleTemplate`, `base`, `script`, `style`, `meta` and `link`, as well as `htmlAttrs` and `bodyAttrs`. There are also two shorthand properties, `charset` and `viewport`, which set the corresponding meta tags. Alternatively, you can pass a function returning the object for reactive metadata.
+Within your `setup` function, you can call `useHead` with an object of meta properties with keys corresponding to meta tags: `title`, `titleTemplate`, `base`, `script`, `noscript`, `style`, `meta` and `link`, as well as `htmlAttrs` and `bodyAttrs`. There are also two shorthand properties, `charset` and `viewport`, which set the corresponding meta tags. Alternatively, you can pass a function returning the object for reactive metadata.
 
 For example:
 
@@ -70,7 +70,7 @@ useHead({
 
 ## Meta Components
 
-Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>`, `<Html>` and `<Head>` components so that you can interact directly with your metadata within your component's template.
+Nuxt provides `<Title>`, `<Base>`, `<Script>`, `<NoScript>`, `<Style>`, `<Meta>`, `<Link>`, `<Body>`, `<Html>` and `<Head>` components so that you can interact directly with your metadata within your component's template.
 
 Because these component names match native HTML elements, it is very important that they are capitalized in the template.
 

--- a/docs/content/4.examples/3.composables/use-head.md
+++ b/docs/content/4.examples/3.composables/use-head.md
@@ -7,7 +7,7 @@ template: Example
 This example shows how to use `useHead` and Nuxt built-in components to bind meta data to the head of the page.
 
 ::alert{type=info icon=👉}
-Learn more about [meta tags](/migration/meta).
+Learn more about [meta tags](/guide/features/head-management#meta-components).
 ::
 
 ::ReadMore{link="/api/composables/use-head"}

--- a/docs/content/4.examples/3.composables/use-head.md
+++ b/docs/content/4.examples/3.composables/use-head.md
@@ -7,10 +7,10 @@ template: Example
 This example shows how to use `useHead` and Nuxt built-in components to bind meta data to the head of the page.
 
 ::alert{type=info icon=👉}
-Learn more about [meta tags](/api/composables/head).
+Learn more about [meta tags](/migration/meta).
 ::
 
-::ReadMore{link="/api/composables/use-fetch"}
+::ReadMore{link="/api/composables/use-head"}
 ::
 
 ::ReadMore{link="/guide/features/head-management"}

--- a/docs/content/4.examples/3.composables/use-head.md
+++ b/docs/content/4.examples/3.composables/use-head.md
@@ -7,7 +7,7 @@ template: Example
 This example shows how to use `useHead` and Nuxt built-in components to bind meta data to the head of the page.
 
 ::alert{type=info icon=👉}
-Learn more about [meta tags](/api/composables/use-meta).
+Learn more about [meta tags](/api/composables/head).
 ::
 
 ::ReadMore{link="/api/composables/use-fetch"}

--- a/docs/content/migration/4.meta.md
+++ b/docs/content/migration/4.meta.md
@@ -11,7 +11,7 @@ Nuxt 3 provides several different ways to manage your meta tags.
 2. Through the `useHead` [composable](/guide/features/head-management)
 3. Through [global meta components](/guide/features/head-management)
 
-You can customize `title`, `titleTemplate`, `base`, `script`, `style`, `meta`, `link`, `htmlAttrs` and `bodyAttrs`.
+You can customize `title`, `titleTemplate`, `base`, `script`, `noscript`, `style`, `meta`, `link`, `htmlAttrs` and `bodyAttrs`.
 
 ::alert{icon=📦}
 Nuxt currently uses [`vueuse/head`](https://github.com/vueuse/head) to manage your meta tags, but implementation details may change.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
#4104

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi ! This PR adds some changes to the documentation:
  - it adds `noscript` mentions
  - fix some links : 
    - in composable/use-head, change the read more from use-fetch to use-head
    - in composable/use-head, change the Meta Tag link (broken) from /api/composables/use-meta to /migration/meta

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

