### PR TITLE
feat(nuxt-link): add `isExternal` to slot props

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -47,13 +47,13 @@ export type NuxtLinkProps = {
 const requestIdleCallback: Window['requestIdleCallback'] = process.server
   ? undefined as any
   : (globalThis.requestIdleCallback || ((cb) => {
-      const start = Date.now()
-      const idleDeadline = {
-        didTimeout: false,
-        timeRemaining: () => Math.max(0, 50 - (Date.now() - start))
-      }
-      return setTimeout(() => { cb(idleDeadline) }, 1)
-    }))
+    const start = Date.now()
+    const idleDeadline = {
+      didTimeout: false,
+      timeRemaining: () => Math.max(0, 50 - (Date.now() - start))
+    }
+    return setTimeout(() => { cb(idleDeadline) }, 1)
+  }))
 
 const cancelIdleCallback: Window['cancelIdleCallback'] = process.server
   ? null as any
@@ -203,8 +203,8 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                   unobserve?.()
                   unobserve = null
                   await Promise.all([
-                    nuxtApp.hooks.callHook('link:prefetch', to.value as string).catch(() => {}),
-                    !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
+                    nuxtApp.hooks.callHook('link:prefetch', to.value as string).catch(() => { }),
+                    !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => { })
                   ])
                   prefetched.value = true
                 })
@@ -265,6 +265,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             route: router.resolve(href!),
             rel,
             target,
+            isExternal,
             isActive: false,
             isExactActive: false
           })


### PR DESCRIPTION

### 🔗 Linked issue

#8799 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR exposes the `isExternal` scoped slot prop of `<NuxtLink>`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

