### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/3.api/3.utils/show-error.md
+++ b/docs/content/3.api/3.utils/show-error.md
@@ -2,7 +2,7 @@
 
 Nuxt provides a quick and simple way to show a full screen error page if needed.
 
-Within your pages, components and plugins you can use `showError` to show an error error.
+Within your pages, components and plugins you can use `showError` to show an error.
 
 **Parameters:**
 


### PR DESCRIPTION
### ❓ Type of change

- [x ] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

Fixes a double-word typo on /api/utils/show-error/show-error/.

> …use `showError` to show an error error.

-->

>…use `showError` to show an error.

- [x] I have updated the documentation accordingly.
