### PR TITLE
feat(nuxt): add hook debug mode

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -54,7 +54,7 @@
     "globby": "^13.1.2",
     "h3": "^0.7.21",
     "hash-sum": "^2.0.0",
-    "hookable": "^5.4.0",
+    "hookable": "^5.4.1",
     "knitwork": "^0.1.2",
     "magic-string": "^0.26.7",
     "mlly": "^0.5.16",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -54,7 +54,7 @@
     "globby": "^13.1.2",
     "h3": "^0.7.21",
     "hash-sum": "^2.0.0",
-    "hookable": "^5.3.0",
+    "hookable": "^5.4.0",
     "knitwork": "^0.1.2",
     "magic-string": "^0.26.7",
     "mlly": "^0.5.16",

--- a/packages/nuxt/src/app/plugins/debug.ts
+++ b/packages/nuxt/src/app/plugins/debug.ts
@@ -2,8 +2,5 @@ import { createDebugger } from 'hookable'
 import { defineNuxtPlugin } from '#app'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  // @ts-expect-error remove in next version of hookable
-  createDebugger(nuxtApp.hooks, {
-    tag: 'nuxt app'
-  })
+  createDebugger(nuxtApp.hooks, { tag: 'nuxt-app' })
 })

--- a/packages/nuxt/src/app/plugins/debug.ts
+++ b/packages/nuxt/src/app/plugins/debug.ts
@@ -1,20 +1,9 @@
+import { createDebugger } from 'hookable'
 import { defineNuxtPlugin } from '#app'
 
-const wrapName = (event: string) => process.server ? `[nuxt] ${event}` : event
-
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.hooks.beforeEach(({ name }) => {
-    console.time(wrapName(name))
-  })
-
-  nuxtApp.hooks.afterEach(({ name, args }) => {
-    if (process.client) {
-      console.groupCollapsed(name)
-      console.timeLog(name, args)
-      console.groupEnd()
-    }
-    if (process.server) {
-      console.timeEnd(wrapName(name))
-    }
+  // @ts-expect-error remove in next version of hookable
+  createDebugger(nuxtApp.hooks, {
+    tag: 'nuxt app'
   })
 })

--- a/packages/nuxt/src/app/plugins/debug.ts
+++ b/packages/nuxt/src/app/plugins/debug.ts
@@ -1,0 +1,20 @@
+import { defineNuxtPlugin } from '#app'
+
+const wrapName = (event: string) => process.server ? `[nuxt] ${event}` : event
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hooks.beforeEach(({ name }) => {
+    console.time(wrapName(name))
+  })
+
+  nuxtApp.hooks.afterEach(({ name, args }) => {
+    if (process.client) {
+      console.groupCollapsed(name)
+      console.timeLog(name, args)
+      console.groupEnd()
+    }
+    if (process.server) {
+      console.timeEnd(wrapName(name))
+    }
+  })
+})

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -7,7 +7,6 @@ import { resolvePath } from '@nuxt/kit'
 import defu from 'defu'
 import fsExtra from 'fs-extra'
 import { toEventHandler, dynamicEventHandler } from 'h3'
-import { createDebugger } from 'hookable'
 import { distDir } from '../dirs'
 import { ImportProtectionPlugin } from './plugins/import-protection'
 
@@ -18,6 +17,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Resolve config
   const _nitroConfig = ((nuxt.options as any).nitro || {}) as NitroConfig
   const nitroConfig: NitroConfig = defu(_nitroConfig, <NitroConfig>{
+    debug: nuxt.options.debug,
     rootDir: nuxt.options.rootDir,
     workspaceDir: nuxt.options.workspaceDir,
     srcDir: nuxt.options.serverDir,
@@ -130,11 +130,6 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     exclude: [/core[\\/]runtime[\\/]nitro[\\/]renderer/]
   }))
 
-  if (nuxt.options.debug) {
-    nitroConfig.plugins = nitroConfig.plugins || []
-    nitroConfig.plugins.push(resolve(distDir, 'core/runtime/nitro/plugins/debug'))
-  }
-
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
 
@@ -150,13 +145,6 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
   // Connect hooks
   nuxt.hook('close', () => nitro.hooks.callHook('close'))
-  if (nuxt.options.debug) {
-    // @ts-expect-error remove in next version of hookable
-    const { close } = createDebugger(nitro.hooks, {
-      tag: 'nitro build'
-    })
-    nitro.hooks.hook('close', close)
-  }
 
   // Setup handlers
   const devMiddlewareHandler = dynamicEventHandler()

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -129,6 +129,11 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     exclude: [/core[\\/]runtime[\\/]nitro[\\/]renderer/]
   }))
 
