### PR TITLE
refactor(nuxt): use relative imports into composables

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -2,7 +2,8 @@ import { defineComponent, h, ref, resolveComponent, PropType, computed, DefineCo
 import { RouteLocationRaw, Router } from 'vue-router'
 import { hasProtocol } from 'ufo'
 
-import { navigateTo, useRouter, useNuxtApp } from '#app'
+import { navigateTo, useRouter } from '../composables/router'
+import { useNuxtApp } from '../nuxt'
 
 const firstNonUndefined = <T>(...args: (T | undefined)[]) => args.find(arg => arg !== undefined)
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -1,6 +1,6 @@
 import { onBeforeMount, onServerPrefetch, onUnmounted, ref, getCurrentInstance, watch, unref } from 'vue'
 import type { Ref, WatchSource } from 'vue'
-import { NuxtApp, useNuxtApp } from '#app'
+import { NuxtApp, useNuxtApp } from '../nuxt'
 
 export type _Transform<Input = any, Output = any> = (input: Input) => Output
 

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -4,8 +4,8 @@ import { appendHeader } from 'h3'
 import type { CompatibilityEvent } from 'h3'
 import destr from 'destr'
 import { isEqual } from 'ohash'
+import { useNuxtApp } from '../nuxt'
 import { useRequestEvent } from './ssr'
-import { useNuxtApp } from '#app'
 
 type _CookieOptions = Omit<CookieSerializeOptions & CookieParseOptions, 'decode' | 'encode'>
 

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -1,6 +1,6 @@
 import { createError as _createError, H3Error } from 'h3'
 import { toRef } from 'vue'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '../nuxt'
 
 export const useError = () => toRef(useNuxtApp().payload, 'error')
 

--- a/packages/nuxt/src/app/composables/hydrate.ts
+++ b/packages/nuxt/src/app/composables/hydrate.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '../nuxt'
 
 /**
  * Allows full control of the hydration cycle to set and receive data from the server.

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -1,6 +1,6 @@
 import { parseURL, joinURL } from 'ufo'
 import { useNuxtApp } from '../nuxt'
-import { useHead } from '#app'
+import { useHead } from '..'
 
 interface LoadPayloadOptions {
   fresh?: boolean

--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'vue'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '../nuxt'
 
 /**
  * Preload a component or components that have been globally registered.

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -2,7 +2,9 @@ import { getCurrentInstance, inject } from 'vue'
 import type { Router, RouteLocationNormalizedLoaded, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, NavigationFailure, RouteLocationPathRaw } from 'vue-router'
 import { sendRedirect } from 'h3'
 import { hasProtocol, joinURL, parseURL } from 'ufo'
-import { useNuxtApp, useRuntimeConfig, useState, createError, NuxtError } from '#app'
+import { useNuxtApp, useRuntimeConfig } from '../nuxt'
+import { createError, NuxtError } from './error'
+import { useState } from './state'
 
 export const useRouter = () => {
   return useNuxtApp()?.$router as Router

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-redeclare */
 import type { CompatibilityEvent } from 'h3'
-import { useNuxtApp } from '#app'
-import { NuxtApp } from '#app/nuxt'
+import { useNuxtApp, NuxtApp } from '../nuxt'
 
 export function useRequestHeaders<K extends string = string> (include: K[]): Record<K, string | undefined>
 export function useRequestHeaders (): Readonly<Record<string, string | undefined>>

--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -1,6 +1,6 @@
 import { isRef, toRef } from 'vue'
 import type { Ref } from 'vue'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '../nuxt'
 
 /**
  * Create a global reactive ref that will be hydrated but not shared across ssr requests

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -13,7 +13,7 @@ vi.mock('vue', async () => {
 })
 
 // Mocks Nuxt `useRouter()`
-vi.mock('#app', () => ({
+vi.mock('../src/app/composables/router', () => ({
   useRouter: () => ({ resolve: ({ to }: { to: string }) => ({ href: to }) })
 }))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I came a significant performance hit (in Nuxt Bridge) from importing from `#app` alias with vite, because `#app` re-exports lots of files which themselves import from `#app`.

We can work around that by using relative imports, which I think is also slightly nicer. Even though I haven't measured a slow-down in this repo, it can't hurt and should be a more intelligible approach for vite. I've left a number of imports from `#app` untouched within plugins/components as these are not re-exported from `#app`. (It might also be possible to do the same with `head`, but it's still in a quasi-independent state and this can wait for improvements to its implementation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

