### PR TITLE
fix(nuxt): do not inline global styles in HTML response

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -289,18 +289,14 @@ function renderHTMLDocument (html: NuxtRenderHTMLContext) {
 }
 
 async function renderInlineStyles (usedModules: Set<string> | string[]) {
-  const { entryCSS } = await getClientManifest()
   const styleMap = await getSSRStyles()
   const inlinedStyles = new Set<string>()
-  for (const mod of ['entry', ...usedModules]) {
+  for (const mod of usedModules) {
     if (mod in styleMap) {
       for (const style of await styleMap[mod]()) {
         inlinedStyles.add(`<style>${style}</style>`)
       }
     }
-  }
-  for (const css of entryCSS?.css || []) {
-    inlinedStyles.add(`<link rel="stylesheet" href=${JSON.stringify(buildAssetsURL(css))} media="print" onload="this.media='all'; this.onload=null;">`)
   }
   return Array.from(inlinedStyles).join('')
 }

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -126,16 +126,6 @@ export async function buildServer (ctx: ViteBuildContext) {
         if (shouldRemoveCSS) {
           entry.css = []
         }
-        // Add entry CSS as prefetch (non-blocking)
-        if (entry.isEntry) {
-          manifest.entryCSS = {
-            file: '',
-            css: entry.css
-          }
-          entry.css = []
-          entry.dynamicImports = entry.dynamicImports || []
-          entry.dynamicImports.push('entryCSS')
-        }
       }
     })
   }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -598,19 +598,18 @@ describe.skipIf(process.env.NUXT_TEST_DEV || process.env.TEST_WITH_WEBPACK)('inl
     for (const style of [
       '{--assets:"assets"}', // <script>
       '{--scoped:"scoped"}', // <style lang=css>
-      '{--postcss:"postcss"}', // <style lang=postcss>
-      '{--global:"global"', // entryfile dependency
-      '{--plugin:"plugin"}' // plugin dependency
+      '{--postcss:"postcss"}' // <style lang=postcss>
     ]) {
       expect(html).toContain(style)
     }
   })
 
-  it('only renders prefetch for entry styles', async () => {
+  it('does not load stylesheet for page styles', async () => {
     const html: string = await $fetch('/styles')
     expect(html.match(/<link [^>]*href="[^"]*\.css">/g)?.filter(m => m.includes('entry'))?.map(m => m.replace(/\.[^.]*\.css/, '.css'))).toMatchInlineSnapshot(`
       [
-        "<link rel=\\"prefetch\\" as=\\"style\\" href=\\"/_nuxt/entry.css\\">",
+        "<link rel=\\"preload\\" as=\\"style\\" href=\\"/_nuxt/entry.css\\">",
+        "<link rel=\\"stylesheet\\" href=\\"/_nuxt/entry.css\\">",
       ]
     `)
   })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/issues/7619

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This reverts https://github.com/nuxt/framework/pull/7386. Rather than attempt to lazy load the entry CSS, it's safer to rely on browser fetching it in the previous (blocking) manner. We still experience the benefit of inlining SFC styles and we can reconsider entry CSS inlining in future.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
