### PR TITLE
fix(nuxt): fix broken external urls when baseURL is set in config

### DIFF
--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -19,7 +19,7 @@ if (!globalThis.$fetch) {
     onRequest ({ request, options }) {
       if (/^https?:\/\//gm.test(<string>request) && !options.baseURL) {
         options.baseURL = ''
-      } else {
+      } else if (!options.baseURL) {
         options.baseURL = baseURL()
       }
     }

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -15,7 +15,14 @@ import AppComponent from '#build/app-component.mjs'
 if (!globalThis.$fetch) {
   // @ts-ignore
   globalThis.$fetch = $fetch.create({
-    baseURL: baseURL()
+    // @ts-ignore
+    onRequest ({ request, options }) {
+      if (/^https?:\/\//gm.test(<string>request) && !options.baseURL) {
+        options.baseURL = ''
+      } else {
+        options.baseURL = baseURL()
+      }
+    }
   })
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

#7983 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #7983 - set baseURL for ohmyfetch dynamically through interceptor. The urls were prefixed with baseURL even if they were external.

Using **onRequest** method of ohmyfetch we set a request interceptor which checks for:
- http(-s) at the beginning of request url
- not set baseURL in options

If both are true, it sets the baseURL to `''` (allowing external link calls). Otherwise if not already in request config - sets the baseURL

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
