### PR TITLE
fix(schema): only disallow vite server port and host

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { KeepAliveProps, TransitionProps } from 'vue'
 import { ConfigSchema } from '../../schema/config'
-import type { ViteServerOptions, UserConfig as ViteUserConfig } from 'vite'
+import type { ServerOptions as ViteServerOptions, UserConfig as ViteUserConfig } from 'vite'
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 import type { MetaObject } from './meta'
 import type { Nuxt } from './nuxt'

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,6 +1,6 @@
 import type { KeepAliveProps, TransitionProps } from 'vue'
 import { ConfigSchema } from '../../schema/config'
-import type { UserConfig as ViteUserConfig } from 'vite'
+import type { ViteServerOptions, UserConfig as ViteUserConfig } from 'vite'
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 import type { MetaObject } from './meta'
 import type { Nuxt } from './nuxt'
@@ -53,7 +53,7 @@ export interface ViteConfig extends ViteUserConfig {
   /**
    * Use environment variables or top level `server` options to configure Nuxt server.
    */
-  server?: never
+  server?: Omit<ViteServerOptions, 'port' | 'host'>
 }
 
 
@@ -61,11 +61,11 @@ export interface ViteConfig extends ViteUserConfig {
 
 type RuntimeConfigNamespace = Record<string, any>
 
-export interface PublicRuntimeConfig extends RuntimeConfigNamespace {}
+export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
 
 // TODO: remove before release of 3.0.0
 /** @deprecated use RuntimeConfig interface */
-export interface PrivateRuntimeConfig extends RuntimeConfigNamespace {}
+export interface PrivateRuntimeConfig extends RuntimeConfigNamespace { }
 
 export interface RuntimeConfig extends PrivateRuntimeConfig, RuntimeConfigNamespace {
   public: PublicRuntimeConfig
@@ -88,4 +88,4 @@ export interface NuxtAppConfig {
   keepalive: boolean | KeepAliveProps
 }
 
-export interface AppConfig {}
+export interface AppConfig { }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/pull/7317#issuecomment-1247923503

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

So options like `hmr` can be configured seamlessly.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

