### PR TITLE
fix(nuxt): don't load payloads for external urls

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -10,8 +10,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   // Load payload into cache
   nuxtApp.hooks.hook('link:prefetch', (url) => {
-    const { protocol } = parseURL(url)
-    if (!protocol) {
+    if (!parseURL(url).protocol) {
       return loadPayload(url)
     }
   })

--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -1,3 +1,4 @@
+import { parseURL } from 'ufo'
 import { defineNuxtPlugin, loadPayload, isPrerendered, useRouter } from '#app'
 
 export default defineNuxtPlugin((nuxtApp) => {
@@ -8,7 +9,12 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   // Load payload into cache
-  nuxtApp.hooks.hook('link:prefetch', to => loadPayload(to))
+  nuxtApp.hooks.hook('link:prefetch', (url) => {
+    const { protocol } = parseURL(url)
+    if (!protocol) {
+      return loadPayload(url)
+    }
+  })
 
   // Load payload after middleware & once final route is resolved
   useRouter().beforeResolve(async (to, from) => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Regression of https://github.com/nuxt/framework/pull/8225. We need to ensure we're only loading payloads for internal URLs. (Actually we need to implement something like https://github.com/nuxt/framework/pull/7805 as a proper fix.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

