### PR TITLE
feat(nuxt): allow .client components to have a fallback slot

### DIFF
--- a/docs/content/2.guide/2.directory-structure/1.components.md
+++ b/docs/content/2.guide/2.directory-structure/1.components.md
@@ -200,6 +200,23 @@ If a component is meant to be rendered only client-side, you can add the `.clien
 </template>
 ```
 
+Just as `<ClientOnly>`, you can add a fallback slot to be rendered server-side for `.client` components.
+
+```html{}[pages/example.vue]
+<template>
+  <div>
+    <Sidebar />
+      <!-- this component will only be rendered on client side -->
+      <Comments>
+        <template #fallback>
+          <!-- but this will be rendered on server side -->
+          <p>Loading comments...</p>
+        </template>
+      </Comments>
+  </div>
+</template>
+```
+
 ::alert{type=warning}
 This feature only works with Nuxt auto-imports and `#components` imports. Explicitly importing these components from their real paths does not convert them into client-only components.
 ::

--- a/packages/nuxt/src/app/components/server-placeholder.ts
+++ b/packages/nuxt/src/app/components/server-placeholder.ts
@@ -2,7 +2,9 @@ import { defineComponent, createElementBlock } from 'vue'
 
 export default defineComponent({
   name: 'ServerPlaceholder',
-  render () {
+  render (ctx: any) {
+    const slot = ctx.$slots.fallback || ctx.$slots.placeholder
+    if (slot) { return slot() }
     return createElementBlock('div')
   }
 })

--- a/packages/nuxt/src/app/components/server-placeholder.ts
+++ b/packages/nuxt/src/app/components/server-placeholder.ts
@@ -4,7 +4,10 @@ export default defineComponent({
   name: 'ServerPlaceholder',
   render (ctx: any) {
     const slot = ctx.$slots.fallback || ctx.$slots.placeholder
-    if (slot) { return slot() }
+    if (slot) {
+      const res = slot()
+      return res.length === 1 ? res[0] : res
+    }
     return createElementBlock('div')
   }
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -160,6 +160,7 @@ describe('pages', () => {
     expect(html).toContain('<div class="client-only-script" foo="bar">')
     expect(html).toContain('<div class="client-only-script-setup" foo="hello">')
     expect(html).toContain('<div>Fallback</div>')
+    expect(html).toContain('<div>Fallback, this should not visible once mounted</div>')
     // ensure components are not rendered server-side
     expect(html).not.toContain('Should not be server rendered')
 
@@ -168,6 +169,7 @@ describe('pages', () => {
     const page = await createPage('/client-only-components')
 
     await page.waitForLoadState('networkidle')
+    expect(await page.textContent('body')).not.toContain('Fallback, this should not visible once mounted')
 
     const hiddenSelectors = [
       '.string-stateful-should-be-hidden',

--- a/test/fixtures/basic/pages/client-only-components.vue
+++ b/test/fixtures/basic/pages/client-only-components.vue
@@ -27,7 +27,14 @@
     <ClientStringChildStatefulScript
       ref="stringStatefulScriptComp"
       class="string-stateful-script"
-    />
+    >
+      <template #fallback>
+        <div>
+          <!-- test fallback slot -->
+          Fallback, this should not visible once mounted
+        </div>
+      </template>
+    </ClientStringChildStatefulScript>
     <ClientNoState class="no-state" />
     <!-- ensure directives are correctly passed -->
     <ClientStringChildStateful v-show="show" class="string-stateful-should-be-hidden" />
@@ -35,8 +42,19 @@
     <ClientStringChildStatefulScript
       v-show="show"
       class="string-stateful-script-should-be-hidden"
-    />
+    >
+      <template #fallback>
+        <div>Fallback, this should not visible once mounted</div>
+      </template>
+    </ClientStringChildStatefulScript>
     <ClientNoState v-show="show" class="no-state-hidden" />
+    <ClientStringChildStateful>
+      <template #fallback>
+        <!-- test fragment as fallback slot -->
+        <div>Fallback, this should not visible once mounted</div>
+        <div>Fallback, this should not visible once mounted</div>
+      </template>
+    </ClientStringChildStateful>
 
     <button class="test-ref-1" @click="stringStatefulComp.add">
       increment count


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/framework/issues/8748

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Hi ! this PR simply allow using a fallback or placeholder slot within `ServerPlaceholder`.
Currently the treeshake module treeshake every slots except the fallback or placeholder slots for `<ClientOnly>` or `.client` components.
This would allow `.client` components to have a `fallback|placeholder` slot server-side.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

