### PR TITLE
fix(vite): handle all vite middleware routes

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -109,10 +109,11 @@ export async function buildClient (ctx: ViteBuildContext) {
     const viteServer = await vite.createServer(clientConfig)
     ctx.clientServer = viteServer
     await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: true, isServer: false })
+    const viteRoutes = viteServer.middlewares.stack.map(m => m.route).filter(r => r.length > 1)
     const viteMiddleware = defineEventHandler(async (event) => {
       // Workaround: vite devmiddleware modifies req.url
       const originalURL = event.req.url!
-      if (!originalURL.startsWith('/__nuxt_vite_node__') && !originalURL.startsWith(clientConfig.base!)) {
+      if (!viteRoutes.some(route => originalURL.startsWith(route)) && !originalURL.startsWith(clientConfig.base!)) {
         event.req.url = joinURL('/__url', originalURL)
       }
       await new Promise((resolve, reject) => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Fix #8522

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite plugin might register their custom server middleware to the Vite dev server, for example:

- [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect#install)
- [unocss/inspector](https://github.com/unocss/unocss/tree/main/packages/inspector)

#7989 introduced a regression that bypassed all custom vite middleware. This PR fixes it by checking the registered routes to Vite middleware and forwarding them as-is. This also removes the hard-code `/__nuxt_vite_node__` handling.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

