### PR TITLE
fix(nuxt): don't prerender index.html with a server

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -57,7 +57,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
         .concat(nuxt.options._generate ? ['/', '/200.html', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false ? ['/index.html', '/200.html', '/404.html'] : [])
+        .concat(nuxt.options.ssr === false ? ['/200.html', '/404.html'] : [])
+        .concat(nuxt.options.ssr === false && nuxt.options._generate ? ['/index.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -57,7 +57,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
         .concat(nuxt.options._generate ? ['/200.html', '/404.html', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr && nuxt.options._generate ? [nuxt.options.ssr ? '/' : '/index.html'] : [])
+        .concat(nuxt.options._generate ? [nuxt.options.ssr ? '/' : '/index.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -57,7 +57,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
         .concat(nuxt.options._generate ? ['/', '/200.html', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false && nuxt.options._generate ? ['/index.html', '/200.html', '/404.html'] : [])
+        .concat(nuxt.options.ssr === false && nuxt.options._generate ? ['/index.html', '/404.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -56,8 +56,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     prerender: {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
-        .concat(nuxt.options._generate ? ['/', '/200.html', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false && nuxt.options._generate ? ['/index.html', '/404.html'] : [])
+        .concat(nuxt.options._generate ? ['/200.html', '/404.html', ...nuxt.options.generate.routes] : [])
+        .concat(nuxt.options.ssr && nuxt.options._generate ? [nuxt.options.ssr ? '/' : '/index.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -56,8 +56,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     prerender: {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
-        .concat(nuxt.options._generate ? ['/200.html', '/404.html', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options._generate ? [nuxt.options.ssr ? '/' : '/index.html'] : [])
+        .concat(nuxt.options.generate.routes)
+        .concat(nuxt.options._generate ? [nuxt.options.ssr ? '/' : '/index.html', '/200.html', '/404.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -57,8 +57,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: ([] as string[])
         .concat(nuxt.options._generate ? ['/', '/200.html', ...nuxt.options.generate.routes] : [])
-        .concat(nuxt.options.ssr === false ? ['/200.html', '/404.html'] : [])
-        .concat(nuxt.options.ssr === false && nuxt.options._generate ? ['/index.html'] : [])
+        .concat(nuxt.options.ssr === false && nuxt.options._generate ? ['/index.html', '/200.html', '/404.html'] : [])
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7826

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We should not be prerendering `index.html` if there is a dynamic server as runtime config (or nitro plugins) may change the response.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

