### PR TITLE
chore(nuxt): add type for headers

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -45,9 +45,11 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
 
   // HTML response (via SSR)
   const isErrorPage = event.req.url?.startsWith('/__nuxt_error')
-  let html = !isErrorPage ? await $fetch(withQuery('/__nuxt_error', errorObject), {
-    headers: event.req.headers,
-  }).catch(() => null) : null
+  let html = !isErrorPage
+    ? await $fetch(withQuery('/__nuxt_error', errorObject), {
+      headers: event.req.headers as HeadersInit
+    }).catch(() => null)
+    : null
 
   // Fallback to static rendered error page
   if (!html) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🧹Chore
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This casts incoming headers to HeadersInit and resolves lint issue. @pi0 can you confirm that this is valid (ie. that the actual type of these headers is assignable in fetch) or do we need to normalise them instead?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

