### PR TITLE
fix(nuxt): avoid directly importing `vue-router` inside `<NuxtLayout>`

### DIFF
--- a/packages/nuxt/src/app/components/layout.ts
+++ b/packages/nuxt/src/app/components/layout.ts
@@ -3,7 +3,7 @@ import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import { _wrapIf } from './utils'
 import { useRoute } from '#app'
 // @ts-ignore
-import { useRoute as useVueRouterRoute } from '#build/vue-router-imports'
+import { useRoute as useVueRouterRoute } from '#build/pages'
 // @ts-ignore
 import layouts from '#build/layouts'
 // @ts-ignore

--- a/packages/nuxt/src/app/components/layout.ts
+++ b/packages/nuxt/src/app/components/layout.ts
@@ -1,7 +1,9 @@
 import { computed, defineComponent, h, inject, nextTick, onMounted, Ref, Transition, unref, VNode } from 'vue'
-import { RouteLocationNormalizedLoaded, useRoute as useVueRouterRoute } from 'vue-router'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import { _wrapIf } from './utils'
 import { useRoute } from '#app'
+// @ts-ignore
+import { useRoute as useVueRouterRoute } from '#build/vue-router-imports'
 // @ts-ignore
 import layouts from '#build/layouts'
 // @ts-ignore

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -23,6 +23,11 @@ export default defineNuxtModule({
     // Disable module (and use universal router) if pages dir do not exists or user has disabled it
     if ((nuxt.options.pages === false || (nuxt.options.pages !== true && !pagesDirs.some(dir => existsSync(dir)))) && !isRouterOptionsPresent) {
       addPlugin(resolve(distDir, 'app/plugins/router'))
+      // Add vue-router import for `<NuxtLayout>` integration
+      addTemplate({
+        filename: 'vue-router-imports.mjs',
+        getContents: () => 'export { useRoute } from \'#app\''
+      })
       return
     }
 
@@ -133,6 +138,12 @@ export default defineNuxtModule({
         const { routes, imports } = normalizeRoutes(pages)
         return [...imports, `export default ${routes}`].join('\n')
       }
+    })
+
+    // Add vue-router import for `<NuxtLayout>` integration
+    addTemplate({
+      filename: 'vue-router-imports.mjs',
+      getContents: () => 'export { useRoute } from \'vue-router\''
     })
 
     // Add router options template

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -25,7 +25,7 @@ export default defineNuxtModule({
       addPlugin(resolve(distDir, 'app/plugins/router'))
       // Add vue-router import for `<NuxtLayout>` integration
       addTemplate({
-        filename: 'vue-router-imports.mjs',
+        filename: 'pages.mjs',
         getContents: () => 'export { useRoute } from \'#app\''
       })
       return
@@ -142,7 +142,7 @@ export default defineNuxtModule({
 
     // Add vue-router import for `<NuxtLayout>` integration
     addTemplate({
-      filename: 'vue-router-imports.mjs',
+      filename: 'pages.mjs',
       getContents: () => 'export { useRoute } from \'vue-router\''
     })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/8415

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As noted in https://github.com/nuxt/framework/pull/8133, this follows up to remove a `vue-router` dependency from all use of `<NuxtLayout>`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

