### PR TITLE
docs: change deprecated `useBody` with `readBody`

### DIFF
--- a/docs/content/2.guide/2.directory-structure/1.server.md
+++ b/docs/content/2.guide/2.directory-structure/1.server.md
@@ -141,7 +141,7 @@ export default defineEventHandler(() => `Default api handler`)
 
 ```ts [server/api/submit.post.ts]
 export default defineEventHandler(async (event) => {
-    const body = await useBody(event)
+    const body = await readBody(event)
     return { body }
 })
 ```
@@ -149,7 +149,7 @@ export default defineEventHandler(async (event) => {
 You can now universally call this API using `$fetch('/api/submit', { method: 'post', body: { test: 123 } })`.
 
 ::alert{type=warning title=Attention}
-We are using `submit.post.ts` in the filename only to match requests with `POST` method that can accept the request body. When using `useBody` within a GET request, `useBody` will throw a `405 Method Not Allowed` HTTP error.
+We are using `submit.post.ts` in the filename only to match requests with `POST` method that can accept the request body. When using `readBody` within a GET request, `readBody` will throw a `405 Method Not Allowed` HTTP error.
 ::
 
 ### Handling Requests With Query Parameters
@@ -275,7 +275,7 @@ Create a new file in `server/api/test.post.ts`:
 
 ```ts [server/api/test.post.ts]
 export default defineEventHandler(async (event) => {
-  const body = await useBody(event)
+  const body = await readBody(event)
   await useStorage().setItem('redis:test', body)
   return 'Data is set'
 })


### PR DESCRIPTION


### 🔗 Linked issue
none

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`useBody` is now deprecated in favor of `readBody`. See [this response on twitter](https://twitter.com/danielcroe/status/1582131640922701824) with info from @danielroe. This PR updates the Nuxt docs to reflect that change. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

