### PR TITLE
fix(nuxt): load payload after middleware and once final route is resolved

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -10,7 +10,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   // Load payload into cache
   nuxtApp.hooks.hook('link:prefetch', to => loadPayload(to))
 
-  // Load payload after final route is resolved
+  // Load payload after middleware & once final route is resolved
   useRouter().beforeResolve(async (to, from) => {
     if (to.path === from.path) { return }
     const payload = await loadPayload(to.path)

--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, loadPayload, addRouteMiddleware, isPrerendered } from '#app'
+import { defineNuxtPlugin, loadPayload, isPrerendered, useRouter } from '#app'
 
 export default defineNuxtPlugin((nuxtApp) => {
   // Only enable behavior if initial page is prerendered
@@ -6,17 +6,16 @@ export default defineNuxtPlugin((nuxtApp) => {
   if (!isPrerendered()) {
     return
   }
-  const prefetchPayload = async (url: string) => {
-    const payload = await loadPayload(url)
+
+  // Load payload into cache
+  nuxtApp.hooks.hook('link:prefetch', to => loadPayload(to))
+
+  // Load payload after final route is resolved
+  useRouter().beforeResolve(async (to, from) => {
+    if (to.path === from.path) { return }
+    const payload = await loadPayload(to.path)
     if (!payload) { return }
     Object.assign(nuxtApp.payload.data, payload.data)
     Object.assign(nuxtApp.payload.state, payload.state)
-  }
-  nuxtApp.hooks.hook('link:prefetch', async (to) => {
-    await prefetchPayload(to)
-  })
-  addRouteMiddleware(async (to, from) => {
-    if (to.path === from.path) { return }
-    await prefetchPayload(to.path)
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/7562

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is not an alternative to https://github.com/nuxt/framework/pull/7567, but a separate fix. It ensures the data is only applied immediately before the route resolves (so after all middleware have been processed - and not when the data is prefetched)....

Where same asyncData keys are used for different routes (e.g. in a `[slug].vue`), this will resolve the issue, with one exception: if there are still additional async setups required and the keys collide.

In some ways this mitigates https://github.com/nuxt/framework/issues/7562 because data isn't overwritten when it is prefetched, but only when the route is changed.

---

**Note**: although it hotfixes content + prerender, we still would want to change content implementation as suspense doesn't work when swapping data out like this; instead, we want a route-based composable so that we can have two 'trees'. (useState doesn't work best when holding _route-based_ data because it isn't naturally associated with a route... See https://github.com/nuxt/framework/issues/7568.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

