### PR TITLE
fix(nuxt): add `payload.client` plugin only for production build

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -2,7 +2,7 @@ import { defineNuxtPlugin, loadPayload, addRouteMiddleware, isPrerendered } from
 
 export default defineNuxtPlugin((nuxtApp) => {
   // Only enable behavior if initial page is prerendered
-  // TOOD: Support hybrid
+  // TOOD: Support hybrid and dev
   if (!isPrerendered()) {
     return
   }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -174,7 +174,9 @@ async function initNuxt (nuxt: Nuxt) {
   })
 
   // Add prerender payload support
-  addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
+  if (!nuxt.options.dev) {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
+  }
 
   // Track components used to render for webpack
   if (nuxt.options.builder === '@nuxt/webpack-builder') {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#6455

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Payload extraction is currently not used for dev mode (but planned https://github.com/nuxt/framework/issues/6411). While plugin auto disables itself, there is no need for it to be added.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

