### PR TITLE
fix(nuxt): keep `state` in initial state instead of extracting it

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -10,7 +10,6 @@ export default defineNuxtPlugin((nuxtApp) => {
     const payload = await loadPayload(url)
     if (!payload) { return }
     Object.assign(nuxtApp.payload.data, payload.data)
-    Object.assign(nuxtApp.payload.state, payload.state)
   }
   nuxtApp.hooks.hook('link:prefetch', async (to) => {
     await prefetchPayload(to)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -296,9 +296,9 @@ function renderPayloadResponse (ssrContext: NuxtSSRContext) {
 }
 
 function splitPayload (ssrContext: NuxtSSRContext) {
-  const { data, state, prerenderedAt, ...initial } = ssrContext.payload
+  const { data, prerenderedAt, ...initial } = ssrContext.payload
   return {
     initial: { ...initial, prerenderedAt },
-    payload: { data, state, prerenderedAt }
+    payload: { data, prerenderedAt }
   }
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -590,7 +590,7 @@ describe.skipIf(process.env.NUXT_TEST_DEV || isWindows)('payload rendering', () 
   it('renders a payload', async () => {
     const payload = await $fetch('/random/a/_payload.js', { responseType: 'text' })
     expect(payload).toMatch(
-      /export default \{data:\{\$frand_a:\[[^\]]*\]\},state:\{"\$srandom:rand_a":\d*,"\$srandom:default":\d*\},prerenderedAt:\d*\}/
+      /export default \{data:\{\$frand_a:\[[^\]]*\]\},prerenderedAt:\d*\}/
     )
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #7562

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#6455 adds `payload.state` (set by `useState`) to the extracted payload. This will cause hydration and unwanted behavior on navigation by orriding already initialized state. 

This PR, makes behavior closer to Nuxt 2 by keeping state to the initial state inlined in the pages. Only payload data is now extracted.

Alternatives: We could instead keep extracting state and only try to set keys that are not assigned yet but it seems wrong performance wise if state is _initial state_ it should be set once and if is same across pages, loading it adds to network overhead. We can revise it later with some better approach to only record state change diffs and include that in `_payload.js` somehow.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

