### PR TITLE
fix(webpack): print build errors

### DIFF
--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -156,11 +156,8 @@ async function compile (compiler: Compiler) {
   const stats = await new Promise<webpack.Stats>((resolve, reject) => compiler.run((err, stats) => err ? reject(err) : resolve(stats!)))
 
   if (stats.hasErrors()) {
-    // non-quiet mode: errors will be printed by webpack itself
     const error = new Error('Nuxt build error')
-    if (nuxt.options.build.quiet === true) {
-      error.stack = stats.toString('errors-only')
-    }
+    error.stack = stats.toString('errors-only')
     throw error
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently webpack does not print build errors, despite the comment in this file.

For a reproduction, see https://stackblitz.com/edit/nuxt-starter-repdpw and run `npm run build`. The following is all that is printed:

```js
 ERROR  Nuxt build error                                                                        11:40:09

  at compile@node_modules/ (nuxt/webpack-builder/dist/index.mjs:1165:19)
  at <anonymous> (<anonymous>)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

