### PR TITLE
docs(error-handling): fix useError() type definition

### DIFF
--- a/docs/content/1.getting-started/8.error-handling.md
+++ b/docs/content/1.getting-started/8.error-handling.md
@@ -73,7 +73,7 @@ const handleError = () => clearError({ redirect: '/' })
 
 ### `useError`
 
-* `function useError (): Ref<any>`
+* `function useError (): Ref<Error | { url, statusCode, statusMessage, message, description, data }>`
 
 This function will return the global Nuxt error that is being handled.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
Resolves #7743

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes type definitions of `useError()` in documentation. 
That differed because of the following change.

https://github.com/nuxt/framework/pull/6389/files

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
