### PR TITLE
fix(nuxt): allow auto-import component with same filename

### DIFF
--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -65,7 +65,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => {
       const s = new MagicString(code)
 
       // replace `_resolveComponent("...")` to direct import
-      s.replace(/(?<=[ (])_?resolveComponent\(\s*["'](lazy-|Lazy)?([^'"]*?)["'][\s,]*\)/g, (full, lazy, name) => {
+      s.replace(/(?<=[ (])_?resolveComponent\(\s*["'](lazy-|Lazy)?([^'"]*?)["'][\s,]*[^)]*\)/g, (full, lazy, name) => {
         const component = findComponent(components, name, options.mode)
         if (component) {
           let identifier = map.get(component) || `__nuxt_component_${num++}`

--- a/test/fixtures/basic/components/Nested/SugarCounter.vue
+++ b/test/fixtures/basic/components/Nested/SugarCounter.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps({
+  count: Number
+})
+</script>
+
+<template>
+  <div>
+    <SugarCounter :count="count" />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -12,7 +12,7 @@
     <NuxtLink to="/">
       Link
     </NuxtLink>
-    <SugarCounter :count="12" />
+    <NestedSugarCounter :count="12" />
     <CustomComponent />
     <component :is="`test${'-'.toString()}global`" />
     <component :is="`with${'-'.toString()}suffix`" />


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7696

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Within a file named `Foo/Bar.vue` if it resolves `<Bar />`, Vue will pass a second param to `resolveComponent`, which our regexp didn't allow for. This PR allows resolving `<Bar />` from auto-imports in this case. If `<Bar />` doesn't exist, it will fall back to the Vue behaviour that allows use of recursive components in this way.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

