### PR TITLE
fix(head): allow using the default slot for script content like noscript

### DIFF
--- a/examples/composables/use-head/app.vue
+++ b/examples/composables/use-head/app.vue
@@ -12,6 +12,7 @@
         <Title>Luck number: {{ dynamic }}</Title>
         <Meta name="description" :content="`My page's ${dynamic} description`" />
         <Link rel="preload" href="/test.txt" as="script" />
+        <Script>console.log("hello script");</Script>
       </Head>
     </Html>
 

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -90,9 +90,19 @@ export const Script = defineComponent({
     /** @deprecated **/
     language: String
   },
-  setup: setupForUseMeta(script => ({
-    script: [script]
-  }))
+  setup: setupForUseMeta((props, { slots }) => {
+    const script = { ...props }
+    const textContent = (slots.default?.() || [])
+      .filter(({ children }) => children)
+      .map(({ children }) => children)
+      .join('')
+    if (textContent) {
+      script.children = textContent
+    }
+    return {
+      script: [script]
+    }
+  })
 })
 
 // <noscript>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolves #7853 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #7853 by aligning the script component's functionality to the noscript and style tags, which already allow using the default slot to specify the children property of useHead.

(not sure if this should be marked as a new feature or an enhancement)
(I also did not find any documentation that I should update, the documentation is written in a way where I already thought this is possible :P)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

