### PR TITLE
fix(nuxt): add `vue-router` to optimized deps

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -162,6 +162,11 @@ export default defineNuxtModule({
       getContents: () => 'export { useRoute } from \'vue-router\''
     })
 
+    // Optimize vue-router to ensure we share the same injection symbol
+    nuxt.options.vite.optimizeDeps = nuxt.options.vite.optimizeDeps || {}
+    nuxt.options.vite.optimizeDeps.include = nuxt.options.vite.optimizeDeps.include || []
+    nuxt.options.vite.optimizeDeps.include.push('vue-router')
+
     // Add router options template
     addTemplate({
       filename: 'router.options.mjs',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/8526

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems that we could end up with multiple versions of `vue-router` when optimising dependencies, and therefore have mismatching route symbols.

This PR ensures that when using the pages integration we process the router first.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
