### PR TITLE
perf(nuxt)!: use component loader to add meta components

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -15,8 +15,36 @@ export default defineNuxtModule({
     // Add #head alias
     nuxt.options.alias['#head'] = runtimeDir
 
-    // Add generic plugin
-    addPlugin({ src: resolve(runtimeDir, 'plugin') })
+    const componentsPath = resolve(runtimeDir, 'components')
+    const headComponents = [
+      'Script',
+      'NoScript',
+      'Link',
+      'Base',
+      'Title',
+      'Meta',
+      'Style',
+      'Head',
+      'Html',
+      'Body'
+    ].map(c => ({
+      // kebab case version of these tags is not valid
+      kebabName: c,
+      pascalName: c,
+      export: c,
+      preload: false,
+      prefetch: false,
+      filePath: componentsPath,
+      import: `require(${JSON.stringify(componentsPath)})['${c}']`,
+      chunkName: `components/${c}`,
+      shortPath: componentsPath
+    }))
+    nuxt.hook('components:extend', (components) => {
+      components.push(...headComponents)
+    })
+
+    // Add mixin plugin
+    addPlugin({ src: resolve(runtimeDir, 'mixin-plugin') })
 
     // Add library specific plugin
     addPlugin({ src: resolve(runtimeDir, 'lib/vueuse-head.plugin') })

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { addPlugin, defineNuxtModule } from '@nuxt/kit'
+import { addComponent, addPlugin, defineNuxtModule } from '@nuxt/kit'
 import { distDir } from '../dirs'
 
 export default defineNuxtModule({
@@ -15,8 +15,9 @@ export default defineNuxtModule({
     // Add #head alias
     nuxt.options.alias['#head'] = runtimeDir
 
+    // Register components
     const componentsPath = resolve(runtimeDir, 'components')
-    const headComponents = [
+    for (const componentName of [
       'Script',
       'NoScript',
       'Link',
@@ -27,21 +28,15 @@ export default defineNuxtModule({
       'Head',
       'Html',
       'Body'
-    ].map(c => ({
-      // kebab case version of these tags is not valid
-      kebabName: c,
-      pascalName: c,
-      export: c,
-      preload: false,
-      prefetch: false,
-      filePath: componentsPath,
-      import: `require(${JSON.stringify(componentsPath)})['${c}']`,
-      chunkName: `components/${c}`,
-      shortPath: componentsPath
-    }))
-    nuxt.hook('components:extend', (components) => {
-      components.push(...headComponents)
-    })
+    ]) {
+      addComponent({
+        name: componentName,
+        filePath: componentsPath,
+        export: componentName,
+        // kebab case version of these tags is not valid
+        kebabName: componentName
+      })
+    }
 
     // Add mixin plugin
     addPlugin({ src: resolve(runtimeDir, 'mixin-plugin') })

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -2,6 +2,8 @@ import { resolve } from 'pathe'
 import { addComponent, addPlugin, defineNuxtModule } from '@nuxt/kit'
 import { distDir } from '../dirs'
 
+const components = ['Script', 'NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head', 'Html', 'Body']
+
 export default defineNuxtModule({
   meta: {
     name: 'meta'
@@ -17,18 +19,7 @@ export default defineNuxtModule({
 
     // Register components
     const componentsPath = resolve(runtimeDir, 'components')
-    for (const componentName of [
-      'Script',
-      'NoScript',
-      'Link',
-      'Base',
-      'Title',
-      'Meta',
-      'Style',
-      'Head',
-      'Html',
-      'Body'
-    ]) {
+    for (const componentName of components) {
       addComponent({
         name: componentName,
         filePath: componentsPath,

--- a/packages/nuxt/src/head/runtime/mixin-plugin.ts
+++ b/packages/nuxt/src/head/runtime/mixin-plugin.ts
@@ -1,12 +1,6 @@
 import { getCurrentInstance } from 'vue'
-import * as Components from './components'
 import { useHead } from './composables'
 import { defineNuxtPlugin, useNuxtApp } from '#app'
-
-type MetaComponents = typeof Components
-declare module '@vue/runtime-core' {
-  export interface GlobalComponents extends MetaComponents {}
-}
 
 const metaMixin = {
   created () {
@@ -27,9 +21,4 @@ const metaMixin = {
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.mixin(metaMixin)
-
-  for (const name in Components) {
-    // eslint-disable-next-line import/namespace
-    nuxtApp.vueApp.component(name, (Components as any)[name])
-  }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/nuxt/framework/issues/8166

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Rather than globally registering all meta components, this PR uses the component loader to register them. This should reduce initial bundle size by approx 3kB.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

