### PR TITLE
fix(nuxi): backward compatibility for kit <= RC.10 without `useNitro`

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -28,6 +28,7 @@ export default defineNuxtCommand({
       }
     })
 
+    // Use ? for backward compatibility for Nuxt <= RC.10
     const nitro = useNitro?.()
 
     await clearDir(nuxt.options.buildDir)

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -28,7 +28,7 @@ export default defineNuxtCommand({
       }
     })
 
-    const nitro = useNitro()
+    const nitro = useNitro?.()
 
     await clearDir(nuxt.options.buildDir)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If used with an older version of kit without the feature it will error out on:

```
 ERROR  useNitro is not a function
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

