### PR TITLE
fix(vite): don't fail builds for virtual modules that don't support inlining

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -104,6 +104,7 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
 
         const resolved = await this.resolve(i.specifier, id)
         if (!resolved) { continue }
+        if (!(await this.resolve(resolved.id + '?inline&used'))) { continue }
 
         const ref = this.emitFile({
           type: 'chunk',

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -20,6 +20,8 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
 
   const relativeToSrcDir = (path: string) => relative(options.srcDir, path)
 
+  const warnCache = new Set<string>()
+
   return {
     name: 'ssr-styles',
     generateBundle (outputOptions) {
@@ -104,7 +106,13 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
 
         const resolved = await this.resolve(i.specifier, id)
         if (!resolved) { continue }
-        if (!(await this.resolve(resolved.id + '?inline&used'))) { continue }
+        if (!(await this.resolve(resolved.id + '?inline&used'))) {
+          if (!warnCache.has(resolved.id)) {
+            warnCache.add(resolved.id)
+            this.warn(`[nuxt] Cannot extract styles for \`${i.specifier}\`. Its styles will not be inlined when server-rendering.`)
+          }
+          continue
+        }
 
         const ref = this.emitFile({
           type: 'chunk',

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -12,7 +12,18 @@ export default defineNuxtConfig({
   buildDir: process.env.NITRO_BUILD_DIR,
   builder: process.env.TEST_WITH_WEBPACK ? 'webpack' : 'vite',
   theme: './extends/bar',
-  css: ['~/assets/global.css'],
+  css: ['~/assets/global.css', 'virtual.css'],
+  vite: {
+    plugins: [{
+      name: 'virtual',
+      resolveId (id) {
+        if (id === 'virtual.css') { return 'virtual.css' }
+      },
+      load (id) {
+        if (id === 'virtual.css') { return ':root { color: red }' }
+      }
+    }]
+  },
   extends: [
     './extends/node_modules/foo'
   ],

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -36,8 +36,10 @@ export default defineNuxtConfig({
   modules: [
     '~/modules/example',
     function (_, nuxt) {
+      if (process.env.TEST_WITH_WEBPACK) { return }
+
       nuxt.options.css.push('virtual.css')
-      nuxt.options.build.transpile.push(/virtual.css/)
+      nuxt.options.build.transpile.push('virtual.css')
       const plugin = createUnplugin(() => ({
         name: 'virtual',
         resolveId (id) {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -14,23 +14,6 @@ export default defineNuxtConfig({
   builder: process.env.TEST_WITH_WEBPACK ? 'webpack' : 'vite',
   theme: './extends/bar',
   css: ['~/assets/global.css'],
-  modules: [
-    function (_, nuxt) {
-      nuxt.options.css.push('virtual.css')
-      nuxt.options.build.transpile.push(/virtual.css/)
-      const plugin = createUnplugin(() => ({
-        name: 'virtual',
-        resolveId (id) {
-          if (id === 'virtual.css') { return 'virtual.css' }
-        },
-        load (id) {
-          if (id === 'virtual.css') { return ':root { --virtual: red }' }
-        }
-      }))
-      addVitePlugin(plugin.vite())
-      addWebpackPlugin(plugin.webpack())
-    }
-  ],
   extends: [
     './extends/node_modules/foo'
   ],
@@ -50,7 +33,24 @@ export default defineNuxtConfig({
   privateRuntimeConfig: {
     privateConfig: 'secret_key'
   },
-  modules: ['~/modules/example'],
+  modules: [
+    '~/modules/example',
+    function (_, nuxt) {
+      nuxt.options.css.push('virtual.css')
+      nuxt.options.build.transpile.push(/virtual.css/)
+      const plugin = createUnplugin(() => ({
+        name: 'virtual',
+        resolveId (id) {
+          if (id === 'virtual.css') { return 'virtual.css' }
+        },
+        load (id) {
+          if (id === 'virtual.css') { return ':root { --virtual: red }' }
+        }
+      }))
+      addVitePlugin(plugin.vite())
+      addWebpackPlugin(plugin.webpack())
+    }
+  ],
   hooks: {
     'modules:done' () {
       addComponent({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7372

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Virtual CSS files that want Nuxt inline styles need to respond to the resolved ID with the correct query flags (`?inline&used`). I've updated three key virtual CSS modules (see linked issue). But we shouldn't fail builds if user is using some other virtual CSS module; this PR simply makes sure we skip those virtual modules. Any CSS they inject will not be inlined.)

We could also display a warning message so users at least know this is happening and know where to raise an issue. wdyt @pi0?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

