### PR TITLE
fix(nuxt): remove Fragment from `createClientOnly`

### DIFF
--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -1,4 +1,4 @@
-import { ref, onMounted, defineComponent, createElementBlock, h, Fragment } from 'vue'
+import { ref, onMounted, defineComponent, createElementBlock, h } from 'vue'
 
 export default defineComponent({
   name: 'ClientOnly',
@@ -31,7 +31,7 @@ export function createClientOnly (component) {
     // override the component render (non script setup component)
     clone.render = (ctx, ...args) => {
       return ctx.mounted$
-        ? h(Fragment, ctx.$attrs ?? ctx._.attrs, component.render(ctx, ...args))
+        ? h(component.render(ctx, ...args))
         : h('div', ctx.$attrs ?? ctx._.attrs)
     }
   } else if (clone.template) {
@@ -52,8 +52,7 @@ export function createClientOnly (component) {
           ? { ...setupState, mounted$ }
           : (...args) => {
               return mounted$.value
-                // use Fragment to avoid oldChildren is null issue
-                ? h(Fragment, ctx.attrs, setupState(...args))
+                ? h(setupState(...args))
                 : h('div', ctx.attrs)
             }
       })

--- a/packages/nuxt/src/app/components/client-only.mjs
+++ b/packages/nuxt/src/app/components/client-only.mjs
@@ -51,9 +51,14 @@ export function createClientOnly (component) {
         return typeof setupState !== 'function'
           ? { ...setupState, mounted$ }
           : (...args) => {
-              return mounted$.value
-                ? h(setupState(...args))
-                : h('div', ctx.attrs)
+              if (mounted$.value) {
+                const res = setupState(...args)
+                return (res.children === null || typeof res.children === 'string')
+                  ? createElementBlock(res.type, res.props, res.children, res.patchFlag, res.dynamicProps, res.shapeFlag)
+                  : h(res)
+              } else {
+                return h('div', ctx.attrs)
+              }
             }
       })
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

linked to https://github.com/nuxt/framework/pull/6165#issuecomment-1199255073
resolve https://github.com/nuxt/framework/issues/7755

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi 👋 👋  This PR remove the Fragment workaround which prevent using v-show on .client components.

There is additionnal changes in the setup part where we return the render function. 

Previously in the linked PR, there's was a `Oldchildren is null` issue if we returned directly the setup result as a render function. 
Using the `h()` function to return the VNode was working only for some components (based on @danielroe 's  https://github.com/nuxt/framework/pull/6165#issuecomment-1197878279).

However the component fails to render or update its render silently if it only has a root tag with a string and a variable such as :

`````vue
<template>
  <div>
      I'm a string children {{ count }}. I will be mounted but will still render a simple div
  </div>
</template>
``````

The workaround was to use a Fragment but it leads to https://github.com/nuxt/framework/issues/7755 issue .

This is fixed by verifying the result of `setupState`.children which can be `string|array|null|object` and rendering the component using `createElementBlock` when res.children is null or a string
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

