### PR TITLE
style: lint some types

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -83,7 +83,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
 /**
  * Try to resolve first existing file in paths
  */
-export async function findPath (paths: string|string[], opts?: ResolvePathOptions, pathType: 'file' | 'dir' = 'file'): Promise<string|null> {
+export async function findPath (paths: string | string[], opts?: ResolvePathOptions, pathType: 'file' | 'dir' = 'file'): Promise<string | null> {
   if (!Array.isArray(paths)) {
     paths = [paths]
   }
@@ -110,8 +110,8 @@ export function resolveAlias (path: string, alias?: Record<string, string>): str
 }
 
 export interface Resolver {
-  resolve(...path: string[]): string
-  resolvePath(path: string, opts?: ResolvePathOptions): Promise<string>
+  resolve (...path: string[]): string
+  resolvePath (path: string, opts?: ResolvePathOptions): Promise<string>
 }
 
 /**

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -338,6 +338,7 @@ export default defineUntypedSchema({
     $resolve: async (val, get) => [
       '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
       '**/*.{spec,test}.{js,ts,jsx,tsx}', // ignore tests
+      '**/.d.ts', // ignore type declarations
       '.output',
       await get('ignorePrefix') && `**/${await get('ignorePrefix')}*.*`
     ].concat(val).filter(Boolean)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #8778

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We can safely ignore `.d.ts` files from our resolver for layouts, pages, middleware, plugins, etc. (and indeed from the vite build _watcher_). They will still be included in the user's project and type checked.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
