### PR TITLE
fix(nuxt): treeshake client-only components with placeholders

### DIFF
--- a/packages/nuxt/src/components/tree-shake.ts
+++ b/packages/nuxt/src/components/tree-shake.ts
@@ -4,6 +4,8 @@ import MagicString from 'magic-string'
 import { parse, walk, ELEMENT_NODE, Node } from 'ultrahtml'
 import { createUnplugin } from 'unplugin'
 import type { Component } from '@nuxt/schema'
+import { resolve } from 'pathe'
+import { distDir } from '../dirs'
 
 interface TreeShakeTemplatePluginOptions {
   sourcemap?: boolean
@@ -29,7 +31,7 @@ export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplat
 
       if (!regexpMap.has(components)) {
         const clientOnlyComponents = components
-          .filter(c => c.mode === 'client' && !components.some(other => other.mode !== 'client' && other.pascalName === c.pascalName))
+          .filter(c => c.mode === 'client' && !components.some(other => other.mode !== 'client' && other.pascalName === c.pascalName && other.filePath !== resolve(distDir, 'app/components/server-placeholder')))
           .flatMap(c => [c.pascalName, c.kebabName])
           .concat(['ClientOnly', 'client-only'])
         const tags = clientOnlyComponents


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/nuxt.js/issues/15396
<!-- Please ensure there is an open issue and mention its number as nuxt/framework#123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: currently the tree-shake module does not treeshake .client components due to nuxt/framework#7412 that adds `ServerPlaceholder` as .client components server side component.
This PR fix the RegexpMap of the treeshake module by adding a condition to verify that `other.filePath` is not the path to `ServerPlaceholder`. 
btw this can be closed if nuxt/framework#8713 pass

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves nuxt/nuxt.js#12299" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

