### PR TITLE
fix(nuxt): avoid preloading external routes

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -204,7 +204,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                   unobserve = null
                   await Promise.all([
                     nuxtApp.hooks.callHook('link:prefetch', to.value as string).catch(() => {}),
-                    preloadRouteComponents(to.value as string, router).catch(() => {})
+                    !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
                   ])
                   prefetched.value = true
                 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

regression from https://github.com/nuxt/framework/pull/8225 - we should avoid using `router.resolve` on routes we know are external.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

