### PR TITLE
feat(nuxt): support `redirect` within page metadata

### DIFF
--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -1,8 +1,20 @@
 import { KeepAliveProps, TransitionProps, UnwrapRef } from 'vue'
-import type { RouteLocationNormalizedLoaded } from 'vue-router'
+import type { RouteLocationNormalizedLoaded, RouteRecordRedirectOption } from 'vue-router'
 
 export interface PageMeta {
   [key: string]: any
+  /**
+   * Where to redirect if the route is directly matched. The redirection happens
+   * before any navigation guard and triggers a new navigation with the new
+   * target location.
+   */
+  redirect?: RouteRecordRedirectOption
+  /**
+   * Aliases for the record. Allows defining extra paths that will behave like a
+   * copy of the record. Allows having paths shorthands like `/users/:id` and
+   * `/u/:id`. All `alias` and `path` values must share the same params.
+   */
+  alias?: string | string[]
   pageTransition?: boolean | TransitionProps
   layoutTransition?: boolean | TransitionProps
   key?: false | string | ((route: RouteLocationNormalizedLoaded) => string)

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -243,7 +243,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
         alias: aliasCode,
-        redirect: `${metaImportName}?.redirect || undefined`,
+        redirect: route.redirect ? JSON.stringify(route.redirect) : `${metaImportName}?.redirect || undefined`,
         component: genDynamicImport(file, { interopDefault: true })
       }
     }))

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -243,6 +243,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
         alias: aliasCode,
+        redirect: `${metaImportName}?.redirect || undefined`,
         component: genDynamicImport(file, { interopDefault: true })
       }
     }))

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -43,7 +43,8 @@ export type NuxtPage = {
   path: string
   file: string
   meta?: Record<string, any>
-  alias?: string[]
+  alias?: string[] | string
+  redirect?: string
   children?: NuxtPage[]
 }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -55,6 +55,16 @@ describe('pages', () => {
     await expectNoClientErrors('/')
   })
 
+  it('respects aliases in page metadata', async () => {
+    const html = await $fetch('/some-alias')
+    expect(html).toContain('Hello Nuxt 3!')
+  })
+
+  it('respects redirects in page metadata', async () => {
+    const { headers } = await fetch('/redirect', { redirect: 'manual' })
+    expect(headers.get('location')).toEqual('/')
+  })
+
   it('render 404', async () => {
     const html = await $fetch('/not-found')
 

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -28,6 +28,10 @@ setupDevtoolsPlugin({}, () => {})
 
 const config = useRuntimeConfig()
 
+definePageMeta({
+  alias: '/some-alias'
+})
+
 // reset title template example
 useHead({
   titleTemplate: ''

--- a/test/fixtures/basic/pages/redirect.vue
+++ b/test/fixtures/basic/pages/redirect.vue
@@ -1,0 +1,11 @@
+<script setup>
+definePageMeta({
+  redirect: () => '/'
+})
+</script>
+
+<template>
+  <div>
+    <div>redirect.vue</div>
+  </div>
+</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5222

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR:
* supports redirect (as well as alias) in page metadata
* adds types for redirect within `extend:pages`
* updates types for redirect + alias in page metadata
* adds some tests for the behaviour

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

