### PR TITLE
fix(nuxi): read in `.env` before evaluating schema

### DIFF
--- a/packages/schema/src/config/_app.ts
+++ b/packages/schema/src/config/_app.ts
@@ -51,10 +51,14 @@ export default defineUntypedSchema({
      * NUXT_APP_BASE_URL=/prefix/ node .output/server/index.mjs
      * ```
      */
-    baseURL: process.env.NUXT_APP_BASE_URL || '/',
+    baseURL: {
+      $resolve: async (val) => val || process.env.NUXT_APP_BASE_URL || '/',
+    },
 
     /** The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if set). This is set at build time and should not be customized at runtime. */
-    buildAssetsDir: process.env.NUXT_APP_BUILD_ASSETS_DIR || '/_nuxt/',
+    buildAssetsDir: {
+      $resolve: async (val) => val || process.env.NUXT_APP_BUILD_ASSETS_DIR || '/_nuxt/',
+    },
 
     /**
      * The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if set).


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #8076

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were evaluating the default values when the `@nuxt/schema` module was evaluated. But when we are using `dotenv` we mutate `process.env` later on. So this makes sure that the app env variables can be updated.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

