### PR TITLE
ci(crawl): ignore `<a>` links without hrefs

### DIFF
--- a/scripts/crawl.mjs
+++ b/scripts/crawl.mjs
@@ -87,7 +87,7 @@ const crawler = new Crawler({
       return done()
     }
 
-    $('a:not([href*=mailto])').each((_, el) => {
+    $('a:not([href*=mailto]):not([href*=tel])').each((_, el) => {
       if ('attribs' in el && 'href' in el.attribs) {
         queue(el.attribs.href, uri)
       }

--- a/scripts/crawl.mjs
+++ b/scripts/crawl.mjs
@@ -32,6 +32,13 @@ const erroredUrls = new Set()
  * @param {string | undefined} referrer The referring page
  */
 function queue (path, referrer) {
+  if (!path) {
+    const message = chalk.red(`${chalk.bold('✗')} ${referrer} linked to empty href`)
+    if (isCI) { actions.error(message) }
+    logger.log(message)
+    return
+  }
+
   if (urlsToOmit.some(url => path.startsWith(url))) { return }
 
   const { pathname, origin } = new URL(path, referrer)
@@ -80,7 +87,11 @@ const crawler = new Crawler({
       return done()
     }
 
-    $('a:not([href*=mailto])').each((_, el) => 'attribs' in el && queue(el.attribs.href, uri))
+    $('a:not([href*=mailto])').each((_, el) => {
+      if ('attribs' in el && 'href' in el.attribs) {
+        queue(el.attribs.href, uri)
+      }
+    })
 
     logger.success(chalk.green(uri))
     logger.debug(uri, `[${crawler.queueSize} / ${urls.size}]`)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes an issue with the crawler trying to crawl `<a>` links used purely for their anchor value.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

