### PR TITLE
fix(test-utils): respect `setupTimeout`

### DIFF
--- a/packages/test-utils/src/context.ts
+++ b/packages/test-utils/src/context.ts
@@ -9,7 +9,7 @@ export function createTestContext (options: Partial<TestOptions>): TestContext {
     testDir: resolve(process.cwd(), 'test'),
     fixture: 'fixture',
     configFile: 'nuxt.config',
-    setupTimeout: 60000,
+    setupTimeout: 120 * 1000,
     dev: !!JSON.parse(process.env.NUXT_TEST_DEV || 'false'),
     logLevel: 1,
     server: true,

--- a/packages/test-utils/src/setup/jest.ts
+++ b/packages/test-utils/src/setup/jest.ts
@@ -8,7 +8,7 @@ export default async function setupJest (hooks: TestHooks) {
 
   // TODO: add globals existing check to provide better error message
   // @ts-expect-error jest types
-  test('setup', hooks.setup, 120 * 1000)
+  test('setup', hooks.setup, hooks.ctx.options.setupTimeout)
   // @ts-expect-error jest types
   beforeEach(hooks.beforeEach)
   // @ts-expect-error jest types

--- a/packages/test-utils/src/setup/vitest.ts
+++ b/packages/test-utils/src/setup/vitest.ts
@@ -5,7 +5,7 @@ export default async function setupVitest (hooks: TestHooks) {
 
   hooks.ctx.mockFn = vitest.vi.fn
 
-  vitest.beforeAll(hooks.setup, 120 * 1000)
+  vitest.beforeAll(hooks.setup, hooks.ctx.options.setupTimeout)
   vitest.beforeEach(hooks.beforeEach)
   vitest.afterEach(hooks.afterEach)
   vitest.afterAll(hooks.afterAll)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #5460

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were not doing anything with `setupTimeout`, but hard coding the setup length.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

