### PR TITLE
docs: clarify access of RuntimeConfig with Options API

### DIFF
--- a/docs/content/2.guide/4.going-further/10.runtime-config.md
+++ b/docs/content/2.guide/4.going-further/10.runtime-config.md
@@ -35,6 +35,9 @@ console.log(runtimeConfig.apiSecret)
 console.log(runtimeConfig.public.apiBase)
 ```
 
+::alert{type=info}
+When using Options API the public runtime config is available via `this.$config.public`, e.g. `this.$confiig.public.apiBase`.
+
 ### Environment Variables
 
 The most common way to provide configuration is by using [Environment Variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa).

--- a/docs/content/2.guide/4.going-further/10.runtime-config.md
+++ b/docs/content/2.guide/4.going-further/10.runtime-config.md
@@ -36,7 +36,7 @@ console.log(runtimeConfig.public.apiBase)
 ```
 
 ::alert{type=info}
-When using Options API the public runtime config is available via `this.$config.public`, e.g. `this.$confiig.public.apiBase`.
+When using Options API the public runtime config is available via `this.$config.public`.
 
 ### Environment Variables
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since the public runtime config moved from `$config` into `$config.public` and the docs only mention use with Composition API it seemed to me at first that runtime config was not available in Options API. Therefore, added a small note so save other people a few minutes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