+  if (nuxt.options.debug) {
+    nitroConfig.plugins = nitroConfig.plugins || []
+    nitroConfig.plugins.push(resolve(distDir, 'core/runtime/nitro/plugins/debug'))
+  }
+
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
 

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -7,6 +7,7 @@ import { resolvePath } from '@nuxt/kit'
 import defu from 'defu'
 import fsExtra from 'fs-extra'
 import { toEventHandler, dynamicEventHandler } from 'h3'
+import { createDebugger } from 'hookable'
 import { distDir } from '../dirs'
 import { ImportProtectionPlugin } from './plugins/import-protection'
 
@@ -149,6 +150,13 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
   // Connect hooks
   nuxt.hook('close', () => nitro.hooks.callHook('close'))
+  if (nuxt.options.debug) {
+    // @ts-expect-error remove in next version of hookable
+    const { close } = createDebugger(nitro.hooks, {
+      tag: 'nitro build'
+    })
+    nitro.hooks.hook('close', close)
+  }
 
   // Setup handlers
   const devMiddlewareHandler = dynamicEventHandler()

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,5 +1,5 @@
 import { join, normalize, resolve } from 'pathe'
-import { createHooks } from 'hookable'
+import { createHooks, createDebugger } from 'hookable'
 import type { Nuxt, NuxtOptions, NuxtConfig, ModuleContainer, NuxtHooks } from '@nuxt/schema'
 import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, addVitePlugin, addWebpackPlugin, tryResolveModule, addPlugin } from '@nuxt/kit'
 // Temporary until finding better placement
@@ -183,7 +183,7 @@ async function initNuxt (nuxt: Nuxt) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/preload.server'))
   }
 
-  // Track components used to render for webpack
+  // Add nuxt app debugger
   if (nuxt.options.debug) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/debug'))
   }
@@ -233,6 +233,14 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   }
 
   const nuxt = createNuxt(options)
+
+  // TODO: parallel kit:compatibility calls in defineModule
+  // if (nuxt.options.debug) {
+  //   // @ts-expect-error remove in next version of hookable
+  //   createDebugger(nuxt.hooks, {
+  //     tag: 'nuxt build'
+  //   })
+  // }
 
   if (opts.ready !== false) {
     await nuxt.ready()

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,5 +1,5 @@
 import { join, normalize, resolve } from 'pathe'
-import { createHooks } from 'hookable'
+import { createHooks, createDebugger } from 'hookable'
 import type { Nuxt, NuxtOptions, NuxtConfig, ModuleContainer, NuxtHooks } from '@nuxt/schema'
 import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, addVitePlugin, addWebpackPlugin, tryResolveModule, addPlugin } from '@nuxt/kit'
 // Temporary until finding better placement
@@ -234,13 +234,9 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   const nuxt = createNuxt(options)
 
-  // TODO: parallel kit:compatibility calls in defineModule
-  // if (nuxt.options.debug) {
-  //   // @ts-expect-error remove in next version of hookable
-  //   createDebugger(nuxt.hooks, {
-  //     tag: 'nuxt build'
-  //   })
-  // }
+  if (nuxt.options.debug) {
+    createDebugger(nuxt.hooks, { tag: 'nuxt' })
+  }
 
   if (opts.ready !== false) {
     await nuxt.ready()

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -183,6 +183,11 @@ async function initNuxt (nuxt: Nuxt) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/preload.server'))
   }
 
