### PR TITLE
docs: Add recommendation for controlling plugin registration order.

### DIFF
--- a/docs/content/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/content/2.guide/2.directory-structure/1.plugins.md
@@ -47,7 +47,7 @@ You can control the order in which plugins are registered by prefixing a number 
 For example:
 
 ```bash
-plugins
+plugins/
  | - 1.myPlugin.ts
  | - 2.myOtherPlugin.ts
 ```

--- a/docs/content/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/content/2.guide/2.directory-structure/1.plugins.md
@@ -40,6 +40,22 @@ export default defineNuxtPlugin(nuxtApp => {
 })
 ```
 
+## Plugin Registration Order
+
+You can control the order in which plugins are registered by prefixing a number to the file names.
+
+For example:
+
+```bash
+plugins
+ | - 1.myPlugin.ts
+ | - 2.myOtherPlugin.ts
+```
+
+In this example, "2.myOtherPlugin.ts" will be able to access anything that was injected by "1.myPlugin.ts."
+
+This is useful in situations where you have a plugin that depends on another plugin.
+
 ## Using Composables Within Plugins
 
 You can use [composables](/guide/directory-structure/composables) within Nuxt plugins:
@@ -54,7 +70,7 @@ However, keep in mind there are some limitations and differences:
 
 **If a composable depends on another plugin registered later, it might not work.**
 
-**Reason:** Plugins are called in order sequencially and before everything else. You might use a composable that dependants on another plugin which is not called yet.
+**Reason:** Plugins are called in order sequentially and before everything else. You might use a composable that depends on another plugin which has not been called yet.
 
 **If a composable depends on the Vue.js lifecycle, it won't work.**
 

--- a/docs/content/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/content/2.guide/2.directory-structure/1.plugins.md
@@ -52,7 +52,7 @@ plugins/
  | - 2.myOtherPlugin.ts
 ```
 
-In this example, "2.myOtherPlugin.ts" will be able to access anything that was injected by "1.myPlugin.ts."
+In this example, `2.myOtherPlugin.ts` will be able to access anything that was injected by `1.myPlugin.ts`.
 
 This is useful in situations where you have a plugin that depends on another plugin.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
From discussion https://github.com/nuxt/framework/discussions/1260#discussioncomment-3842023

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Controlling the order of plugin registration is a common requirement, so I think this should be added as an explicit recommendation in the docs.

Right now, it just says "Plugins are called in order sequentially and before everything else" in a small part of the docs. I don't think it's verbose enough. A section titled something like "Plugin registration order" would be very helpful.

From discussion https://github.com/nuxt/framework/discussions/1260#discussioncomment-3842023

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

