### PR TITLE
fix(vite): enable fs strict mode

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -64,7 +64,6 @@ export default defineUntypedSchema({
     },
     server: {
       fs: {
-        strict: false,
         allow: {
           $resolve: async (val, get) => [
             await get('buildDir'),

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -69,6 +69,7 @@ export default defineUntypedSchema({
             await get('buildDir'),
             await get('srcDir'),
             await get('rootDir'),
+            await get('workspaceDir'),
             ...(await get('modulesDir')),
             ...val ?? []
           ]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Enable vite fs restriction by default(https://vitejs.dev/config/server-options.html#server-fs-strict). 

This ensures avoiding access to fs using `/_nuxt/@fs/` url.

This PR might introduce regressions with modules trying to access outside of `rootDir`, `srcDir`, `buildDir`, `workspaceDir` or either of `modulesDir` (modules are automatically added). In this case, can be manually added using `nuxt.options.vite.server.fs.allow[]`

```ts
export default defineNuxtConfig({
  vite: {
    server: {
      fs: {
        allow: [
          '/xyz'
        ]
      }
    }
  }
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

