### PR TITLE
feat(nuxt)!: `refresh` to override previous requests by default

### DIFF
--- a/docs/content/1.getting-started/6.data-fetching.md
+++ b/docs/content/1.getting-started/6.data-fetching.md
@@ -152,10 +152,10 @@ function next() {
 
 The key to making this work is to call the `refresh()` method returned from the `useFetch()` composable when a query parameter has changed.
 
-By default, `refresh()` will not make a new request if one is already pending. You can override any pending requests with the override option. Previous requests will not be cancelled, but their result will not update the data or pending state - and any previously awaited promises will not resolve until this new request resolves.
+By default, `refresh()` will cancel any pending requests; their result will not update the data or pending state. Any previously awaited promises will not resolve until this new request resolves. You can prevent this behaviour by setting the `dedupe` option, which will instead return the promise for the currently-executing request, if there is one.
 
 ```js
-refresh({ override: true })
+refresh({ dedupe: true })
 ```
 
 ### `refreshNuxtData`

--- a/docs/content/3.api/1.composables/use-async-data.md
+++ b/docs/content/3.api/1.composables/use-async-data.md
@@ -30,7 +30,7 @@ type AsyncDataOptions<DataT> = {
 }
 
 interface RefreshOptions {
-  override?: boolean
+  dedupe?: boolean
 }
 
 type AsyncData<DataT, ErrorT> = {

--- a/docs/content/3.api/1.composables/use-fetch.md
+++ b/docs/content/3.api/1.composables/use-fetch.md
@@ -32,7 +32,7 @@ type UseFetchOptions = {
 type AsyncData<DataT> = {
   data: Ref<DataT>
   pending: Ref<boolean>
-  refresh: (opts?: { override?: boolean }) => Promise<void>
+  refresh: (opts?: { dedupe?: boolean }) => Promise<void>
   execute: () => Promise<void>
   error: Ref<Error | boolean>
 }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -39,7 +39,7 @@ export interface AsyncDataExecuteOptions {
    * not be cancelled, but their result will not affect the data/pending state - and any
    * previously awaited promises will not resolve until this new request resolves.
    */
-  override?: boolean
+  dedupe?: boolean
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -122,7 +122,7 @@ export function useAsyncData<
 
   asyncData.refresh = asyncData.execute = (opts = {}) => {
     if (nuxt._asyncDataPromises[key]) {
-      if (!opts.override) {
+      if (opts.dedupe === false) {
         // Avoid fetching same key more than once at a time
         return nuxt._asyncDataPromises[key]
       }

--- a/test/fixtures/basic/pages/useAsyncData/override.vue
+++ b/test/fixtures/basic/pages/useAsyncData/override.vue
@@ -15,14 +15,14 @@ if (count || data.value !== 1) {
 }
 
 timeout = 100
-const p = refresh()
+const p = refresh({ dedupe: true })
 
 if (process.client && (count !== 0 || data.value !== 1)) {
   throw new Error('count should start at 0')
 }
 
 timeout = 0
-await refresh({ override: true })
+await refresh()
 
 if (process.client && (count !== 1 || data.value !== 1)) {
   throw new Error('override should execute')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/pull/7864

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This renames `override` to `dedupe` and enables it by default, which should be more the expected behaviour.

### 👉 Migration

If you were relying on the previous behaviour (not re-calling a fetch function if one was already running) then you can update your refresh calls like so:

```diff
- refresh()
+ refresh({ dedupe: false })
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

