### PR TITLE
fix(vite, webpack): avoid generating keys where a key is already provided

### DIFF
--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -24,7 +24,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
     enforce: 'post',
     transformInclude (id) {
       const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      return pathname.match(/node_modules\/nuxt3?\//) && pathname.match(/\.(m?[jt]sx?|vue)/) && parseQuery(search).type !== 'style'
+      return !pathname.match(/node_modules\/nuxt3?\//) && pathname.match(/\.(m?[jt]sx?|vue)/) && parseQuery(search).type !== 'style'
     },
     transform (code, id) {
       if (!KEYED_FUNCTIONS_RE.test(code)) { return }

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -22,9 +22,11 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
   return {
     name: 'nuxt:composable-keys',
     enforce: 'post',
-    transform (code, id) {
+    transformInclude (id) {
       const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      if (!pathname.match(/\.(m?[jt]sx?|vue)/) || parseQuery(search).type === 'style') { return }
+      return pathname.match(/node_modules\/nuxt3?\//) && pathname.match(/\.(m?[jt]sx?|vue)/) && parseQuery(search).type !== 'style'
+    },
+    transform (code, id) {
       if (!KEYED_FUNCTIONS_RE.test(code)) { return }
       const { 0: script = code, index: codeIndex = 0 } = code.match(/(?<=<script[^>]*>)[\S\s.]*?(?=<\/script>)/) || []
       const s = new MagicString(code)

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -50,7 +50,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
 
             case 'useFetch':
             case 'useLazyFetch':
-              if (node.arguments.length >= 2) { return }
+              if (node.arguments.length >= 3 || stringTypes.includes(node.arguments[1]?.type)) { return }
               break
 
             case 'useAsyncData':
@@ -59,9 +59,8 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
               break
           }
 
-          const end = (node as any).end
           s.appendLeft(
-            codeIndex + end - 1,
+            codeIndex + (node as any).end - 1,
             (node.arguments.length ? ', ' : '') + "'$" + hash(`${relativeID}-${++count}`) + "'"
           )
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7578

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With webpack, we were processing code _twice_ and therefore injecting several auto-generated keys, one after the other. This PR prevents double-insertion of keys, and also prevents insertion when there is an obvious string or template literal key provided already.

It also excludes nuxt sourcefiles (e.g. `#app`) from having keys inserted into them.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

