### PR TITLE
feat(nuxt): refresh override for data fetching composables

### DIFF
--- a/docs/content/1.getting-started/6.data-fetching.md
+++ b/docs/content/1.getting-started/6.data-fetching.md
@@ -147,6 +147,12 @@ function next() {
 
 The key to making this work is to call the `refresh()` method returned from the `useFetch()` composable when a query parameter has changed.
 
+By default, `refresh()` will not make a new request if one is already pending. You can override any pending requests with the override option. Previous requests will not be cancelled, but their result will not update the data or pending state - and any previously awaited promises will not resolve until this new request resolves.
+
+```js
+refresh({ override: true })
+```
+
 ### `refreshNuxtData`
 
 Invalidate the cache of `useAsyncData`, `useLazyAsyncData`, `useFetch` and `useLazyFetch` and trigger the refetch.

--- a/docs/content/3.api/1.composables/use-async-data.md
+++ b/docs/content/3.api/1.composables/use-async-data.md
@@ -27,7 +27,7 @@ type AsyncDataOptions<DataT> = {
 }
 
 interface RefreshOptions {
-  _initial?: boolean
+  override?: boolean
 }
 
 type AsyncData<DataT, ErrorT> = {

--- a/docs/content/3.api/1.composables/use-fetch.md
+++ b/docs/content/3.api/1.composables/use-fetch.md
@@ -30,7 +30,7 @@ type UseFetchOptions = {
 type AsyncData<DataT> = {
   data: Ref<DataT>
   pending: Ref<boolean>
-  refresh: () => Promise<void>
+  refresh: (opts?: { override?: boolean }) => Promise<void>
   execute: () => Promise<void>
   error: Ref<Error | boolean>
 }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -89,20 +89,12 @@ export function useFetch<
   let controller: AbortController
 
   const asyncData = useAsyncData<_ResT, ErrorT, Transform, PickKeys>(key, () => {
+    controller?.abort?.()
     controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
     return $fetch(_request.value, { signal: controller.signal, ..._fetchOptions }) as Promise<_ResT>
   }, _asyncDataOptions)
 
-  const originalRefresh = asyncData.refresh
-
-  asyncData.refresh = asyncData.execute = (opts?: AsyncDataExecuteOptions) => {
-    if (opts?.override) {
-      controller?.abort?.()
-    }
-    return originalRefresh(opts)
-  }
-
-  return asyncData.then(r => ({ ...r, refresh: asyncData.refresh, execute: asyncData.refresh }))
+  return asyncData
 }
 
 export function useLazyFetch<

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -2,7 +2,7 @@ import type { FetchError, FetchOptions } from 'ohmyfetch'
 import type { TypedInternalResponse, NitroFetchRequest } from 'nitropack'
 import { computed, unref, Ref } from 'vue'
 import type { AsyncDataOptions, _Transform, KeyOfRes, AsyncData, PickFrom } from './asyncData'
-import { useAsyncData, AsyncDataExecuteOptions } from './asyncData'
+import { useAsyncData } from './asyncData'
 
 export type FetchResult<ReqT extends NitroFetchRequest> = TypedInternalResponse<ReqT, unknown>
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -670,6 +670,10 @@ describe.skipIf(isWindows)('useAsyncData', () => {
     await $fetch('/useAsyncData/refresh')
   })
 
+  it('requests can be cancelled/overridden', async () => {
+    await expectNoClientErrors('/useAsyncData/override')
+  })
+
   it('two requests made at once resolve and sync', async () => {
     await expectNoClientErrors('/useAsyncData/promise-all')
   })

--- a/test/fixtures/basic/pages/useAsyncData/override.vue
+++ b/test/fixtures/basic/pages/useAsyncData/override.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    Override
+    {{ data }}
+  </div>
+</template>
+
+<script setup lang="ts">
+let count = 0
+let timeout = 0
+const { data, refresh } = await useAsyncData(() => process.server ? Promise.resolve(1) : new Promise(resolve => setTimeout(() => resolve(++count), timeout)))
+
+if (count || data.value !== 1) {
+  throw new Error('Data should be unset')
+}
+
+timeout = 100
+const p = refresh()
+
+if (process.client && (count !== 0 || data.value !== 1)) {
+  throw new Error('count should start at 0')
+}
+
+timeout = 0
+await refresh({ override: true })
+
+if (process.client && (count !== 1 || data.value !== 1)) {
+  throw new Error('override should execute')
+}
+
+await p
+
+if (process.client && (count !== 2 || data.value !== 1)) {
+  throw new Error('cancelled promise should not affect data')
+}
+</script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7058, resolves #2973

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds an `override` option to force override previous async data calls. With `useFetch`, we additionally use `AbortController` (if available in user's target) to cancel the fetch request. Either way, previous async data calls do not affect pending state or resolved data, and any promises returned by previous calls will await the new, overriding call.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

