### PR TITLE
fix(test-utils): support vitest v0.20.x

### DIFF
--- a/packages/test-utils/src/run.ts
+++ b/packages/test-utils/src/run.ts
@@ -21,14 +21,20 @@ export async function runTests (opts: RunTestOptions) {
     process.env.NUXT_TEST_DEV = 'true'
   }
 
+  // TODO: add `as typeof import('vitest/dist/node')` and remove workaround
+  // when we upgrade vitest: see https://github.com/nuxt/framework/issues/6297
+
   // @ts-ignore missing types
   const { startVitest } = await import('vitest/dist/node.mjs')
-  const succeeded = await startVitest(
+  const args: any[] = [
     [] /* argv */,
     // Vitest options
     {
       root: opts.rootDir,
-      run: !opts.watch
+      run: !opts.watch,
+      deps: {
+        inline: [/@nuxt\/test-utils/]
+      }
     },
     // Vite options
     {
@@ -36,7 +42,9 @@ export async function runTests (opts: RunTestOptions) {
         tsconfigRaw: '{}'
       }
     }
-  )
+  ]
+  if (startVitest.length >= 4) { args.unshift('test') }
+  const succeeded = await startVitest(...args)
 
   if (!succeeded) {
     process.exit(1)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/3252, resolves https://github.com/nuxt/framework/issues/7709

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vitest v0.20 added an additional parameter, which we weren't respecting with test-utils. This PR also adds nuxt/test-utils to `deps.inline` which is required to avoid `Vitest was initialized with native Node instead of Vite Node` error.

We can drop the workaround if we want to have a hard dependency on vitest 0.20+

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

