### PR TITLE
fix(nuxt): allow responding with custom headers from `error.vue`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -1,7 +1,8 @@
 import { withQuery } from 'ufo'
 import type { NitroErrorHandler } from 'nitropack'
 import type { H3Error } from 'h3'
-import { getRequestHeaders } from 'h3'
+import { getRequestHeaders, H3Response } from 'h3'
+import { useNitroApp } from '#internal/nitro'
 import { normalizeError, isJsonRequest } from '#internal/nitro/utils'
 
 export default <NitroErrorHandler> async function errorhandler (error: H3Error, event) {
@@ -46,14 +47,15 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
 
   // HTML response (via SSR)
   const isErrorPage = event.req.url?.startsWith('/__nuxt_error')
-  let html = !isErrorPage
-    ? await $fetch(withQuery('/__nuxt_error', errorObject), {
-      headers: getRequestHeaders(event) as HeadersInit
+  const res = !isErrorPage
+    ? await useNitroApp().localFetch(withQuery('/__nuxt_error', errorObject), {
+      headers: getRequestHeaders(event) as Record<string, string>,
+      redirect: 'manual'
     }).catch(() => null)
     : null
 
   // Fallback to static rendered error page
-  if (!html) {
+  if (!res) {
     const { template } = process.dev
       // @ts-ignore
       ? await import('@nuxt/ui-templates/templates/error-dev.mjs')
@@ -63,9 +65,13 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
       // TODO: Support `message` in template
       (errorObject as any).description = errorObject.message
     }
-    html = template(errorObject)
+    event.res.setHeader('Content-Type', 'text/html;charset=UTF-8')
+    return event.res.end(template(errorObject))
   }
 
-  event.res.setHeader('Content-Type', 'text/html;charset=UTF-8')
-  event.res.end(html)
+  event.respondWith(new H3Response(await res.text(), {
+    headers: res.headers,
+    status: res.status,
+    statusText: res.statusText
+  }))
 }

--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -71,7 +71,7 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
 
   event.respondWith(new H3Response(await res.text(), {
     headers: res.headers,
-    status: res.status,
-    statusText: res.statusText
+    status: res.status === 200 ? errorObject.statusCode : res.status,
+    statusText: res.statusText || errorObject.statusMessage
   }))
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

follow-up to https://github.com/nuxt/framework/pull/7340, resolves https://github.com/nuxt/framework/issues/7469

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows responding to an error within `error.vue` with more than just HTML and the original error code, such as modifying the code or redirecting to a different page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

