### PR TITLE
feat: allow disabling payload extraction

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -101,6 +101,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       'process.env.NUXT_NO_SSR': nuxt.options.ssr === false,
       'process.env.NUXT_NO_SCRIPTS': !!nuxt.options.experimental.noScripts,
       'process.env.NUXT_INLINE_STYLES': !!nuxt.options.experimental.inlineSSRStyles,
+      'process.env.NUXT_PAYLOAD_EXTRACTION': !!nuxt.options.experimental.payloadExtraction,
       'process.dev': nuxt.options.dev,
       __VUE_PROD_DEVTOOLS__: false
     },

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -174,7 +174,7 @@ async function initNuxt (nuxt: Nuxt) {
   })
 
   // Add prerender payload support
-  if (!nuxt.options.dev) {
+  if (!nuxt.options.dev && nuxt.options.experimental.payloadExtraction) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
   }
 

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -74,5 +74,10 @@ export default defineUntypedSchema({
      * Turn off rendering of Nuxt scripts and JS resource hints.
      */
     noScripts: false,
+
+    /**
+     * When this option is enabled (by default) payload of pages generated with `nuxt generate` are extracted
+     */
+    payloadExtraction: true,
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7587

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows disabling payload extraction with `nuxi generate` introduced in RC.10 (#6455) using `experimental.payloadExtraction: false`

```js
export default defineNuxtConfig({
  experimental: {
    payloadExtraction: false
  }
})
```

Remarks:
- Even by disabling the (static) payload extraction, `/_payload.js` endpoint is still available for renderer. It is a separate feature
- I've confirmed tree-shaking keeps working with refactors


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

