### PR TITLE
fix(nuxt): page hydration and double load

### DIFF
--- a/packages/nuxt/src/app/components/layout.ts
+++ b/packages/nuxt/src/app/components/layout.ts
@@ -1,6 +1,6 @@
 import { computed, defineComponent, h, inject, nextTick, onMounted, Ref, Transition, unref, VNode } from 'vue'
-import { _wrapIf } from './utils'
 import { RouteLocationNormalizedLoaded, useRoute as useVueRouterRoute } from 'vue-router'
+import { _wrapIf } from './utils'
 import { useRoute } from '#app'
 // @ts-ignore
 import layouts from '#build/layouts'

--- a/packages/nuxt/src/app/components/layout.ts
+++ b/packages/nuxt/src/app/components/layout.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, isRef, nextTick, onMounted, Ref, Transition, VNode } from 'vue'
+import { computed, defineComponent, h, nextTick, onMounted, Ref, Transition, unref, VNode } from 'vue'
 import { _wrapIf } from './utils'
 import { useRouter } from '#app'
 // @ts-ignore
@@ -47,7 +47,7 @@ export default defineComponent({
     // Use router.currentRoute.value instead because this must be changed synchronized with route
     const router = useRouter()
     const route = computed(() => router.currentRoute.value)
-    const layout = computed(() => (isRef(props.name) ? props.name.value : props.name) ?? route.value.meta.layout as string ?? 'default')
+    const layout = computed(() => unref(props.name) ?? route.value.meta.layout as string ?? 'default')
 
     let vnode: VNode
     let _layout: string | false

--- a/packages/nuxt/src/app/components/layout.ts
+++ b/packages/nuxt/src/app/components/layout.ts
@@ -1,11 +1,41 @@
-import { defineComponent, unref, nextTick, onMounted, Ref, Transition, VNode } from 'vue'
+import { computed, defineComponent, h, isRef, nextTick, onMounted, Ref, Transition, VNode } from 'vue'
 import { _wrapIf } from './utils'
-import { useRoute } from '#app'
+import { useRouter } from '#app'
 // @ts-ignore
 import layouts from '#build/layouts'
 // @ts-ignore
 import { appLayoutTransition as defaultLayoutTransition } from '#build/nuxt.config.mjs'
 
+// TODO: revert back to defineAsyncComponent when https://github.com/vuejs/core/issues/6638 is resolved
+const LayoutLoader = defineComponent({
+  props: {
+    name: String,
+    ...process.dev ? { hasTransition: Boolean } : {}
+  },
+  async setup (props, context) {
+    let vnode: VNode
+
+    if (process.dev && process.client) {
+      onMounted(() => {
+        nextTick(() => {
+          if (props.name && ['#comment', '#text'].includes(vnode?.el?.nodeName)) {
+            console.warn(`[nuxt] \`${props.name}\` layout does not have a single root node and will cause errors when navigating between routes.`)
+          }
+        })
+      })
+    }
+
+    const LayoutComponent = await layouts[props.name]().then((r: any) => r.default || r)
+
+    return () => {
+      if (process.dev && process.client && props.hasTransition) {
+        vnode = h(LayoutComponent, {}, context.slots)
+        return vnode
+      }
+      return h(LayoutComponent, {}, context.slots)
+    }
+  }
+})
 export default defineComponent({
   props: {
     name: {
@@ -14,7 +44,10 @@ export default defineComponent({
     }
   },
   setup (props, context) {
-    const route = useRoute()
+    // Use router.currentRoute.value instead because this must be changed synchronized with route
+    const router = useRouter()
+    const route = computed(() => router.currentRoute.value)
+    const layout = computed(() => (isRef(props.name) ? props.name.value : props.name) ?? route.value.meta.layout as string ?? 'default')
 
     let vnode: VNode
     let _layout: string | false
@@ -29,26 +62,16 @@ export default defineComponent({
     }
 
     return () => {
-      const layout = unref(props.name) ?? route.meta.layout as string ?? 'default'
-
-      const hasLayout = layout && layout in layouts
-      if (process.dev && layout && !hasLayout && layout !== 'default') {
-        console.warn(`Invalid layout \`${layout}\` selected.`)
+      const hasLayout = layout.value && layout.value in layouts
+      if (process.dev && layout.value && !hasLayout && layout.value !== 'default') {
+        console.warn(`Invalid layout \`${layout.value}\` selected.`)
       }
 
-      const transitionProps = route.meta.layoutTransition ?? defaultLayoutTransition
+      const transitionProps = route.value.meta.layoutTransition ?? defaultLayoutTransition
 
       // We avoid rendering layout transition if there is no layout to render
       return _wrapIf(Transition, hasLayout && transitionProps, {
-        default: () => {
-          if (process.dev && process.client && transitionProps) {
-            _layout = layout
-            vnode = _wrapIf(layouts[layout], hasLayout, context.slots).default()
-            return vnode
-          }
-
-          return _wrapIf(layouts[layout], hasLayout, context.slots).default()
-        }
+        default: () => _wrapIf(LayoutLoader, hasLayout && { key: layout.value, name: layout.value, hasTransition: !!transitionProps }, context.slots).default()
       }).default()
     }
   }

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -12,7 +12,11 @@ import { callWithNuxt, isNuxtError, showError, useError, useRoute, useNuxtApp } 
 const ErrorComponent = defineAsyncComponent(() => import('#build/error-component.mjs').then(r => r.default || r))
 
 const nuxtApp = useNuxtApp()
-const onResolve = () => nuxtApp.callHook('app:suspense:resolve')
+const done = nuxtApp.deferHydration()
+
+const onResolve = () => {
+  done()
+}
 
 // Inject default route (outside of pages) as active route
 provide('_route', useRoute())

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -12,11 +12,7 @@ import { callWithNuxt, isNuxtError, showError, useError, useRoute, useNuxtApp } 
 const ErrorComponent = defineAsyncComponent(() => import('#build/error-component.mjs').then(r => r.default || r))
 
 const nuxtApp = useNuxtApp()
-const done = nuxtApp.deferHydration()
-
-const onResolve = () => {
-  done()
-}
+const onResolve = nuxtApp.deferHydration()
 
 // Inject default route (outside of pages) as active route
 provide('_route', useRoute())

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -58,10 +58,6 @@ if (process.client) {
 
     const nuxt = createNuxtApp({ vueApp })
 
-    nuxt.hooks.hookOnce('app:suspense:resolve', () => {
-      nuxt.isHydrating = false
-    })
-
     try {
       await applyPlugins(nuxt, plugins)
     } catch (err) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -154,10 +154,9 @@ export const layoutTemplate: NuxtTemplate<TemplateContext> = {
   filename: 'layouts.mjs',
   getContents ({ app }) {
     const layoutsObject = genObjectFromRawEntries(Object.values(app.layouts).map(({ name, file }) => {
-      return [name, `defineAsyncComponent(${genDynamicImport(file, { interopDefault: true })})`]
+      return [name, genDynamicImport(file, { interopDefault: true })]
     }))
     return [
-      'import { defineAsyncComponent } from \'vue\'',
       `export default ${layoutsObject}`
     ].join('\n')
   }

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -43,15 +43,12 @@ export default defineComponent({
           const key = generateRouteKey(props.pageKey, routeProps)
           const transitionProps = props.transition ?? routeProps.route.meta.pageTransition ?? (defaultPageTransition as TransitionProps)
 
-          const done: () => {} = nuxtApp.deferHydration()
+          const done = nuxtApp.deferHydration()
 
           return _wrapIf(Transition, transitionProps,
             wrapInKeepAlive(props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps), h(Suspense, {
               onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
-              onResolve: () => {
-                done?.()
-                nuxtApp.callHook('page:finish', routeProps.Component)
-              }
+              onResolve: () => nuxtApp.callHook('page:finish', routeProps.Component).finally(done)
             }, { default: () => h(Component, { key, routeProps, pageKey: key, hasTransition: !!transitionProps } as {}) })
             )).default()
         }

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, inject, provide, reactive, onMounted, nextTick, Suspense, Transition, KeepAliveProps, TransitionProps } from 'vue'
+import { computed, defineComponent, h, provide, reactive, onMounted, nextTick, Suspense, Transition, KeepAliveProps, TransitionProps } from 'vue'
 import type { DefineComponent, VNode } from 'vue'
 import { RouteLocationNormalized, RouteLocationNormalizedLoaded, RouterView } from 'vue-router'
 import type { RouteLocation } from 'vue-router'
@@ -8,8 +8,6 @@ import { useNuxtApp } from '#app'
 import { _wrapIf } from '#app/components/utils'
 // @ts-ignore
 import { appPageTransition as defaultPageTransition, appKeepalive as defaultKeepaliveConfig } from '#build/nuxt.config.mjs'
-
-const isNestedKey = Symbol('isNested')
 
 export default defineComponent({
   name: 'NuxtPage',
@@ -37,9 +35,6 @@ export default defineComponent({
   setup (props, { attrs }) {
     const nuxtApp = useNuxtApp()
 
-    const isNested = inject(isNestedKey, false)
-    provide(isNestedKey, true)
-
     return () => {
       return h(RouterView, { name: props.name, route: props.route, ...attrs }, {
         default: (routeProps: RouterViewSlotProps) => {
@@ -48,23 +43,16 @@ export default defineComponent({
           const key = generateRouteKey(props.pageKey, routeProps)
           const transitionProps = props.transition ?? routeProps.route.meta.pageTransition ?? (defaultPageTransition as TransitionProps)
 
-          let done: () => {}
-
-          if (!isNested) {
-            done = nuxtApp.deferHydration()
-          }
+          const done: () => {} = nuxtApp.deferHydration()
 
           return _wrapIf(Transition, transitionProps,
-            wrapInKeepAlive(props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps), isNested
-              // Include route children in parent suspense
-              ? h(Component, { key, routeProps, pageKey: key, hasTransition: !!transitionProps } as {})
-              : h(Suspense, {
-                onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
-                onResolve: () => {
-                  done?.()
-                  nuxtApp.callHook('page:finish', routeProps.Component)
-                }
-              }, { default: () => h(Component, { key, routeProps, pageKey: key, hasTransition: !!transitionProps } as {}) })
+            wrapInKeepAlive(props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps), h(Suspense, {
+              onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
+              onResolve: () => {
+                done?.()
+                nuxtApp.callHook('page:finish', routeProps.Component)
+              }
+            }, { default: () => h(Component, { key, routeProps, pageKey: key, hasTransition: !!transitionProps } as {}) })
             )).default()
         }
       })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -4,7 +4,7 @@ import { joinURL } from 'ufo'
 import { isWindows } from 'std-env'
 import { setup, fetch, $fetch, startServer, createPage, url } from '@nuxt/test-utils'
 // eslint-disable-next-line import/order
-import { expectNoClientErrors, renderPage } from './utils'
+import { expectNoClientErrors, renderPage, withLogs } from './utils'
 
 await setup({
   rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
@@ -411,132 +411,89 @@ describe('extends support', () => {
 
 // Bug #7337
 describe('deferred app suspense resolve', () => {
-  it('should wait for all suspense instance on initial hydration', async () => {
-    let done = false
-    const page = await createPage()
-    const logs: string[] = []
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.includes('isHydrating')) {
-        if (done) {
-          throw new Error('Test finished prematurely')
-        }
-        logs.push(text)
-      }
-    })
+  async function behaviour (path: string) {
 
-    try {
-      await page.goto(url('/async-parent/child'))
+    await withLogs(async (page, logs) => {
+      await page.goto(url(path))
       await page.waitForLoadState('networkidle')
 
       // Wait for all pending micro ticks to be cleared in case hydration haven't finished yet.
       await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 0)))
 
-      expect(logs.length).toBe(3)
-      expect(logs.every(log => log === 'isHydrating: true'))
-    } finally {
-      done = true
-    }
+      const hydrationLogs = logs.filter(log => log.includes('isHydrating'))
+      expect(hydrationLogs.length).toBe(3)
+      expect(hydrationLogs.every(log => log === 'isHydrating: true'))
+    })
+  }
+  it('should wait for all suspense instance on initial hydration', async () => {
+    await behaviour('/async-parent/child')
+  })
+  it('should wait for all suspense instance on initial hydration', async () => {
+    await behaviour('/internal-layout/async-parent/child')
   })
 })
 
 // Bug #6592
 describe('page key', () => {
   it('should not cause run of setup if navigation not change page key and layout', async () => {
-    let done = false
-    const page = await createPage()
-    const logs: string[] = []
+    async function behaviour (path: string) {
+      await withLogs(async (page, logs) => {
+        await page.goto(url(`${path}/0`))
+        await page.waitForLoadState('networkidle')
 
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.includes('Running Child Setup')) {
-        if (done) {
-          throw new Error('Test finished prematurely')
-        }
-        logs.push(text)
-      }
-    })
+        await page.click(`[href="${path}/1"]`)
+        await page.waitForSelector('#page-1')
 
-    try {
-      await page.goto(url('/fixed-keyed-child-parent/0'))
-      await page.waitForLoadState('networkidle')
+        // Wait for all pending micro ticks to be cleared,
+        // so we are not resolved too early when there are repeated page loading
+        await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 0)))
 
-      await page.click('[href="/fixed-keyed-child-parent/1"]')
-      await page.waitForSelector('#page-1')
-
-      // Wait for all pending micro ticks to be cleared,
-      // so we are not resolved too early when there are repeated page loading
-      await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 0)))
-
-      expect(logs.length).toBe(1)
-    } finally {
-      done = true
+        expect(logs.filter(l => l.includes('Child Setup')).length).toBe(1)
+      })
     }
+    await behaviour('/fixed-keyed-child-parent')
+    await behaviour('/internal-layout/fixed-keyed-child-parent')
   })
   it('will cause run of setup if navigation changed page key', async () => {
-    let done = false
-    const page = await createPage()
-    const logs: string[] = []
+    async function behaviour (path: string) {
+      await withLogs(async (page, logs) => {
+        await page.goto(url(`${path}/0`))
+        await page.waitForLoadState('networkidle')
 
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.includes('Running Child Setup')) {
-        if (done) {
-          throw new Error('Test finished prematurely')
-        }
-        logs.push(text)
-      }
-    })
+        await page.click(`[href="${path}/1"]`)
+        await page.waitForSelector('#page-1')
 
-    try {
-      await page.goto(url('/keyed-child-parent/0'))
-      await page.waitForLoadState('networkidle')
+        // Wait for all pending micro ticks to be cleared,
+        // so we are not resolved too early when there are repeated page loading
+        await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 0)))
 
-      await page.click('[href="/keyed-child-parent/1"]')
-      await page.waitForSelector('#page-1')
-
-      // Wait for all pending micro ticks to be cleared,
-      // so we are not resolved too early when there are repeated page loading
-      await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 0)))
-
-      expect(logs.length).toBe(2)
-    } finally {
-      done = true
+        expect(logs.filter(l => l.includes('Child Setup')).length).toBe(2)
+      })
     }
+    await behaviour('/keyed-child-parent')
+    await behaviour('/internal-layout/keyed-child-parent')
   })
 })
 
 // Bug #6592
 describe('layout change not load page twice', () => {
-  it('should not cause run of page setup to repeat if layout changed', async () => {
-    let done = false
-    const page = await createPage()
-    const logs: string[] = []
-
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.includes('Running With Layout2 Page Setup')) {
-        if (done) {
-          throw new Error('Test finished prematurely')
-        }
-        logs.push(text)
-      }
-    })
-
-    try {
-      await page.goto(url('/with-layout'))
+  async function behaviour (path1: string, path2: string) {
+    await withLogs(async (page, logs) => {
+      await page.goto(url(path1))
       await page.waitForLoadState('networkidle')
-      await page.click('[href="/with-layout2"]')
+      await page.click(`[href="${path2}"]`)
       await page.waitForSelector('#with-layout2')
 
       // Wait for all pending micro ticks to be cleared,
       // so we are not resolved too early when there are repeated page loading
       await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 0)))
 
-      expect(logs.length).toBe(1)
-    } finally {
-      done = true
-    }
+      expect(logs.filter(l => l.includes('Layout2 Page Setup')).length).toBe(1)
+    })
+  }
+  it('should not cause run of page setup to repeat if layout changed', async () => {
+    await behaviour('/with-layout', '/with-layout2')
+    await behaviour('/internal-layout/with-layout', '/internal-layout/with-layout2')
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -412,7 +412,6 @@ describe('extends support', () => {
 // Bug #7337
 describe('deferred app suspense resolve', () => {
   async function behaviour (path: string) {
-
     await withLogs(async (page, logs) => {
       await page.goto(url(path))
       await page.waitForLoadState('networkidle')

--- a/test/fixtures/basic/layouts/custom-async.vue
+++ b/test/fixtures/basic/layouts/custom-async.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Custom Async Layout:
+    <slot />
+  </div>
+</template>
+
+<script setup>
+await Promise.resolve()
+console.log('isHydrating: ' + useNuxtApp().isHydrating)
+</script>

--- a/test/fixtures/basic/layouts/custom2.vue
+++ b/test/fixtures/basic/layouts/custom2.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    Custom2 Layout:
+    <slot />
+  </div>
+</template>

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -63,10 +63,10 @@ export default defineNuxtConfig({
         meta: {
           ...page.meta || {},
           layout: undefined,
-          _layout: page.meta?.layout,
+          _layout: page.meta?.layout
         }
       })
-      nuxt.hook('pages:extend', pages => {
+      nuxt.hook('pages:extend', (pages) => {
         const newPages = []
         for (const page of pages) {
           if (routesToDuplicate.includes(page.path)) {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,5 +1,7 @@
 import { addComponent, addVitePlugin, addWebpackPlugin } from '@nuxt/kit'
+import type { NuxtPage } from '@nuxt/schema'
 import { createUnplugin } from 'unplugin'
+import { withoutLeadingSlash } from 'ufo'
 
 export default defineNuxtConfig({
   app: {
@@ -50,6 +52,30 @@ export default defineNuxtConfig({
       }))
       addVitePlugin(plugin.vite())
       addWebpackPlugin(plugin.webpack())
+    },
+    function (_options, nuxt) {
+      const routesToDuplicate = ['/async-parent', '/fixed-keyed-child-parent', '/keyed-child-parent', '/with-layout', '/with-layout2']
+      const stripLayout = (page: NuxtPage) => ({
+        ...page,
+        children: page.children?.map(child => stripLayout(child)),
+        name: 'internal-' + page.name,
+        path: withoutLeadingSlash(page.path),
+        meta: {
+          ...page.meta || {},
+          layout: undefined,
+          _layout: page.meta?.layout,
+        }
+      })
+      nuxt.hook('pages:extend', pages => {
+        const newPages = []
+        for (const page of pages) {
+          if (routesToDuplicate.includes(page.path)) {
+            newPages.push(stripLayout(page))
+          }
+        }
+        const internalParent = pages.find(page => page.path === '/internal-layout')
+        internalParent!.children = newPages
+      })
     }
   ],
   hooks: {

--- a/test/fixtures/basic/pages/async-parent.vue
+++ b/test/fixtures/basic/pages/async-parent.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    async-parent
+    <NuxtPage />
+  </div>
+</template>
+
+<script setup>
+await Promise.resolve()
+console.log('isHydrating: ' + useNuxtApp().isHydrating)
+definePageMeta({
+  layout: 'custom'
+})
+</script>

--- a/test/fixtures/basic/pages/async-parent/child.vue
+++ b/test/fixtures/basic/pages/async-parent/child.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    another-parent/child
+  </div>
+</template>
+
+<script setup>
+await Promise.resolve()
+console.log('isHydrating: ' + useNuxtApp().isHydrating)
+definePageMeta({
+  layout: 'custom-async'
+})
+</script>

--- a/test/fixtures/basic/pages/fixed-keyed-child-parent.vue
+++ b/test/fixtures/basic/pages/fixed-keyed-child-parent.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    fixed-keyed-child-parent
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/fixed-keyed-child-parent/[foo].vue
+++ b/test/fixtures/basic/pages/fixed-keyed-child-parent/[foo].vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="`page-${route.params.foo}`">
     [fixed-keyed-child-parent/{{ route.params.foo }}]
-    <NuxtLink href="/fixed-keyed-child-parent/1">
+    <NuxtLink to="../fixed-keyed-child-parent/1">
       To another
     </NuxtLink>
   </div>

--- a/test/fixtures/basic/pages/fixed-keyed-child-parent/[foo].vue
+++ b/test/fixtures/basic/pages/fixed-keyed-child-parent/[foo].vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="`page-${route.params.foo}`">
-    [keyed-child-parent/{{ route.params.foo }}]
-    <NuxtLink href="/keyed-child-parent/1">
+    [fixed-keyed-child-parent/{{ route.params.foo }}]
+    <NuxtLink href="/fixed-keyed-child-parent/1">
       To another
     </NuxtLink>
   </div>
@@ -12,6 +12,6 @@ console.log('Running Child Setup')
 const route = useRoute()
 
 definePageMeta({
-  key: r => 'keyed-' + r.params.foo
+  key: 'keyed'
 })
 </script>

--- a/test/fixtures/basic/pages/internal-layout.vue
+++ b/test/fixtures/basic/pages/internal-layout.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: false
+})
+
+const route = useRoute()
+</script>
+
+<template>
+  <div>
+    <NuxtLayout :name="route.meta._layout as string || 'default'">
+      <NuxtPage />
+    </NuxtLayout>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/keyed-child-parent.vue
+++ b/test/fixtures/basic/pages/keyed-child-parent.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    keyed-child-parent
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/keyed-child-parent/[foo].vue
+++ b/test/fixtures/basic/pages/keyed-child-parent/[foo].vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="`page-${route.params.foo}`">
     [keyed-child-parent/{{ route.params.foo }}]
-    <NuxtLink href="/keyed-child-parent/1">
+    <NuxtLink to="../keyed-child-parent/1">
       To another
     </NuxtLink>
   </div>

--- a/test/fixtures/basic/pages/keyed-child-parent/[foo].vue
+++ b/test/fixtures/basic/pages/keyed-child-parent/[foo].vue
@@ -1,0 +1,17 @@
+<template>
+  <div :id="`page-${route.params.foo}`">
+    [keyed-child-parent/{{ route.params.foo }}]
+    <NuxtLink href="/keyed-child-parent/1">
+      To another
+    </NuxtLink>
+  </div>
+</template>
+
+<script setup>
+console.log('Running Child Setup')
+const route = useRoute()
+
+definePageMeta({
+  key: 'keyed'
+})
+</script>

--- a/test/fixtures/basic/pages/with-layout.vue
+++ b/test/fixtures/basic/pages/with-layout.vue
@@ -7,5 +7,8 @@ definePageMeta({
 <template>
   <div>
     <div>with-layout.vue</div>
+    <NuxtLink href="/with-layout2">
+      to another page
+    </NuxtLink>
   </div>
 </template>

--- a/test/fixtures/basic/pages/with-layout.vue
+++ b/test/fixtures/basic/pages/with-layout.vue
@@ -7,7 +7,7 @@ definePageMeta({
 <template>
   <div>
     <div>with-layout.vue</div>
-    <NuxtLink href="/with-layout2">
+    <NuxtLink to="./with-layout2">
       to another page
     </NuxtLink>
   </div>

--- a/test/fixtures/basic/pages/with-layout2.vue
+++ b/test/fixtures/basic/pages/with-layout2.vue
@@ -1,0 +1,13 @@
+
+<script setup>
+definePageMeta({
+  layout: 'custom2'
+})
+
+console.log('Running With Layout2 Page Setup')
+</script>
+<template>
+  <div id="with-layout2">
+    <div>with-layout2.vue</div>
+  </div>
+</template>

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
-import { createPage, getBrowser, url, useTestContext } from '@nuxt/test-utils'
 import type { Page } from 'playwright'
+import { createPage, getBrowser, url, useTestContext } from '@nuxt/test-utils'
 
 export async function renderPage (path = '/') {
   const ctx = useTestContext()

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,6 @@
 import { expect } from 'vitest'
-import { getBrowser, url, useTestContext } from '@nuxt/test-utils'
+import { createPage, getBrowser, url, useTestContext } from '@nuxt/test-utils'
+import type { Page } from 'playwright'
 
 export async function renderPage (path = '/') {
   const ctx = useTestContext()
@@ -10,7 +11,7 @@ export async function renderPage (path = '/') {
   const browser = await getBrowser()
   const page = await browser.newPage({})
   const pageErrors: Error[] = []
-  const consoleLogs: { type:string, text:string }[] = []
+  const consoleLogs: { type: string, text: string }[] = []
 
   page.on('console', (message) => {
     consoleLogs.push({
@@ -47,4 +48,23 @@ export async function expectNoClientErrors (path: string) {
   expect(pageErrors).toEqual([])
   expect(consoleLogErrors).toEqual([])
   expect(consoleLogWarnings).toEqual([])
+}
+
+export async function withLogs (callback: (page: Page, logs: string[]) => Promise<void>) {
+  let done = false
+  const page = await createPage()
+  const logs: string[] = []
+  page.on('console', (msg) => {
+    const text = msg.text()
+    if (done) {
+      throw new Error('Test finished prematurely')
+    }
+    logs.push(text)
+  })
+
+  try {
+    await callback(page, logs)
+  } finally {
+    done = true
+  }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
Fix #7337, fixes #6592, closes https://github.com/nuxt/framework/pull/7400
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR is a remake of #7400

Besides of fix and workaround in #7400.

1. This PR use a different approach to handle hydrating, so change of page wrapper isn't required.
2. This PR ensure that layout and any page wrapper never change outside of the window that route navigation happens.
    - so #6592 should never happen again
3. This PR adds proper test for linked issue
    - so regression after this should be noticed

A remaining issue is temporary blank page when switching between layout and navigate at the same time.
But that isn't fixable without vuejs/core#6736.
So it isn't handled here.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

