### PR TITLE
fix(nuxt): disable payload extraction for spa generated pages

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -139,7 +139,7 @@ export default defineRenderHandler(async (event) => {
   }
 
   // Whether we are prerendering route
-  const payloadURL = process.env.prerender ? joinURL(url, '_payload.js') : undefined
+  const payloadURL = (process.env.prerender && !ssrContext.noSSR) ? joinURL(url, '_payload.js') : undefined
   if (process.env.prerender) {
     ssrContext.payload.prerenderedAt = Date.now()
   }
@@ -209,7 +209,7 @@ export default defineRenderHandler(async (event) => {
     bodyAppend: normalizeChunks([
       process.env.NUXT_NO_SCRIPTS
         ? undefined
-        : (process.env.prerender
+        : ((process.env.prerender && !ssrContext.noSSR)
             ? `<script type="module">import p from "${payloadURL}";window.__NUXT__={...p,...(${devalue(splitPayload(ssrContext).initial)})}</script>`
             : `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`
           ),

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -106,7 +106,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
 const PAYLOAD_CACHE = process.env.prerender ? new Map() : null // TODO: Use LRU cache
 const PAYLOAD_URL_RE = /\/_payload(\.[a-zA-Z0-9]+)?.js(\?.*)?$/
 
-const NO_SSR_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
+const SPA_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
 
 export default defineRenderHandler(async (event) => {
   // Whether we're rendering an error page
@@ -132,7 +132,10 @@ export default defineRenderHandler(async (event) => {
     req: event.req,
     res: event.res,
     runtimeConfig: useRuntimeConfig() as NuxtSSRContext['runtimeConfig'],
-    noSSR: !!(event.req.headers['x-nuxt-no-ssr']) || (process.env.prerender ? NO_SSR_ROUTES.has(url) : false),
+    noSSR:
+      !!(process.env.NUXT_NO_SSR) ||
+      !!(event.req.headers['x-nuxt-no-ssr']) ||
+      (process.env.prerender ? SPA_ROUTES.has(url) : false),
     error: !!ssrError,
     nuxt: undefined!, /* NuxtApp */
     payload: (ssrError ? { error: ssrError } : {}) as NuxtSSRContext['payload']

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -106,7 +106,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
 const PAYLOAD_CACHE = process.env.prerender ? new Map() : null // TODO: Use LRU cache
 const PAYLOAD_URL_RE = /\/_payload(\.[a-zA-Z0-9]+)?.js(\?.*)?$/
 
-const SPA_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
+const PRERENDER_NO_SSR_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
 
 export default defineRenderHandler(async (event) => {
   // Whether we're rendering an error page
@@ -135,7 +135,7 @@ export default defineRenderHandler(async (event) => {
     noSSR:
       !!(process.env.NUXT_NO_SSR) ||
       !!(event.req.headers['x-nuxt-no-ssr']) ||
-      (process.env.prerender ? SPA_ROUTES.has(url) : false),
+      (process.env.prerender ? PRERENDER_NO_SSR_ROUTES.has(url) : false),
     error: !!ssrError,
     nuxt: undefined!, /* NuxtApp */
     payload: (ssrError ? { error: ssrError } : {}) as NuxtSSRContext['payload']


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/7513#discussioncomment-3649155

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

SPA pages have no actual payload data (other than initial state). 

This also fixes issue for special spa (`index.html`, `200.html` and `404.html`) routes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

