### PR TITLE
perf(nuxt): only inject preload helper when webpack is used

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -176,6 +176,11 @@ async function initNuxt (nuxt: Nuxt) {
   // Add prerender payload support
   addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
 
+  // Track components used to render for webpack
+  if (nuxt.options.builder === '@nuxt/webpack-builder') {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/preload.server'))
+  }
+
   for (const m of modulesToInstall) {
     if (Array.isArray(m)) {
       await installModule(m[0], m[1])

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -68,8 +68,8 @@ export const serverPluginTemplate: NuxtTemplate<TemplateContext> = {
   filename: 'plugins/server.mjs',
   getContents (ctx) {
     const serverPlugins = ctx.app.plugins.filter(p => !p.mode || p.mode !== 'client')
-    const exports: string[] = ['preload']
-    const imports: string[] = ["import preload from '#app/plugins/preload.server'"]
+    const exports: string[] = []
+    const imports: string[] = []
     for (const plugin of serverPlugins) {
       const path = relative(ctx.nuxt.options.rootDir, plugin.src)
       const variable = genSafeVariableName(path).replace(/_(45|46|47)/g, '_') + '_' + hash(path)

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -20,7 +20,7 @@ export default defineUntypedSchema({
         vite: '@nuxt/vite-builder',
         webpack: '@nuxt/webpack-builder',
       }
-      return map[val] || (await get('vite') === false ? map.webpack : map.vite)
+      return map[val] || val || (await get('vite') === false ? map.webpack : map.vite)
     }
   },
   /**

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -3,6 +3,7 @@ import { ConfigSchema } from '../../schema/config'
 import type { UserConfig as ViteUserConfig } from 'vite'
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 import type { MetaObject } from './meta'
+import type { Nuxt } from './nuxt'
 
 type DeepPartial<T> = T extends Function ? T : T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 
@@ -27,6 +28,7 @@ export type NuxtConfigLayer = ConfigLayer<NuxtConfig & {
 /** Normalized Nuxt options available as `nuxt.options.*` */
 export interface NuxtOptions extends ConfigSchema {
   sourcemap: Required<Exclude<ConfigSchema['sourcemap'], boolean>>
+  builder: '@nuxt/vite-builder' | '@nuxt/webpack-builder' | { bundle: (nuxt: Nuxt) => Promise<void> }
   _layers: NuxtConfigLayer[]
 }
 

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -26,7 +26,7 @@ export type NuxtConfigLayer = ConfigLayer<NuxtConfig & {
 }>
 
 /** Normalized Nuxt options available as `nuxt.options.*` */
-export interface NuxtOptions extends ConfigSchema {
+export interface NuxtOptions extends Omit<ConfigSchema, 'builder'> {
   sourcemap: Required<Exclude<ConfigSchema['sourcemap'], boolean>>
   builder: '@nuxt/vite-builder' | '@nuxt/webpack-builder' | { bundle: (nuxt: Nuxt) => Promise<void> }
   _layers: NuxtConfigLayer[]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This started out as a simple small perf improvement but ended up fixing a couple of bugs as well. The changes are:

* only inject the server preload plugin when webpack builder is used (it adds a needless overhead with vite)
* update NuxtOptions schema so it correctly shows resolved value of `builder`
* update resolver for builder so it respects a custom builder value

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

