### PR TITLE
fix(kit): log module id to the console when import fails

### DIFF
--- a/packages/kit/src/internal/cjs.ts
+++ b/packages/kit/src/internal/cjs.ts
@@ -1,3 +1,4 @@
+import { relative } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { join, normalize } from 'pathe'
 import { interopDefault } from 'mlly'
@@ -124,7 +125,7 @@ export function requireModule (id: string, opts: RequireModuleOptions = {}) {
 
     return requiredModule
   } catch (error: unknown) {
-    console.error(`Error while requiring module \`${id.split('/').pop()}\`: ${error}`)
+    console.error(`Error while requiring module \`${relative(process.cwd(), resolvedPath)}\`: ${error}`)
     throw error
   }
 }

--- a/packages/kit/src/internal/cjs.ts
+++ b/packages/kit/src/internal/cjs.ts
@@ -118,10 +118,15 @@ export function requireModule (id: string, opts: RequireModuleOptions = {}) {
     clearRequireCache(resolvedPath)
   }
 
-  // Try to require
-  const requiredModule = _require(resolvedPath)
+  try {
+    // Try to require
+    const requiredModule = _require(resolvedPath)
 
-  return requiredModule
+    return requiredModule
+  } catch (error: unknown) {
+    console.error(`Error while requiring module \`${id.split('/').pop()}\`: ${error}`)
+    throw error
+  }
 }
 
 export function importModule (id: string, opts: RequireModuleOptions = {}) {

--- a/packages/kit/src/internal/cjs.ts
+++ b/packages/kit/src/internal/cjs.ts
@@ -1,4 +1,3 @@
-import { relative } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { join, normalize } from 'pathe'
 import { interopDefault } from 'mlly'
@@ -119,15 +118,10 @@ export function requireModule (id: string, opts: RequireModuleOptions = {}) {
     clearRequireCache(resolvedPath)
   }
 
-  try {
-    // Try to require
-    const requiredModule = _require(resolvedPath)
+  // Try to require
+  const requiredModule = _require(resolvedPath)
 
-    return requiredModule
-  } catch (error: unknown) {
-    console.error(`Error while requiring module \`${relative(process.cwd(), resolvedPath)}\`: ${error}`)
-    throw error
-  }
+  return requiredModule
 }
 
 export function importModule (id: string, opts: RequireModuleOptions = {}) {

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,4 +1,3 @@
-import { relative } from 'node:path'
 import type { Nuxt, NuxtModule } from '@nuxt/schema'
 import { useNuxt } from '../context'
 import { resolveModule, requireModule, importModule } from '../internal/cjs'

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,3 +1,4 @@
+import { relative } from 'node:path'
 import type { Nuxt, NuxtModule } from '@nuxt/schema'
 import { useNuxt } from '../context'
 import { resolveModule, requireModule, importModule } from '../internal/cjs'
@@ -42,7 +43,13 @@ async function normalizeModule (nuxtModule: string | NuxtModule, inlineOptions?:
     const _src = resolveModule(resolveAlias(nuxtModule), { paths: nuxt.options.modulesDir })
     // TODO: also check with type: 'module' in closest `package.json`
     const isESM = _src.endsWith('.mjs')
-    nuxtModule = isESM ? await importModule(_src) : requireModule(_src)
+
+    try {
+      nuxtModule = isESM ? await importModule(_src) : requireModule(_src)
+    } catch (error: unknown) {
+      console.error(`Error while requiring module \`${nuxtModule}\`: ${error}`)
+      throw error
+    }
   }
 
   // Throw error if input is not a function


### PR DESCRIPTION
### 🔗 Linked issue

#8191 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #8191 - in case of error during module require/import it will be printed to the console in the form of 'Error while requiring module {module_name}: {error}'.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

