### PR TITLE
fix(vite): prevent overlap between vite assets and app routes

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -5,8 +5,7 @@ import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { Connect, ServerOptions } from 'vite'
 import { logger } from '@nuxt/kit'
 import { getPort } from 'get-port-please'
-import { joinURL, withLeadingSlash, withoutLeadingSlash, withTrailingSlash } from 'ufo'
-import escapeRE from 'escape-string-regexp'
+import { joinURL, withoutLeadingSlash } from 'ufo'
 import defu from 'defu'
 import type { OutputOptions } from 'rollup'
 import { cacheDirPlugin } from './plugins/cache-dir'
@@ -110,12 +109,12 @@ export async function buildClient (ctx: ViteBuildContext) {
     const viteServer = await vite.createServer(clientConfig)
     ctx.clientServer = viteServer
     await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: true, isServer: false })
-    const baseURL = joinURL(ctx.nuxt.options.app.baseURL.replace(/^\./, '') || '/', ctx.nuxt.options.app.buildAssetsDir)
-    const BASE_RE = new RegExp(`^${escapeRE(withTrailingSlash(withLeadingSlash(baseURL)))}`)
     const viteMiddleware: Connect.NextHandleFunction = (req, res, next) => {
       // Workaround: vite devmiddleware modifies req.url
       const originalURL = req.url!
-      req.url = originalURL.replace(BASE_RE, '/')
+      if (!originalURL.startsWith('/__nuxt_vite_node__') && !originalURL.startsWith(clientConfig.base!)) {
+        req.url = joinURL('/__url', originalURL)
+      }
       viteServer.middlewares.handle(req, res, (err: unknown) => {
         req.url = originalURL
         next(err)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #7904

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As is, `/app` will render `/app.vue`. (The `base` config option is completely ignored - and in fact removed by vite - so no need to do the same ourselves.) A workaround is to inject and remove a random string to _bypass_ matching vite-handled paths.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

