### PR TITLE
docs: change required node version to be above 16.11

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -23,7 +23,7 @@ Before getting started, please make sure you have installed the recommended setu
   * Either enable [**Take Over Mode**](https://vuejs.org/guide/typescript/overview.html#volar-takeover-mode) (recommended)
   * ... or add **TypeScript Vue Plugin (Volar)** 👉 [[Download](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin)]
 
-<sup>*</sup> If you already have Node.js installed, check with `node --version` that you are using version 14.16 or above 16.11.
+<sup>*</sup> If you already have Node.js installed, check with `node --version` above 16.11.
 
 ::alert{type=info}
 


### PR DESCRIPTION
### 🔗 Linked issue

#8407
#8335

### ❓ Type of change


- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt 3 seems not work on node versions bellow 16. So the documentation need to be updated

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