+  // Track components used to render for webpack
+  if (nuxt.options.debug) {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/debug'))
+  }
+
   for (const m of modulesToInstall) {
     if (Array.isArray(m)) {
       await installModule(m[0], m[1])

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,5 +1,5 @@
 import { join, normalize, resolve } from 'pathe'
-import { createHooks, createDebugger } from 'hookable'
+import { createHooks } from 'hookable'
 import type { Nuxt, NuxtOptions, NuxtConfig, ModuleContainer, NuxtHooks } from '@nuxt/schema'
 import { loadNuxtConfig, LoadNuxtOptions, nuxtCtx, installModule, addComponent, addVitePlugin, addWebpackPlugin, tryResolveModule, addPlugin } from '@nuxt/kit'
 // Temporary until finding better placement

--- a/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
+++ b/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
@@ -1,13 +1,8 @@
+import { createDebugger } from 'hookable'
 import type { NitroAppPlugin } from 'nitropack'
 
-const wrapName = (event: string) => `[nitro] ${event}`
-
 export default <NitroAppPlugin> function (nitro) {
-  nitro.hooks.beforeEach(({ name }) => {
-    console.time(wrapName(name))
-  })
-
-  nitro.hooks.afterEach(({ name }) => {
-    console.timeEnd(wrapName(name))
+  createDebugger(nitro.hooks, {
+    tag: 'nitro app'
   })
 }

--- a/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
+++ b/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
@@ -1,0 +1,13 @@
+import type { NitroAppPlugin } from 'nitropack'
+
+const wrapName = (event: string) => process.server ? `[nitro] ${event}` : event
+
+export default <NitroAppPlugin> function (nitro) {
+  nitro.hooks.beforeEach(({ name }) => {
+    console.time(wrapName(name))
+  })
+
+  nitro.hooks.afterEach(({ name }) => {
+    console.timeEnd(wrapName(name))
+  })
+}

--- a/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
+++ b/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
@@ -1,8 +1,0 @@
-import { createDebugger } from 'hookable'
-import type { NitroAppPlugin } from 'nitropack'
-
-export default <NitroAppPlugin> function (nitro) {
-  createDebugger(nitro.hooks, {
-    tag: 'nitro app'
-  })
-}

--- a/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
+++ b/packages/nuxt/src/core/runtime/nitro/plugins/debug.ts
@@ -1,6 +1,6 @@
 import type { NitroAppPlugin } from 'nitropack'
 
-const wrapName = (event: string) => process.server ? `[nitro] ${event}` : event
+const wrapName = (event: string) => `[nitro] ${event}`
 
 export default <NitroAppPlugin> function (nitro) {
   nitro.hooks.beforeEach(({ name }) => {

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'pathe'
-import { isDevelopment } from 'std-env'
+import { isDebug, isDevelopment } from 'std-env'
 import createRequire from 'create-require'
 import { pascalCase } from 'scule'
 import jiti from 'jiti'
@@ -148,7 +148,7 @@ export default defineUntypedSchema({
 
   /**
    * Set to `true` to enable debug mode.
-   * 
+   *
    * At the moment, it prints out hook names and timings on the server, and
    * logs hook arguments as well in the browser.
    *
@@ -156,7 +156,7 @@ export default defineUntypedSchema({
    * @version 3
    */
   debug: {
-    $resolve: async (val, get) => val ?? false
+    $resolve: async (val, get) => val ?? isDebug
   },
 
   /**

--- a/packages/schema/src/config/_common.ts
+++ b/packages/schema/src/config/_common.ts
@@ -148,12 +148,15 @@ export default defineUntypedSchema({
 
   /**
    * Set to `true` to enable debug mode.
+   * 
+   * At the moment, it prints out hook names and timings on the server, and
+   * logs hook arguments as well in the browser.
    *
-   * By default, it's only enabled in development mode.
    * @version 2
+   * @version 3
    */
   debug: {
-    $resolve: async (val, get) => val ?? await get('dev')
+    $resolve: async (val, get) => val ?? false
   },
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -8380,6 +8380,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hookable@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "hookable@npm:5.4.1"
+  checksum: 2a48150436bf70b4b756bcf15694809032c490c1747aba363a6de928a96712e808b0918de06c933e082cc2042c3f051b593d400df6af4773cd9ad1e85d677839
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -11029,7 +11036,7 @@ __metadata:
     globby: ^13.1.2
     h3: ^0.7.21
     hash-sum: ^2.0.0
-    hookable: ^5.4.0
+    hookable: ^5.4.1
     knitwork: ^0.1.2
     magic-string: ^0.26.7
     mlly: ^0.5.16

--- a/yarn.lock
+++ b/yarn.lock
@@ -8286,10 +8286,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hookable@npm:^5.2.2, hookable@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "hookable@npm:5.3.0"
-  checksum: 5a170b790fc472fae11cc8ebc7a1336e7063c3f0a9697cefb5b18d455fcda4d1eadf21c254a27c0625fbbe31f736fd662797c21e6425e9c8cf073182b2ecae7f
+"hookable@npm:^5.2.2, hookable@npm:^5.3.0, hookable@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "hookable@npm:5.4.0"
+  checksum: 810376b27eab8a8c05684c2c4cb394c7837ac3cf7a91a63f0468cef908a87c982ab2f0320dce0bceaa5fac99006f361a113eb739d0ae3801a9137586b4707f0a
   languageName: node
   linkType: hard
 
@@ -10942,7 +10942,7 @@ __metadata:
     globby: ^13.1.2
     h3: ^0.7.21
     hash-sum: ^2.0.0
-    hookable: ^5.3.0
+    hookable: ^5.4.0
     knitwork: ^0.1.2
     magic-string: ^0.26.7
     mlly: ^0.5.16


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #3718

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for `debug: true` in your nuxt config (disabled by default). At the moment, it prints out hook names and timings on the server, and logs hook arguments as well in the browser.

#### Example output

**Server**

```bash
[nuxt] app:created: 2.109ms
[nuxt] vue:setup: 0.035ms
[nuxt] app:rendered: 0.019ms
[nitro] render:html: 0.048ms
[nitro] render:response: 0.01ms
```

**Client**

![CleanShot 2022-09-20 at 16 33 23](https://user-images.githubusercontent.com/28706372/191301261-7f457735-dfd2-4c21-936a-d67731370116.png)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

