### PR TITLE
perf(nitro): respond with early hints in node-based environments

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -1,4 +1,4 @@
-import { createRenderer } from 'vue-bundle-renderer/runtime'
+import { createRenderer, renderResourceHeaders } from 'vue-bundle-renderer/runtime'
 import type { RenderResponse } from 'nitropack'
 import type { Manifest } from 'vite'
 import { appendHeader, getQuery } from 'h3'
@@ -100,7 +100,10 @@ const getSPARenderer = lazyCachedFunction(async () => {
     return Promise.resolve(result)
   }
 
-  return { renderToString }
+  return {
+    rendererContext: renderer.rendererContext,
+    renderToString
+  }
 })
 
 const PAYLOAD_CACHE = (process.env.NUXT_PAYLOAD_EXTRACTION && process.env.prerender) ? new Map() : null // TODO: Use LRU cache
@@ -148,14 +151,16 @@ export default defineRenderHandler(async (event) => {
     ssrContext.payload.prerenderedAt = Date.now()
   }
 
+  // Render app
+  const renderer = (process.env.NUXT_NO_SSR || ssrContext.noSSR) ? await getSPARenderer() : await getSSRRenderer()
+
+  // Render 103 Early Hints
   if (!isRenderingPayload && !process.env.prerender && event.res.socket) {
-    const { link } = await getEarlyHints()
+    const { link } = renderResourceHeaders({}, renderer.rendererContext)
     // TODO: use https://github.com/nodejs/node/pull/44180 when we drop support for node 16
     event.res.socket!.write(`HTTP/1.1 103 Early Hints\r\nLink: ${link}\r\n\r\n`, 'utf-8',)
   }
 
-  // Render app
-  const renderer = (process.env.NUXT_NO_SSR || ssrContext.noSSR) ? await getSPARenderer() : await getSSRRenderer()
   const _rendered = await renderer.renderToString(ssrContext).catch((err) => {
     if (!ssrError) {
       // Use explicitly thrown error in preference to subsequent rendering errors
@@ -309,11 +314,3 @@ function splitPayload (ssrContext: NuxtSSRContext) {
     payload: { data, prerenderedAt }
   }
 }
-
-const getEarlyHints = lazyCachedFunction(async () => {
-  const renderer = process.env.NUXT_NO_SSR ? await getSPARenderer() : await getSSRRenderer()
-  const result = await renderer.renderToString({
-    runtimeConfig: useRuntimeConfig() as NuxtSSRContext['runtimeConfig'],
-  } as any)
-  return result.renderResourceHeaders()
-})

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -158,7 +158,7 @@ export default defineRenderHandler(async (event) => {
   if (!isRenderingPayload && !process.env.prerender && event.res.socket) {
     const { link } = renderResourceHeaders({}, renderer.rendererContext)
     // TODO: use https://github.com/nodejs/node/pull/44180 when we drop support for node 16
-    event.res.socket!.write(`HTTP/1.1 103 Early Hints\r\nLink: ${link}\r\n\r\n`, 'utf-8',)
+    event.res.socket!.write(`HTTP/1.1 103 Early Hints\r\nLink: ${link}\r\n\r\n`, 'utf-8')
   }
 
   const _rendered = await renderer.renderToString(ssrContext).catch((err) => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/unjs/nitro/issues/439

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for rendering Early Hints in node-based servers. We could also consider locating this elsewhere (e.g. in nitropack: https://github.com/unjs/nitro/issues/439), but the particular hints we want to render are very tied to the specifics of the Nuxt renderer, and not easily portable. Thoughts/suggestions welcome.

I have opened a PR to refactor L104 -> h3 (https://github.com/unjs/h3/pull/184), where it may also be used in userland (e.g. nitro middleware or plugins). If merged, we can refactor this PR to use the same utility.

If you want to test this, build the app and run:

```
curl -D - http://localhost:3000
```

It's only [currently supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103#browser_compatibility) in Chrome 103+, and you'll need to be on a newer protocol than HTTP/1.1 to see it in action.

We currently render the headers per-request, which takes less than 1ms (tests ranged from 0.3ms -> 0.9ms). I've opened a PR in vue-bundle-renderer in case we want to statically render them to string when the renderer is created, as a further optimisation (https://github.com/nuxt-contrib/vue-bundle-renderer/pull/40), but this may be unnecessary.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

