### PR TITLE
fix(ssr): ensure useRequestHeaders are case-insensitive

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -2,7 +2,7 @@
 import type { H3Event } from 'h3'
 import { useNuxtApp, NuxtApp } from '../nuxt'
 
-export function useRequestHeaders<K extends string = string> (include: K[]): Record<K, string | undefined>
+export function useRequestHeaders<K extends string = string> (include: K[]): Record<Lowercase<K>, string | undefined>
 export function useRequestHeaders (): Readonly<Record<string, string | undefined>>
 export function useRequestHeaders (include?: any[]) {
   if (process.client) { return {} }

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -8,7 +8,7 @@ export function useRequestHeaders (include?: any[]) {
   if (process.client) { return {} }
   const headers = useNuxtApp().ssrContext?.event.req.headers ?? {}
   if (!include) { return headers }
-  return Object.fromEntries(include.filter(key => headers[key]).map(key => [key, headers[key]]))
+  return Object.fromEntries(include.map(key => key.toLowerCase()).filter(key => headers[key]).map(key => [key, headers[key]]))
 }
 
 export function useRequestEvent (nuxtApp: NuxtApp = useNuxtApp()): H3Event {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/discussions/8803

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes headers case-insensitive.

Would be good to double-check if headers always come lower-cased from the server. If no, maybe add a transform step there too.
https://github.com/unjs/h3/blob/6beee463d0e95207480acfd21badc2c2fa46f6c3/src/utils/request.ts#L58-L65 does not handle casing. Should I create a PR or an issue there too?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

