### PR TITLE
fix(vite): provide fallback reason

### DIFF
--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -40,6 +40,8 @@ function createRunner () {
         if (!errorData) {
           throw err
         }
+        errorData.stack = errorData.stack || err.stack
+        errorData.reason = errorData.reason || err.message
         let _err
         try {
           const { message, stack } = formatViteError(errorData)

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -40,7 +40,6 @@ function createRunner () {
         if (!errorData) {
           throw err
         }
-        errorData.stack = errorData.stack || err.stack
         errorData.reason = errorData.reason || err.message
         let _err
         try {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/7534

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds more info in the event of minimal error data. In the linked issue, error data is:

```js
const errorData = {
  code: "ERR_MODULE_NOT_FOUND",
}
```

That's enough to thwart our formatter.

<img width="1610" alt="CleanShot 2022-09-15 at 23 09 56@2x" src="https://user-images.githubusercontent.com/28706372/190517539-14f8bcf0-b76c-4096-a27f-ac2785643dbc.png">

This PR adds stack + reason fallbacks, transforming it to:

<img width="1611" alt="CleanShot 2022-09-15 at 23 09 19@2x" src="https://user-images.githubusercontent.com/28706372/190517460-a41da88c-e729-4360-aefa-a2cee284387a.png">

Admittedly probably the stack isn't helpful in this case, but at least the error message tells us the module that couldn't be fetched. Alternatively, maybe we could directly throw the error if we only have a `code` in errorData?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

