### PR TITLE
perf(nuxt): use simple `JSON.stringify` to compare params

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -1,6 +1,5 @@
 import type { RouterConfig } from '@nuxt/schema'
 import type { RouterScrollBehavior, RouteLocationNormalized } from 'vue-router'
-import { isEqual } from 'ohash'
 import { nextTick } from 'vue'
 import { useNuxtApp } from '#app'
 
@@ -59,7 +58,7 @@ function _isDifferentRoute (a: RouteLocationNormalized, b: RouteLocationNormaliz
   if (!samePageComponent) {
     return true
   }
-  if (samePageComponent && !isEqual(a.params, b.params)) {
+  if (samePageComponent && JSON.stringify(a.params) !== JSON.stringify(b.params)) {
     return true
   }
   return false


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#8327

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using `JSON.stringify` to compare two route params as suggested by @Atinux. It saves 1.53Kb gzip (~1.6%) bundle size when pages are enabled by not importing `ohash`. Difference is that we _assume_ order of params remains same.

Note: we probably need this library in other places in the future such as `useFetch` if depending on URL again (#6632).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

