### PR TITLE
fix(nuxi): don't include an array of paths within an array

### DIFF
--- a/packages/nuxi/src/utils/cjs.ts
+++ b/packages/nuxi/src/utils/cjs.ts
@@ -3,14 +3,16 @@ import { pathToFileURL } from 'node:url'
 import { normalize, dirname } from 'pathe'
 
 export function getModulePaths (paths?: string | string[]): string[] {
-  return [
-    // @ts-ignore
-    global.__NUXT_PREPATHS__,
-    ...(paths ? [] : Array.isArray(paths) ? paths : [paths]),
-    process.cwd(),
-    // @ts-ignore
-    global.__NUXT_PATHS__
-  ].filter(Boolean)
+  return ([] as Array<string | undefined>)
+    .concat(
+      // @ts-expect-error global object
+      global.__NUXT_PREPATHS__,
+      paths,
+      process.cwd(),
+      // @ts-expect-error global object
+      global.__NUXT_PATHS__
+    )
+    .filter(Boolean) as string[]
 }
 
 const _require = createRequire(process.cwd())


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/bridge/issues/515. https://github.com/nuxt/bridge/pull/514. ctx: https://github.com/nuxt/framework/pull/6943

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`global.__NUXT_PREPATHS__` is an array (if defined) and the `resolveModule` was choking on this (sometimes):

https://github.com/nuxt/framework/blob/8b24992f6d905c6d1188830087f8d59a14b3f544/packages/nuxi/src/utils/cjs.ts#L20-L22

`Array.concat()` handles this for us.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

