### PR TITLE
fix: correct default scroll behavior for routes without page transition

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -31,7 +31,7 @@ export default <RouterConfig> {
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
-    const hasTransition = to.meta.pageTransition !== false && from.meta.pageTransition !== false
+    const hasTransition = !!(to.meta.pageTransition && from.meta.pageTransition)
     const hookToWait = hasTransition ? 'page:transition:finish' : 'page:finish'
     return new Promise((resolve) => {
       nuxtApp.hooks.hookOnce(hookToWait, async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

#8699

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`router.options.ts` falsely determines that an `undefined` page transition is `true`, meaning it HAS a transition.
Whereas `page.mjs` correctly interprets an `undefined` transition as `false`.

This commit changes the condition in `router.options.ts` to consider an `undefined` transition as `false`.

Resolves #8699 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

