### PR TITLE
perf(nuxt)!: use component loader to add meta components

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'pathe'
-import { addPlugin, defineNuxtModule } from '@nuxt/kit'
+import { addComponent, addPlugin, defineNuxtModule } from '@nuxt/kit'
 import { distDir } from '../dirs'
+
+const components = ['Script', 'NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head', 'Html', 'Body']
 
 export default defineNuxtModule({
   meta: {
@@ -20,5 +22,13 @@ export default defineNuxtModule({
 
     // Add library specific plugin
     addPlugin({ src: resolve(runtimeDir, 'lib/vueuse-head.plugin') })
+
+    for (const name of components) {
+      addComponent({
+        name,
+        filePath: resolve(runtimeDir, 'components'),
+        export: name
+      })
+    }
   }
 })

--- a/packages/nuxt/src/head/runtime/plugin.ts
+++ b/packages/nuxt/src/head/runtime/plugin.ts
@@ -1,12 +1,6 @@
 import { getCurrentInstance } from 'vue'
-import * as Components from './components'
 import { useHead } from './composables'
 import { defineNuxtPlugin, useNuxtApp } from '#app'
-
-type MetaComponents = typeof Components
-declare module '@vue/runtime-core' {
-  export interface GlobalComponents extends MetaComponents {}
-}
 
 const metaMixin = {
   created () {
@@ -27,9 +21,4 @@ const metaMixin = {
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.mixin(metaMixin)
-
-  for (const name in Components) {
-    // eslint-disable-next-line import/namespace
-    nuxtApp.vueApp.component(name, (Components as any)[name])
-  }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #8166

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Rather than globally registering all meta components, this PR uses the component loader to register them. This should reduce initial bundle size by approx 3kB.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

