### PR TITLE
fix(nuxt): filter headers with lower case in useRequestHeaders

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-redeclare */
 import type { H3Event } from 'h3'
 import { useNuxtApp, NuxtApp } from '../nuxt'
 
@@ -8,7 +7,7 @@ export function useRequestHeaders (include?: any[]) {
   if (process.client) { return {} }
   const headers = useNuxtApp().ssrContext?.event.req.headers ?? {}
   if (!include) { return headers }
-  return Object.fromEntries(include.filter(key => headers[key]).map(key => [key, headers[key]]))
+  return Object.fromEntries(include.filter(key => headers[String(key).toLowerCase()]).map(key => [key, headers[String(key).toLowerCase()]]))
 }
 
 export function useRequestEvent (nuxtApp: NuxtApp = useNuxtApp()): H3Event {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

https://github.com/nuxt/framework/discussions/8803

https://nodejs.org/docs/latest-v18.x/api/http.html#messageheaders
> Header names are lower-cased.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

