### PR TITLE
refactor(nuxt): deprecate `<Script>` component tag in template

### DIFF
--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -98,7 +98,7 @@ export const Script = defineComponent({
   },
   setup: setupForUseMeta((props, { slots }) => {
     if (process.dev && !scriptDeprecated) {
-      console.log(`[nuxt] \`<Script>\` is deprecated and may be removed in a future release. We advise using \`useHead()\` directly.`)
+      console.log('[nuxt] `<Script>` is deprecated and may be removed in a future release. We advise using `useHead()` directly.')
       scriptDeprecated = true
     }
 

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -66,6 +66,10 @@ const globalProps = {
 }
 
 // <script>
+
+let scriptDeprecated = false
+
+/** @deprecated */
 export const Script = defineComponent({
   // eslint-disable-next-line vue/no-reserved-component-names
   name: 'Script',
@@ -93,6 +97,11 @@ export const Script = defineComponent({
     renderPriority: [String, Number]
   },
   setup: setupForUseMeta((props, { slots }) => {
+    if (process.dev && !scriptDeprecated) {
+      console.log(`[nuxt] \`<Script>\` is deprecated and may be removed in a future release. We advise using \`useHead()\` directly.`)
+      scriptDeprecated = true
+    }
+
     const script = { ...props }
     const textContent = (slots.default?.() || [])
       .filter(({ children }) => children)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Including `<Script>`  in template may possibly open the door to unexpected behaviour. We expect to release `nuxt/scripts` to significantly improve experience for users and module authors, and in preparation, we want to deprecate `<Script>` in favour of directly using `useHead`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

