### PR TITLE
fix(kit): don't require nuxt when resolving path

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { basename, dirname, resolve, join, normalize, isAbsolute } from 'pathe'
 import { globby } from 'globby'
 import { resolveAlias as _resolveAlias } from 'pathe/utils'
-import { tryUseNuxt, useNuxt } from './context'
+import { tryUseNuxt } from './context'
 import { tryResolveModule } from './internal/cjs'
 import { isIgnored } from './ignore'
 
@@ -34,7 +34,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   }
 
   // Use current nuxt options
-  const nuxt = useNuxt()
+  const nuxt = tryUseNuxt()
   const cwd = opts.cwd || (nuxt ? nuxt.options.rootDir : process.cwd())
   const extensions = opts.extensions || (nuxt ? nuxt.options.extensions : ['.ts', '.mjs', '.cjs', '.json'])
   const modulesDir = nuxt ? nuxt.options.modulesDir : []


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently if nuxt instance is not present when calling `resolvePath`, we will throw an error. We already check for existence, so this was likely not intended.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
