### PR TITLE
fix(vite): disable server warmup with `vite-node`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -112,7 +112,11 @@ export async function bundle (nuxt: Nuxt) {
       }
     })
 
-    if (nuxt.options.vite.warmupEntry !== false) {
+    if (
+      nuxt.options.vite.warmupEntry !== false &&
+      // https://github.com/nuxt/framework/issues/7510
+      !(env.isServer && ctx.nuxt.options.vite.devBundler !== 'legacy')
+    ) {
       const start = Date.now()
       warmupViteServer(server, [join('/@fs/', ctx.entry)], env.isServer)
         .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/7510

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Disable vite-node cache warmup until investigating #https://github.com/nuxt/framework/issues/7510 and benchmarking. Currently it has _negative_ performance effect.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

