### PR TITLE
docs(configuration): add imports for defineAppConfig && defineNuxtConfig

### DIFF
--- a/docs/content/1.getting-started/3.configuration.md
+++ b/docs/content/1.getting-started/3.configuration.md
@@ -14,6 +14,8 @@ The `nuxt.config.ts` file is located at the root of a Nuxt project and can overr
 A minimal configuration file exports the `defineNuxtConfig` function containing an object with your configuration. The `defineNuxtConfig` helper is globally available without import.
 
 ```ts [nuxt.config.ts]
+import { defineNuxtConfig } from "nuxt";
+
 export default defineNuxtConfig({
   // My Nuxt config
 })
@@ -38,6 +40,8 @@ Those values should be defined in `nuxt.config` and can be overridden using envi
 ::code-group
 
 ```ts [nuxt.config.ts]
+import { defineNuxtConfig } from "nuxt";
+
 export default defineNuxtConfig({
   runtimeConfig: {
     // The private keys which are only available server-side
@@ -74,6 +78,8 @@ The `app.config.ts` file, also located at the root of a Nuxt project, is used to
 A minimal configuration file exports the `defineAppConfig` function containing an object with your configuration. The `defineAppConfig` helper is globally available without import.
 
 ```ts [app.config.ts]
+import { defineAppConfig } from 'nuxt/app'
+
 export default defineAppConfig({
   title: 'Hello Nuxt',
   theme: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
For beginners, codesandbox or stackblitz gives error without imports and it requires for them to do another search for importing defineNuxtConfig and defineAppConfig. That's why I've added these imports to example configs.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

