### PR TITLE
fix(vite): respect `ctx.nuxt.options.modulesDir` for resolving externals with `vite-node`

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -102,7 +102,7 @@ function createViteNodeMiddleware (ctx: ViteBuildContext, invalidates: Set<strin
     node.shouldExternalize = async (id: string) => {
       const result = await isExternal(id)
       if (result?.external) {
-        return resolveModule(result.id, { url: ctx.nuxt.options.rootDir })
+        return resolveModule(result.id, { url: ctx.nuxt.options.modulesDir })
       }
       return false
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7609

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are overriding `shouldExternalize` (PR: #6153) of vite-node, and use mlly resolver to directly resolve paths. Issue with #7609 happens because directly setting URL to the directory of `rootDir`, causes resolving from parent `node_modules` and finally different resolved `vue` version. (Correct way is setting `rootDir + '/_node_modules'` or `rootDir + /index.mjs`)

This PR resolves issue by respecting `modulesDir` for resolving `vue` and other dependencies. In the future we might come of with better implementation to actually reuse same vite resolution. I didn't use `return id` on external branch (while it works!) until getting confirmation from @antfu. Vite-node's default external handler however does this. [src](https://github.com/vitest-dev/vitest/blob/95da4d66933db46da368d5d66f422afd26fba4c1/packages/vite-node/src/externalize.ts#L85)

Also worth to mention that `isExternal('vue')` resolves to `null` as it is unable to determine external status.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

