### PR TITLE
fix(nuxt): don't treeshake client-only fallback templates

### DIFF
--- a/packages/nuxt/src/components/tree-shake.ts
+++ b/packages/nuxt/src/components/tree-shake.ts
@@ -6,7 +6,7 @@ import type { Component } from '@nuxt/schema'
 
 interface TreeShakeTemplatePluginOptions {
   sourcemap?: boolean
-  getComponents(): Component[]
+  getComponents (): Component[]
 }
 
 export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplatePluginOptions) => {
@@ -26,7 +26,7 @@ export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplat
           .filter(c => c.mode === 'client' && !components.some(other => other.mode !== 'client' && other.pascalName === c.pascalName))
           .map(c => `${c.pascalName}|${c.kebabName}`)
           .concat('ClientOnly|client-only')
-          .map(component => `<(${component})[^>]*>[\\s\\S]*?<\\/(${component})>`)
+          .map(component => `<(${component})(| [^>]*)>[\\s\\S]*?<\\/(${component})>`)
 
         regexpMap.set(components, new RegExp(`(${clientOnlyComponents.join('|')})`, 'g'))
       }
@@ -34,8 +34,12 @@ export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplat
       const COMPONENTS_RE = regexpMap.get(components)!
       const s = new MagicString(code)
 
-      // Do not render client-only slots on SSR, but preserve attributes
-      s.replace(COMPONENTS_RE, r => r.replace(/<([^>]*[^/])\/?>[\s\S]*$/, '<$1 />'))
+      // Do not render client-only slots on SSR, but preserve attributes and fallback/placeholder slots
+      s.replace(COMPONENTS_RE, r => r.replace(/<([^>]*[^/])\/?>[\s\S]*$/, (chunk: string, el: string) => {
+        const fallback = chunk.match(/<template[^>]*(#|v-slot:)(fallback|placeholder)[^>]*>[\s\S]*?<\/template>/)?.[0] || ''
+        const tag = el.split(' ').shift()
+        return `<${el}>${fallback}</${tag}>`
+      }))
 
       if (s.hasChanged()) {
         return {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -137,6 +137,8 @@ describe('pages', () => {
     const html = await $fetch('/client-only-components')
     expect(html).toContain('<div class="client-only-script" foo="bar">')
     expect(html).toContain('<div class="client-only-script-setup" foo="hello">')
+    expect(html).toContain('<div>Fallback</div>')
+    expect(html).not.toContain('Should not be server rendered')
 
     await expectNoClientErrors('/client-only-components')
   })

--- a/test/fixtures/basic/pages/client-only-components.vue
+++ b/test/fixtures/basic/pages/client-only-components.vue
@@ -8,5 +8,11 @@
         </div>
       </template>
     </ClientOnlySetupScript>
+    <ClientOnly>
+      Should not be server rendered.
+      <template #fallback>
+        <div>Fallback</div>
+      </template>
+    </ClientOnly>
   </div>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/7517

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is an alternative approach to https://github.com/nuxt/framework/pull/7527, using pure regexp to handle fallback/placeholder slots.

It also fixes a bug where we matched _partial_ component names.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

