### PR TITLE
fix(nuxt): don't force prerender `/` if user doesn't have that route

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -102,6 +102,8 @@ export default defineNuxtModule({
       })
       nuxt.hook('nitro:build:before', (nitro) => {
         for (const route of nitro.options.prerender.routes || []) {
+          // Skip default route value as we only generate it if it is already
+          // in the detected routes from `~/pages`.
           if (route === '/') { continue }
           prerenderRoutes.add(route)
         }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -102,6 +102,7 @@ export default defineNuxtModule({
       })
       nuxt.hook('nitro:build:before', (nitro) => {
         for (const route of nitro.options.prerender.routes || []) {
+          if (route === '/') { continue }
           prerenderRoutes.add(route)
         }
         nitro.options.prerender.routes = Array.from(prerenderRoutes)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/issues/5483#issuecomment-1157960000

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With pages module, we add routes to the default routes values. But if the user doesn't have a `~/pages/index.vue` file we can safely skip processing the default `/` route for prerender.routes.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
