### PR TITLE
fix(nuxt): only observe tag elements for `<NuxtLink>` prefetching

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -197,7 +197,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           let unobserve: Function | null = null
           onMounted(() => {
             idleId = requestIdleCallback(() => {
-              if (el?.value) {
+              if (el?.value?.tagName) {
                 unobserve = observer!.observe(el.value, async () => {
                   unobserve?.()
                   unobserve = null


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7524

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's possible that NuxtLink doesn't render an HTML element; we can skip observing it in this case and leave the user to implement prefetching on their own.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

