### PR TITLE
fix(nuxt): scroll to top on dynamic routes with different params

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -59,7 +59,7 @@ function isDifferentRoute (a: RouteLocationNormalized, b: RouteLocationNormalize
   if (!samePageComponent) {
     return true
   }
-  if (!samePageComponent && !isEqual(a.params, b.params)) {
+  if (samePageComponent && !isEqual(a.params, b.params)) {
     return true
   }
   return false

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -17,7 +17,7 @@ export default <RouterConfig> {
     let position: ScrollPosition = savedPosition || undefined
 
     // Scroll to top if route is changed by default
-    if (!position && from && to && to.meta.scrollToTop !== false && isDifferentRoute(a, b)) {
+    if (!position && from && to && to.meta.scrollToTop !== false && _isDifferentRoute(a, b)) {
       position = { left: 0, top: 0 }
     }
 
@@ -54,7 +54,7 @@ function _getHashElementScrollMarginTop (selector: string): number {
   return 0
 }
 
-function isDifferentRoute (a: RouteLocationNormalized, b: RouteLocationNormalized): boolean {
+function _isDifferentRoute (a: RouteLocationNormalized, b: RouteLocationNormalized): boolean {
   const samePageComponent = a.matched[0] === b.matched[0]
   if (!samePageComponent) {
     return true

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -1,5 +1,6 @@
 import type { RouterConfig } from '@nuxt/schema'
-import type { RouterScrollBehavior } from 'vue-router'
+import type { RouterScrollBehavior, RouteLocationNormalized } from 'vue-router'
+import { isEqual } from 'ohash'
 import { nextTick } from 'vue'
 import { useNuxtApp } from '#app'
 
@@ -16,8 +17,7 @@ export default <RouterConfig> {
     let position: ScrollPosition = savedPosition || undefined
 
     // Scroll to top if route is changed by default
-    const isDifferentRoute = from && to && (from.matched[0] !== to.matched[0] || (from.matched[0] === to.matched[0] && JSON.stringify(from.params) !== JSON.stringify(to.params)))
-    if (!position && isDifferentRoute && to.meta.scrollToTop !== false) {
+    if (!position && from && to && to.meta.scrollToTop !== false && isDifferentRoute(a, b)) {
       position = { left: 0, top: 0 }
     }
 
@@ -52,4 +52,15 @@ function _getHashElementScrollMarginTop (selector: string): number {
     return parseFloat(getComputedStyle(elem).scrollMarginTop)
   }
   return 0
+}
+
+function isDifferentRoute (a: RouteLocationNormalized, b: RouteLocationNormalized): boolean {
+  const samePageComponent = a.matched[0] === b.matched[0]
+  if (!samePageComponent) {
+    return true
+  }
+  if (!samePageComponent && !isEqual(a.params, b.params)) {
+    return true
+  }
+  return false
 }

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -16,11 +16,8 @@ export default <RouterConfig> {
     let position: ScrollPosition = savedPosition || undefined
 
     // Scroll to top if route is changed by default
-    if (
-      !position &&
-      (from && to && from.matched[0] !== to.matched[0]) &&
-      to.meta.scrollToTop !== false
-    ) {
+    const isDifferentRoute = from && to && (from.matched[0] !== to.matched[0] || (from.matched[0] === to.matched[0] && JSON.stringify(from.params) !== JSON.stringify(to.params)))
+    if (!position && isDifferentRoute && to.meta.scrollToTop !== false) {
       position = { left: 0, top: 0 }
     }
 

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -17,7 +17,7 @@ export default <RouterConfig> {
     let position: ScrollPosition = savedPosition || undefined
 
     // Scroll to top if route is changed by default
-    if (!position && from && to && to.meta.scrollToTop !== false && _isDifferentRoute(a, b)) {
+    if (!position && from && to && to.meta.scrollToTop !== false && _isDifferentRoute(from, to)) {
       position = { left: 0, top: 0 }
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Improvement over #3851 so we scroll to top when it's the same page but with different params.

Example: Going from `/movies/14` to `/movies/15` should scroll to top.

I am only using params to `/movies` to `/movies?q=test` does not scroll to top.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

