### PR TITLE
fix(nuxi): print resolved public directory after generate

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -42,8 +42,9 @@ export default defineNuxtCommand({
     await buildNuxt(nuxt)
 
     if (args.prerender) {
+      // TODO: revisit later if/when nuxt build --prerender will output hybrid
       const dir = nitro?.options.output.publicDir
-      const publicDir = dir ? relative(rootDir, dir) : '.output/public'
+      const publicDir = dir ? relative(process.cwd(), dir) : '.output/public'
       consola.success(`You can now deploy \`${publicDir}\` to any static hosting!`)
     }
   }

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import consola from 'consola'
 import { writeTypes } from '../utils/prepare'
 import { loadKit } from '../utils/kit'
@@ -19,7 +19,7 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
     showVersions(rootDir)
 
-    const { loadNuxt, buildNuxt } = await loadKit(rootDir)
+    const { loadNuxt, buildNuxt, useNitro } = await loadKit(rootDir)
 
     const nuxt = await loadNuxt({
       rootDir,
@@ -27,6 +27,8 @@ export default defineNuxtCommand({
         _generate: args.prerender
       }
     })
+
+    const nitro = useNitro()
 
     await clearDir(nuxt.options.buildDir)
 
@@ -38,5 +40,11 @@ export default defineNuxtCommand({
     })
 
     await buildNuxt(nuxt)
+
+    if (args.prerender) {
+      const dir = nitro?.options.output.publicDir
+      const publicDir = dir ? relative(rootDir, dir) : '.output/public'
+      consola.success(`You can now deploy \`${publicDir}\` to any static hosting!`)
+    }
   }
 })

--- a/packages/nuxi/src/commands/generate.ts
+++ b/packages/nuxi/src/commands/generate.ts
@@ -1,4 +1,3 @@
-import consola from 'consola'
 import buildCommand from './build'
 import { defineNuxtCommand } from './index'
 
@@ -11,6 +10,5 @@ export default defineNuxtCommand({
   async invoke (args) {
     args.prerender = true
     await buildCommand.invoke(args)
-    consola.success('You can now deploy `.output/public` to any static hosting!')
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7511

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using new useNitro utility (https://github.com/nuxt/framework/pull/7557) we can access the resolved publicDir for nitro and print the relative path to it, rather than hard coding `.output/public`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

