### PR TITLE
fix(nuxt): check if global transitions are activated for scroll behavior

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -2,6 +2,7 @@ import type { RouterConfig } from '@nuxt/schema'
 import type { RouterScrollBehavior, RouteLocationNormalized } from 'vue-router'
 import { nextTick } from 'vue'
 import { useNuxtApp } from '#app'
+import { appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
 
@@ -31,7 +32,7 @@ export default <RouterConfig> {
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
-    const hasTransition = to.meta.pageTransition !== false && from.meta.pageTransition !== false
+    const hasTransition = defaultPageTransition || (to.meta.pageTransition && from.meta.pageTransition)
     const hookToWait = hasTransition ? 'page:transition:finish' : 'page:finish'
     return new Promise((resolve) => {
       nuxtApp.hooks.hookOnce(hookToWait, async () => {

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -33,8 +33,8 @@ export default <RouterConfig> {
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
-    const hasTransition = defaultPageTransition || (to.meta.pageTransition && from.meta.pageTransition)
-    const hookToWait = hasTransition ? 'page:transition:finish' : 'page:finish'
+    const hasTransition = (route: RouteLocationNormalized) => !!(route.meta.pageTransition ?? defaultPageTransition)
+    const hookToWait = (hasTransition(from) && hasTransition(to)) ? 'page:transition:finish' : 'page:finish'
     return new Promise((resolve) => {
       nuxtApp.hooks.hookOnce(hookToWait, async () => {
         await nextTick()

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -2,6 +2,7 @@ import type { RouterConfig } from '@nuxt/schema'
 import type { RouterScrollBehavior, RouteLocationNormalized } from 'vue-router'
 import { nextTick } from 'vue'
 import { useNuxtApp } from '#app'
+// @ts-ignore
 import { appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>


### PR DESCRIPTION
Resolves a regression from #8463

And resolves #8699

Learn more in the comments from #8327

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Regression since we need to detect if there are global transitions activated in order to listen to `page:transition:finish` hook. Otherwise it's never called and the scrollBehavior is inactive.

Also, since the value of the next and previous page can be `undefined`, using `!== false` was also a wrong usage.