### PR TITLE
fix(schema)!: use strict typescript mode by default

### DIFF
--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -11,7 +11,7 @@ export default defineUntypedSchema({
      * Once you’ve converted your codebase to TypeScript, you can start enabling these checks for greater safety.
      * [Read More](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks)
      */
-    strict: false,
+    strict: true,
 
     /**
      * Include parent workspace in the Nuxt project. Mostly useful for themes and module authors.


### PR DESCRIPTION
### 🔗 Linked issue

resolves #8631

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enables TypeScript's strict mode by default for users who are using TS. This is a better default and best practice.

### 👉 Migration

Users can disable this if they prefer.

```js
export default defineNuxtConfig({
  typescript: {
    strict: false
  }
})
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.