### PR TITLE
fix(nuxt): ensure payload url has no protocol

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -41,6 +41,9 @@ function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   if (u.search) {
     throw new Error('Payload URL cannot contain search params: ' + url)
   }
+  if (u.host !== 'localhost') {
+    throw new Error('Payload URL cannot contain host: ' + url)
+  }
   const hash = opts.hash || (opts.fresh ? Date.now() : '')
   return joinURL(useRuntimeConfig().app.baseURL, u.pathname, hash ? `_payload.${hash}.js` : '_payload.js')
 }

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -1,4 +1,4 @@
-import { parseURL, joinURL } from 'ufo'
+import { joinURL } from 'ufo'
 import { useNuxtApp } from '../nuxt'
 import { useHead, useRuntimeConfig } from '..'
 

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -37,12 +37,12 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {
 // --- Internal ---
 
 function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
-  const parsed = parseURL(url)
-  if (parsed.search) {
+  const u = new URL(url, 'http://localhost')
+  if (u.search) {
     throw new Error('Payload URL cannot contain search params: ' + url)
   }
   const hash = opts.hash || (opts.fresh ? Date.now() : '')
-  return joinURL(useRuntimeConfig().app.baseURL, parsed.pathname, hash ? `_payload.${hash}.js` : '_payload.js')
+  return joinURL(useRuntimeConfig().app.baseURL, u.pathname, hash ? `_payload.${hash}.js` : '_payload.js')
 }
 
 async function _importPayload (payloadURL: string) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use `URL` parser to extract pathname from URL for internal `_getPayloadURL` utility and ensure input does not contain hostname or search params. 

Previously an invalid URL like `loadPayload('/\\example.com')` could be passed.

Credits to @ohb00 for discovering this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

