### PR TITLE
fix(nuxt): always inline entry styles

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -224,7 +224,7 @@ function renderHTMLDocument (html: NuxtRenderHTMLContext) {
 async function renderInlineStyles (usedModules: Set<string> | string[]) {
   const styleMap = await getSSRStyles()
   const inlinedStyles = new Set<string>()
-  for (const mod of usedModules) {
+  for (const mod of ['entry', ...usedModules]) {
     if (mod in styleMap) {
       for (const style of await styleMap[mod]()) {
         inlinedStyles.add(`<style>${style}</style>`)

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -60,11 +60,11 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
         source:
           [
             ...globalStylesArray.map((css, i) => `import style_${i} from './${css}';`),
-            `const globalStyles = [${globalStylesArray.map((_, i) => `style_${i}`).join(', ')}]`,
-            'const resolveStyles = r => globalStyles.concat(r.default || r || [])',
-            `export default ${genObjectFromRawEntries(
-              Object.entries(emitted).map(([key, value]) => [key, `() => import('./${this.getFileName(value)}').then(resolveStyles)`])
-            )}`
+            'const interopDefault = r => r.default || r || []',
+            `export default ${genObjectFromRawEntries([
+              ['entry', `() => [${globalStylesArray.map((_, i) => `style_${i}`).join(', ')}]`],
+              ...Object.entries(emitted).map(([key, value]) => [key, `() => import('./${this.getFileName(value)}').then(interopDefault)`]) as [string, string][]
+            ])}`
           ].join('\n')
       })
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously if we were rendering a page without any styles in its `.vue` file, we would also not render global styles, because they are only concatenated to styles that already exist.

Alternatively we could amend [this line](https://github.com/nuxt/framework/blob/1b1b4eefad07a34aa626301d85fd811072729389/packages/vite/src/plugins/ssr-styles.ts#L28-L30) so that we explicitly add all used components, even if they have no styles, but this would make the file much larger.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

