### PR TITLE
fix(kit): normalize nitro handler paths

### DIFF
--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -1,4 +1,5 @@
 import type { NitroEventHandler, NitroDevEventHandler, Nitro } from 'nitropack'
+import { normalize } from 'pathe'
 import { useNuxt } from './context'
 
 /**
@@ -10,7 +11,8 @@ function normalizeHandlerMethod (handler: NitroEventHandler) {
   const [, method = undefined] = handler.handler.match(/\.(get|head|patch|post|put|delete|connect|options|trace)(\.\w+)*$/) || []
   return {
     method,
-    ...handler
+    ...handler,
+    handler: normalize(handler.handler)
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/Baroshem/nuxt-security/issues/42

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This normalizes paths to handlers passed in via `addServerHandler` and `addDevServerHandler`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
