### PR TITLE
fix(nuxt): add missing `process.client` for early redirect in navigateTo

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -79,7 +79,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   }
 
   // Early redirect on client-side
-  if (!isExternal && isProcessingMiddleware()) {
+  if (process.client && !isExternal && isProcessingMiddleware()) {
     return to
   }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -265,6 +265,12 @@ describe('middlewares', () => {
     expect(html).toContain('auth: ')
     expect(html).not.toContain('Injected by injectAuth middleware')
   })
+
+  it('should redirect to index with http 307 with navigateToOption', async () => {
+    const html = await fetch('/navigate-to-redirect', { redirect: 'manual' })
+    expect(html.headers.get('location')).toEqual('/')
+    expect(html.status).toEqual(307)
+  })
 })
 
 describe('plugins', () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -266,7 +266,7 @@ describe('middlewares', () => {
     expect(html).not.toContain('Injected by injectAuth middleware')
   })
 
-  it('should redirect to index with http 307 with navigateToOption', async () => {
+  it('should redirect to index with http 307 with navigateTo on server side', async () => {
     const html = await fetch('/navigate-to-redirect', { redirect: 'manual' })
     expect(html.headers.get('location')).toEqual('/')
     expect(html.status).toEqual(307)

--- a/test/fixtures/basic/pages/navigate-to-redirect.vue
+++ b/test/fixtures/basic/pages/navigate-to-redirect.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>You should not see me</div>
+</template>
+
+<script setup>
+definePageMeta({
+  middleware: () => {
+    return navigateTo({ path: '/' }, { redirectCode: 307 })
+  }
+})
+</script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/framework/issues/7501
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: , this PR is a small fix adding process.client to early redirect on client side for `navigateTo()`. There's also a small test to ensure the http status code is correct.

 However there's an issue using `navigateTo` in async middlewares which throws a `nuxt instance not available` error. I believe this has been already reported in some issues.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

