### PR TITLE
docs: fix typo on directory-structure/pages

### DIFF
--- a/docs/content/2.guide/2.directory-structure/1.pages.md
+++ b/docs/content/2.guide/2.directory-structure/1.pages.md
@@ -327,7 +327,7 @@ Learn more about [`<NuxtLink>`](/api/components/nuxt-link) usage.
 
 ## Router Options
 
-It is possible to cutomize [vue-router options](https://router.vuejs.org/api/interfaces/routeroptions.html).
+It is possible to customize [vue-router options](https://router.vuejs.org/api/interfaces/routeroptions.html).
 
 ### Using `app/router.options`
 
@@ -343,7 +343,7 @@ export default <RouterOptions> {
 
 #### Custom Routes
 
-:StabilityEdge{title="custom routes"}
+:StabilityEdge{title="Custom Routes"}
 
 You can optionally override routes using a function that accepts scanned routes and returns customized routes.
 If returning `null` or `undefined`, Nuxt will fallback to the default routes. (useful to modify input array)
@@ -365,7 +365,7 @@ export default <RouterOptions> {
 
 #### Custom History (advanced)
 
-:StabilityEdge{title="custom history"}
+:StabilityEdge{title="Custom History"}
 
 You can optionally override history mode using a function that accepts base url and returns history mode.
 If returning `null` or `undefined`, Nuxt will fallback to the default history.
@@ -402,7 +402,7 @@ export default defineNuxtConfig({
 
 ### Hash Mode (SPA)
 
-:StabilityEdge{title="hash mode"}
+:StabilityEdge{title="Hash Mode"}
 
 You can enable hash history in SPA mode. In this mode, router uses a hash character (#) before the actual URL that is internally passed. When enabled, the **URL is never sent to the server** and **SSR is not supported**.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have fixed typo on the `directory-structure/pages` page, capitalized StabilityEdge texts.

