### PR TITLE
fix(nuxi): stub `defineNuxtConfig` for `nuxi info`

### DIFF
--- a/packages/nuxi/src/commands/info.ts
+++ b/packages/nuxi/src/commands/info.ts
@@ -119,7 +119,10 @@ function normalizeConfigModule (module: NuxtModule | string | null | undefined, 
 
 function getNuxtConfig (rootDir: string) {
   try {
-    return jiti(rootDir, { interopDefault: true, esmResolve: true })('./nuxt.config')
+    (globalThis as any).defineNuxtConfig = (c: any) => c
+    const result = jiti(rootDir, { interopDefault: true, esmResolve: true })('./nuxt.config')
+    delete (globalThis as any).defineNuxtConfig
+    return result
   } catch (err) {
     // TODO: Show error as warning if it is not 404
     return {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7727

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With recent change to not require `defineNuxtConfig` to be registered, we neglected to update `nuxi info` - this PR does the same trick to make loading nuxt.config possible in this case.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

