### PR TITLE
fix(nuxt): enable router when `app/router.options.ts` file is present

### DIFF
--- a/docs/content/2.guide/2.directory-structure/1.pages.md
+++ b/docs/content/2.guide/2.directory-structure/1.pages.md
@@ -10,7 +10,7 @@ head.title: "Pages"
 Nuxt provides a file-based routing to create routes within your web application using [Vue Router](https://router.vuejs.org) under the hood.
 
 ::alert{type="info"}
-This directory is **optional**, meaning that [`vue-router`](https://router.vuejs.org) won't be included if you only use [app.vue](/guide/directory-structure/app), reducing your application's bundle size.
+This directory is **optional**, meaning that [`vue-router`](https://router.vuejs.org) won't be included if you only use [app.vue](/guide/directory-structure/app) (unless you provide an [`router.options.ts`](/guide/directory-structure/pages#router-options), reducing your application's bundle size.
 ::
 
 ## Usage

--- a/docs/content/2.guide/2.directory-structure/1.pages.md
+++ b/docs/content/2.guide/2.directory-structure/1.pages.md
@@ -10,7 +10,7 @@ head.title: "Pages"
 Nuxt provides a file-based routing to create routes within your web application using [Vue Router](https://router.vuejs.org) under the hood.
 
 ::alert{type="info"}
-This directory is **optional**, meaning that [`vue-router`](https://router.vuejs.org) won't be included if you only use [app.vue](/guide/directory-structure/app) (unless you provide an [`router.options.ts`](/guide/directory-structure/pages#router-options), reducing your application's bundle size.
+This directory is **optional**, meaning that [`vue-router`](https://router.vuejs.org) won't be included if you only use [app.vue](/guide/directory-structure/app) (unless you set `pages: true` in `nuxt.config` or have a [`app/router.options.ts`](/guide/directory-structure/pages#router-options)), reducing your application's bundle size.
 ::
 
 ## Usage

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -17,11 +17,11 @@ export default defineNuxtModule({
     const pagesDirs = nuxt.options._layers.map(
       layer => resolve(layer.config.srcDir, layer.config.dir?.pages || 'pages')
     )
-      
-    const isRouterOptionsPresent = nuxt.options._layers.some(layer => existsSync(resolve(layer.config.srcDir, 'app/router.options.ts'))) 
-    
+
+    const isRouterOptionsPresent = nuxt.options._layers.some(layer => existsSync(resolve(layer.config.srcDir, 'app/router.options.ts')))
+
     // Disable module (and use universal router) if pages dir do not exists or user has disabled it
-    if ((nuxt.options.pages === false || (nuxt.options.pages !== true && !pagesDirs.some(dir => existsSync(dir)))) &&  !isRouterOptionsPresent) {
+    if ((nuxt.options.pages === false || (nuxt.options.pages !== true && !pagesDirs.some(dir => existsSync(dir)))) && !isRouterOptionsPresent) {
       addPlugin(resolve(distDir, 'app/plugins/router'))
       return
     }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -17,9 +17,11 @@ export default defineNuxtModule({
     const pagesDirs = nuxt.options._layers.map(
       layer => resolve(layer.config.srcDir, layer.config.dir?.pages || 'pages')
     )
-
+      
+    const isRouterOptionsPresent = nuxt.options._layers.some(layer => existsSync(resolve(layer.config.srcDir, 'app/router.options.ts'))) 
+    
     // Disable module (and use universal router) if pages dir do not exists or user has disabled it
-    if (nuxt.options.pages === false || (nuxt.options.pages !== true && !pagesDirs.some(dir => existsSync(dir)))) {
+    if ((nuxt.options.pages === false || (nuxt.options.pages !== true && !pagesDirs.some(dir => existsSync(dir)))) &&  !isRouterOptionsPresent) {
       addPlugin(resolve(distDir, 'app/plugins/router'))
       return
     }


### PR DESCRIPTION
### 🔗 Linked issue
resolves #8177 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
If the user provides a `router.options` file, the module should be enabled, even without a pages dir.

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

