### PR TITLE
fix(vite): normalize vite-node error data

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -113,7 +113,13 @@ function createViteNodeMiddleware (ctx: ViteBuildContext, invalidates: Set<strin
         throw createError({ statusCode: 400 })
       }
       const module = await node.fetchModule(moduleId).catch((err) => {
-        throw createError({ data: err })
+        const errorData = {
+          code: 'VITE_ERROR',
+          id: moduleId,
+          stack: '',
+          ...err
+        }
+        throw createError({ data: errorData })
       })
       return module
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/7534

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There are vast different possibilities from errors rollup and vite throw. Since vite-node tries to make a network request to fetch the modules, we were missing some information (such as module id). This PR _tries_ to normalize it beforehand.

<img width="633" alt="image" src="https://user-images.githubusercontent.com/5158436/190700540-780f99df-5562-43b2-a1f4-391b6de08ec8.png">


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

