### PR TITLE
perf(nuxt): import `defineNuxtConfig` from `nuxt/config`

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -12,11 +12,6 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     configFile: 'nuxt.config',
     rcFile: '.nuxtrc',
     extend: { extendKey: ['theme', 'extends'] },
-    jitiOptions: {
-      alias: {
-        nuxt: 'nuxt/config'
-      }
-    },
     dotenv: true,
     globalRc: true,
     ...opts

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -12,6 +12,11 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     configFile: 'nuxt.config',
     rcFile: '.nuxtrc',
     extend: { extendKey: ['theme', 'extends'] },
+    jitiOptions: {
+      alias: {
+        nuxt: 'nuxt/config'
+      }
+    },
     dotenv: true,
     globalRc: true,
     ...opts

--- a/packages/nuxt/config.cjs
+++ b/packages/nuxt/config.cjs
@@ -1,0 +1,7 @@
+function defineNuxtConfig (config) {
+  return config
+}
+
+module.exports = {
+  defineNuxtConfig
+}

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -1,0 +1,4 @@
+import { NuxtConfig } from '@nuxt/schema'
+export { NuxtConfig } from '@nuxt/schema'
+
+export declare function defineNuxtConfig(config: NuxtConfig): NuxtConfig

--- a/packages/nuxt/config.mjs
+++ b/packages/nuxt/config.mjs
@@ -1,0 +1,5 @@
+function defineNuxtConfig (config) {
+  return config
+}
+
+export { defineNuxtConfig }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -13,7 +13,7 @@
   "exports": {
     ".": "./dist/index.mjs",
     "./config": {
-      "import": "./dist/config.mjs",
+      "import": "./config.mjs",
       "require": "./config.cjs",
       "types": "./config.d.ts"
     },

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -12,6 +12,11 @@
   },
   "exports": {
     ".": "./dist/index.mjs",
+    "./config": {
+      "import": "./dist/config.mjs",
+      "require": "./config.cjs",
+      "types": "./config.d.ts"
+    },
     "./app": "./dist/app/index.mjs",
     "./package.json": "./package.json"
   },
@@ -24,7 +29,8 @@
     "app.d.ts",
     "bin",
     "types.d.ts",
-    "dist"
+    "dist",
+    "config.*"
   ],
   "scripts": {
     "prepack": "unbuild"

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -234,9 +234,10 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   return nuxt
 }
 
+/** @deprecated Use import { defineNuxtConfig } from  'nuxt/config' */
 export function defineNuxtConfig (config: NuxtConfig): NuxtConfig {
   return config
 }
 
-// For a convenience import together with `defineNuxtConfig`
+/** @deprecated Use import type { NuxtConfig } from  'nuxt/config' */
 export type { NuxtConfig }

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,3 @@
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7267

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces new `nuxt/config` subpath export with CJS+MJS build to avoid jiti extra transformations.

~~Also using jiti aliases, `nuxt` is aliases to `nuxt/config` within `nuxt.config` file. This way we transparently introduce this enhancement to all nuxt 3 users.~~ `defineNuxtConfig` from `nuxt` is deprecated. Pending docs/examples update to after release and try. Alias seemed little bit hacky to do and causing potential breaking changes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

