### PR TITLE
docs: add newline at end of sass import

### DIFF
--- a/docs/content/1.getting-started/4.assets.md
+++ b/docs/content/1.getting-started/4.assets.md
@@ -89,7 +89,7 @@ export default defineNuxtConfig({
     css: {
       preprocessorOptions: {
         sass: {
-          additionalData: '@use "@/assets/_colors.sass" as * \n'
+          additionalData: '@use "@/assets/_colors.sass" as *\n'
         }
       }
     }

--- a/docs/content/1.getting-started/4.assets.md
+++ b/docs/content/1.getting-started/4.assets.md
@@ -89,7 +89,7 @@ export default defineNuxtConfig({
     css: {
       preprocessorOptions: {
         sass: {
-          additionalData: '@use "@/assets/_colors.sass" as *'
+          additionalData: '@use "@/assets/_colors.sass" as * \n'
         }
       }
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Sass import needs newline code.

The following error will be displayed if the line feed code is within

```
[sass] expected newline.                                                                                                   
  ╷
1 │ @use "@/assets/_colors.sass" as *abbr,
  │                                       ^
  ╵
  assets/styles/reset.sass 1:39  root stylesheet
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

