### PR TITLE
fix(nuxt): router defaults overwrite custom options always

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -145,7 +145,7 @@ export default defineNuxtModule({
         ))).filter(Boolean) as string[]
 
         // Add default options
-        routerOptionsFiles.unshift(resolve(runtimeDir, 'router.options'))
+        routerOptionsFiles.push(resolve(runtimeDir, 'router.options'))
 
         const configRouterOptions = genObjectFromRawEntries(Object.entries(nuxt.options.router.options)
           .map(([key, value]) => [key, genString(value as string)]))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

- [feat(nuxt): default router scroll behavior](https://github.com/nuxt/framework/pull/3851)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Router default options were introduced in https://github.com/nuxt/framework/commit/ba3a11800c9cc03ba62decfe935d1844f2be34a9. That's great! But now, custom implementations (via `app/router.options.(js|ts)` won't have an effect. The default options stay at the top of all router option layers.

The source of the error seems to be:

https://github.com/nuxt/framework/blob/ba3a11800c9cc03ba62decfe935d1844f2be34a9/packages/nuxt/src/pages/module.ts#L148

`unshift` adds the default to the beginning, but the router options are `reverse`d anyway later:

https://github.com/nuxt/framework/blob/ba3a11800c9cc03ba62decfe935d1844f2be34a9/packages/nuxt/src/pages/module.ts#L159

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

