### PR TITLE
feat(kit, nuxt): support `prerender:routes` and `addPrerenderRoutes`

### DIFF
--- a/docs/content/3.api/4.advanced/1.hooks.md
+++ b/docs/content/3.api/4.advanced/1.hooks.md
@@ -31,7 +31,7 @@ Hook                   | Arguments           | Environment     | Description
 
 # Nuxt Hooks (build time)
 
-Check the [schema source code](https://github.com/nuxt/framework/blob/main/packages/schema/src/types/hooks.ts#L69) for all available hooks.
+Check the [schema source code](https://github.com/nuxt/framework/blob/main/packages/schema/src/types/hooks.ts#L53) for all available hooks.
 
 :NeedContribution
 

--- a/docs/content/3.api/4.advanced/2.kit.md
+++ b/docs/content/3.api/4.advanced/2.kit.md
@@ -77,6 +77,8 @@ description: Nuxt Kit provides composable utilities to help interacting with Nux
 - `addServerHandler (handler)`
 - `addDevServerHandler (handler)`
 - `useNitro()` (only usable after `ready` hook)
+- `addServerPlugin`
+- `addPrerenderRoutes`
 
 ### Resolving
 

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -42,6 +42,25 @@ export function addServerPlugin (plugin: string) {
 }
 
 /**
+ * Adds routes to be prerendered
+ */
+export function addPrerenderRoutes (routes: string | string[]) {
+  const nuxt = useNuxt()
+  if (!Array.isArray(routes)) {
+    routes = [routes]
+  }
+  routes = routes.filter(Boolean)
+  if (!routes.length) {
+    return
+  }
+  nuxt.hook('prerender:routes', (ctx) => {
+    for (const route of routes) {
+      ctx.routes.add(route)
+    }
+  })
+}
+
+/**
  * Access to the Nitro instance
  *
  * **Note:** You can call `useNitro()` only after `ready` hook.

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -148,6 +148,9 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
   // Connect hooks
   nuxt.hook('close', () => nitro.hooks.callHook('close'))
+  nitro.hooks.hook('prerender:routes', (routes) => {
+    nuxt.callHook('prerender:routes', { routes })
+  })
 
   // Setup handlers
   const devMiddlewareHandler = dynamicEventHandler()

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -96,6 +96,7 @@ export interface NuxtHooks {
   'nitro:config': (nitroConfig: NitroConfig) => HookResult
   'nitro:init': (nitro: Nitro) => HookResult
   'nitro:build:before': (nitro: Nitro) => HookResult
+  'prerender:routes': (ctx: { routes: Set<string> }) => HookResult
 
   // Nuxi
   'build:error': (error: Error) => HookResult


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Add `prerender:routes({ routes })` hook proxied from nitro
- Add `addPrerenderRoutes(routes: string | string[])` kit utility for extending prerender routes

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

