### PR TITLE
feat(nuxt): generate spa fallbacks for `nuxt generate`

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -58,7 +58,7 @@
     "knitwork": "^0.1.2",
     "magic-string": "^0.26.3",
     "mlly": "^0.5.14",
-    "nitropack": "^0.5.2",
+    "nitropack": "^0.5.3",
     "nuxi": "3.0.0-rc.9",
     "ohash": "^0.1.5",
     "ohmyfetch": "^0.4.18",

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -56,8 +56,8 @@ export async function initNitro (nuxt: Nuxt) {
     prerender: {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
-        .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false ? ['/', '/200.html', '/404.html'] : [])
+        .concat(nuxt.options._generate ? ['/', '/200.html', ...nuxt.options.generate.routes] : [])
+        .concat(nuxt.options.ssr === false ? ['/index.html', '/200.html', '/404.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -106,6 +106,8 @@ const getSPARenderer = lazyCachedFunction(async () => {
 const PAYLOAD_CACHE = process.env.prerender ? new Map() : null // TODO: Use LRU cache
 const PAYLOAD_URL_RE = /\/_payload(\.[a-zA-Z0-9]+)?.js(\?.*)?$/
 
+const NO_SSR_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
+
 export default defineRenderHandler(async (event) => {
   // Whether we're rendering an error page
   const ssrError = event.req.url?.startsWith('/__nuxt_error')
@@ -130,7 +132,7 @@ export default defineRenderHandler(async (event) => {
     req: event.req,
     res: event.res,
     runtimeConfig: useRuntimeConfig() as NuxtSSRContext['runtimeConfig'],
-    noSSR: !!event.req.headers['x-nuxt-no-ssr'],
+    noSSR: !!(event.req.headers['x-nuxt-no-ssr']) || (process.env.prerender ? NO_SSR_ROUTES.has(url) : false),
     error: !!ssrError,
     nuxt: undefined!, /* NuxtApp */
     payload: (ssrError ? { error: ssrError } : {}) as NuxtSSRContext['payload']

--- a/yarn.lock
+++ b/yarn.lock
@@ -4397,6 +4397,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"c12@npm:^0.2.12":
+  version: 0.2.12
+  resolution: "c12@npm:0.2.12"
+  dependencies:
+    defu: ^6.1.0
+    dotenv: ^16.0.2
+    gittar: ^0.1.1
+    jiti: ^1.15.0
+    mlly: ^0.5.14
+    pathe: ^0.3.7
+    pkg-types: ^0.3.5
+    rc9: ^1.2.2
+  checksum: 3b2fc182d68aceb940e0ff91b875e79a9027d55b6298b15fb9acc19dee60752dbfc597fb1047044c80a1adf86c45751b7c956537c71a03792e9b2bbe52b9742a
+  languageName: node
+  linkType: hard
+
 "cac@npm:^6.7.12":
   version: 6.7.14
   resolution: "cac@npm:6.7.14"
@@ -10211,9 +10227,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitropack@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "nitropack@npm:0.5.2"
+"nitropack@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "nitropack@npm:0.5.3"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
     "@netlify/functions": ^1.2.0
@@ -10227,7 +10243,7 @@ __metadata:
     "@rollup/pluginutils": ^4.2.1
     "@vercel/nft": ^0.22.1
     archiver: ^5.3.1
-    c12: ^0.2.11
+    c12: ^0.2.12
     chalk: ^5.0.1
     chokidar: ^3.5.3
     consola: ^2.15.3
@@ -10276,7 +10292,7 @@ __metadata:
   bin:
     nitro: dist/cli.mjs
     nitropack: dist/cli.mjs
-  checksum: a27577af6902cbf606c56adcff0c2e88007c0eccfb31b674562fa36f88b91ddf02a2d490b08678aa6912e80ff8fc01502ff19cab4ba9cb488edf2223c89eee2f
+  checksum: f43ce535feb213b2a7f8c06e44befdb4058e4c6e5f87c5923e35256ab5fee03c9e71d3d7a3b4aa6bc707b371a203f962447ca5a0b1c10b69d0e5466e7cf6e5ee
   languageName: node
   linkType: hard
 
@@ -10736,7 +10752,7 @@ __metadata:
     knitwork: ^0.1.2
     magic-string: ^0.26.3
     mlly: ^0.5.14
-    nitropack: ^0.5.2
+    nitropack: ^0.5.3
     nuxi: 3.0.0-rc.9
     ohash: ^0.1.5
     ohmyfetch: ^0.4.18


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #5003

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR generates fallback SPA page for `nuxt generate` (ssr: true) in order to make fallback supported.

- `nuxt: generate` + `ssr: true` (default): `200.html` is generated (new) without being server-side rendered.
- `nuxt: generate` + `ssr: false`: `200.html`, `404.html` and `index.html` (new) are generated

Nitro prerenderer detects this _explicit_ routes and disable SSR for them. To avoid confusing with actually prerendering top level `/`, `index.html` is only pre-rendered for `ssr: false`. Also `404.html` is only generated for `ssr: false`. It can be added for `ssr: true` using `nitro.prerender.routes: ['/404.html']` if needed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

