### PR TITLE
feat(nuxt, kit): auto import `defineNuxtConfig`

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -7,6 +7,7 @@ import { NuxtConfigSchema } from '@nuxt/schema'
 export interface LoadNuxtConfigOptions extends LoadConfigOptions<NuxtConfig> {}
 
 export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<NuxtOptions> {
+  (globalThis as any).defineNuxtConfig = (c: any) => c
   const result = await loadConfig<NuxtConfig>({
     name: 'nuxt',
     configFile: 'nuxt.config',
@@ -16,6 +17,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     globalRc: true,
     ...opts
   })
+  delete (globalThis as any).defineNuxtConfig
   const { configFile, layers = [], cwd } = result
   const nuxtConfig = result.config!
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -234,10 +234,11 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   return nuxt
 }
 
-/** @deprecated `defineNuxtConfig` is auto imported! Remove import or (alternatively) use `import { defineNuxtConfig } from  'nuxt/config'` */
+/** @deprecated `defineNuxtConfig` is auto imported. Remove import or alternatively use `import { defineNuxtConfig } from  'nuxt/config'`. */
 export function defineNuxtConfig (config: NuxtConfig): NuxtConfig {
   return config
 }
 
-/** @deprecated Use import type { NuxtConfig } from  'nuxt/config' or remove import  */
-export type { NuxtConfig }
+/** @deprecated Use `import type { NuxtConfig } from  'nuxt/config'`.  */
+type _NuxtConfig = NuxtConfig
+export type { _NuxtConfig as NuxtConfig }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -234,10 +234,10 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   return nuxt
 }
 
-/** @deprecated Use import { defineNuxtConfig } from  'nuxt/config' */
+/** @deprecated `defineNuxtConfig` is auto imported! Remove import or (alternatively) use `import { defineNuxtConfig } from  'nuxt/config'` */
 export function defineNuxtConfig (config: NuxtConfig): NuxtConfig {
   return config
 }
 
-/** @deprecated Use import type { NuxtConfig } from  'nuxt/config' */
+/** @deprecated Use import type { NuxtConfig } from  'nuxt/config' or remove import  */
 export type { NuxtConfig }

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -1,2 +1,6 @@
 export * from './core/nuxt'
 export * from './core/builder'
+
+declare global {
+  const defineNuxtConfig: typeof import('nuxt/config')['defineNuxtConfig']
+}

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -1,6 +1,2 @@
 export * from './core/nuxt'
 export * from './core/builder'
-
-declare global {
-  const defineNuxtConfig: typeof import('nuxt/config')['defineNuxtConfig']
-}

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="nitropack" />
 export * from './dist/index'
+
+declare global {
+  const defineNuxtConfig: typeof import('nuxt/config')['defineNuxtConfig']
+}

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,3 @@
-import { defineNuxtConfig } from 'nuxt/config'
+export default defineNuxtConfig({
 
-export default defineNuxtConfig({})
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#7485

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A quick implementation to make `defineNuxtConfig` available when loading configuration. This way we can remove `import { defineNuxtConfig } from 'nuxt/config' at all!`. If feature proven to be stable, will probably move it to c12.

Type support: It is possible with a global reference defined in `'nuxt'` types. Since we run `nuxi prepare` after installing dependencies, it should be immediately available.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

