### PR TITLE
docs: fix code highlighting

### DIFF
--- a/docs/content/1.getting-started/6.data-fetching.md
+++ b/docs/content/1.getting-started/6.data-fetching.md
@@ -45,7 +45,7 @@ This composable behaves identically to `useFetch` with the `lazy: true` option s
 
 ```vue
 <template>
-  <!-- you'll need to handle a loading state -->
+  <!-- you will need to handle a loading state -->
   <div v-if="pending">
     Loading ...
   </div>

--- a/docs/content/1.getting-started/6.data-fetching.md
+++ b/docs/content/1.getting-started/6.data-fetching.md
@@ -59,7 +59,7 @@ This composable behaves identically to `useFetch` with the `lazy: true` option s
 <script setup>
 const { pending, data: posts } = useLazyFetch('/api/posts')
 watch(posts, (newPosts) => {
-  // Because posts starts out null, you won't have access
+  // Because posts starts out null, you will not have access
   // to its contents immediately, but you can watch it.
 })
 </script>


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Seems like the code highlighter is not able to escape an apostrophe in the comment block and does not. This PR removes it so code this code block is readable.

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1769417/194727863-29c8ae28-ba38-441d-9fa7-9063cdef11a9.png">

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.

