### PR TITLE
feat(nuxt): allow exposing type augmentations from extends layers

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -57,6 +57,13 @@ async function initNuxt (nuxt: Nuxt) {
     // Add module augmentations directly to NuxtConfig
     opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/schema.d.ts') })
     opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/app.config.d.ts') })
+
+    for (const layer of nuxt.options._layers) {
+      const declaration = join(layer.cwd, 'index.d.ts')
+      if (fse.existsSync(declaration)) {
+        opts.references.push({ path: declaration })
+      }
+    }
   })
 
   // Add import protection

--- a/test/fixtures/basic/extends/bar/index.d.ts
+++ b/test/fixtures/basic/extends/bar/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'bing' {
+  interface BingInterface {
+    foo: 'bar'
+  }
+}

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -182,3 +182,9 @@ describe('app config', () => {
     expectTypeOf<AppConfig>().toMatchTypeOf<ExpectedMergedAppConfig>()
   })
 })
+
+describe('extends type declarations', () => {
+  it('correctly adds references to tsconfig', () => {
+    expectTypeOf<import('bing').BingInterface>().toEqualTypeOf<{ foo: 'bar' }>()
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #7373

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows extends layers to automatically add their augments to the end user's app by placing an `index.d.ts` file in their root directory (I think this is correct, vs. srcDir)...

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

