### PR TITLE
docs(roadmap): remove not working link from `nuxt/auth`

### DIFF
--- a/docs/content/5.community/5.roadmap.md
+++ b/docs/content/5.community/5.roadmap.md
@@ -61,6 +61,6 @@ Module         | Status              | Nuxt Support | Repository | Description
 ---------------|---------------------|--------------|------------|-------------------
 Content 1.x    | Maintenance         | 2.x          | [nuxt/content](https://github.com/nuxt/content/tree/v1) | Maintenance only
 Content 2.x    | Active              | 3.x          | [nuxt/content](https://github.com/nuxt/content) | Released
-Auth           | WIP                 | 3.x          | [nuxt/auth](https://github.com/nuxt/auth) | Nuxt 3 support is planned after session support
+Auth           | WIP                 | 3.x          | [nuxt/auth](https://github.com/nuxt-community/auth-module) | Nuxt 3 support is planned after session support
 Image          | Active              | 2.x and 3.x  | [nuxt/image](https://github.com/nuxt/image) | Nuxt 3 support is in progress: [nuxt/image#548](https://github.com/nuxt/image/discussions/548)
 Telemetry      | Active              | 2.x and 3.x  | [nuxt/telemetry](https://github.com/nuxt/telemetry/) | Nuxt 3 is supported. Stats to be public soon!

--- a/docs/content/5.community/5.roadmap.md
+++ b/docs/content/5.community/5.roadmap.md
@@ -61,6 +61,6 @@ Module         | Status              | Nuxt Support | Repository | Description
 ---------------|---------------------|--------------|------------|-------------------
 Content 1.x    | Maintenance         | 2.x          | [nuxt/content](https://github.com/nuxt/content/tree/v1) | Maintenance only
 Content 2.x    | Active              | 3.x          | [nuxt/content](https://github.com/nuxt/content) | Released
-Auth           | WIP                 | 3.x          | [nuxt/auth](https://github.com/nuxt-community/auth-module) | Nuxt 3 support is planned after session support
+Auth           | WIP                 | 3.x          | `nuxt/auth` to be announced | Nuxt 3 support is planned after session support
 Image          | Active              | 2.x and 3.x  | [nuxt/image](https://github.com/nuxt/image) | Nuxt 3 support is in progress: [nuxt/image#548](https://github.com/nuxt/image/discussions/548)
 Telemetry      | Active              | 2.x and 3.x  | [nuxt/telemetry](https://github.com/nuxt/telemetry/) | Nuxt 3 is supported. Stats to be public soon!


### PR DESCRIPTION
There is a wrong url to the Auth repo in the "Core Modules" section.