### PR TITLE
refactor(nuxt)!: fix typo for `NuxtRenderHTMLContext.bodyPrepend`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -21,7 +21,7 @@ export interface NuxtRenderHTMLContext {
   htmlAttrs: string[]
   head: string[]
   bodyAttrs: string[]
-  bodyPreprend: string[]
+  bodyPrepend: string[]
   body: string[]
   bodyAppend: string[]
 }
@@ -223,7 +223,7 @@ export default defineRenderHandler(async (event) => {
       ssrContext.styles
     ]),
     bodyAttrs: normalizeChunks([renderedMeta.bodyAttrs!]),
-    bodyPreprend: normalizeChunks([
+    bodyPrepend: normalizeChunks([
       renderedMeta.bodyScriptsPrepend,
       ssrContext.teleports?.body
     ]),
@@ -288,7 +288,7 @@ function renderHTMLDocument (html: NuxtRenderHTMLContext) {
   return `<!DOCTYPE html>
 <html ${joinAttrs(html.htmlAttrs)}>
 <head>${joinTags(html.head)}</head>
-<body ${joinAttrs(html.bodyAttrs)}>${joinTags(html.bodyPreprend)}${joinTags(html.body)}${joinTags(html.bodyAppend)}</body>
+<body ${joinAttrs(html.bodyAttrs)}>${joinTags(html.bodyPrepend)}${joinTags(html.body)}${joinTags(html.bodyAppend)}</body>
 </html>`
 }
 


### PR DESCRIPTION
### 🔗 Linked issue
No issue.

### ❓ Type of change
* [ ]  📖 Documentation (updates to the documentation or readme)
* [ ]  🐞 Bug fix (a non-breaking change that fixes an issue)
* [ ]  👌 Enhancement (improving an existing functionality like performance)
* [ ]  ✨ New feature (a non-breaking change that adds functionality)
* [x]  ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Tried to use Nitro's `render:html` hook in a server plugin and noticed `bodyPrepend` was actually `bodyPreprend`.

### 📝 Checklist
* [ ]  I have linked an issue or discussion.
* [ ]  I have updated the documentation accordingly.

