### PR TITLE
refactor(nuxt)!: remove support for `404.vue` shorthand

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.ts
+++ b/packages/nuxt/src/pages/runtime/router.ts
@@ -177,8 +177,6 @@ export default defineNuxtPlugin(async (nuxtApp) => {
         fatal: false,
         statusMessage: `Page not found: ${to.fullPath}`
       })])
-    } else if (process.server && to.matched[0].name === '404' && nuxtApp.ssrContext) {
-      nuxtApp.ssrContext.event.res.statusCode = 404
     } else if (process.server) {
       const currentURL = to.fullPath || '/'
       if (!isEqual(currentURL, initialURL)) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -68,7 +68,6 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string): Nux
 
       const tokens = parseSegment(segment)
       const segmentName = tokens.map(({ value }) => value).join('')
-      const isSingleSegment = segments.length === 1
 
       // ex: parent/[slug].vue -> parent-slug
       route.name += (route.name && '-') + segmentName
@@ -79,8 +78,6 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string): Nux
       if (child && child.children) {
         parent = child.children
         route.path = ''
-      } else if (segmentName === '404' && isSingleSegment) {
-        route.path += '/:catchAll(.*)*'
       } else if (segmentName === 'index' && !route.path) {
         route.path += '/'
       } else if (segmentName !== 'index') {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -6,23 +6,11 @@ describe('pages:generateRoutesFromFiles', () => {
   const pagesDir = 'pages'
   const tests = [
     {
-      description: 'should generate correct route for 404',
-      files: [`${pagesDir}/404.vue`],
-      output: [
-        {
-          name: '404',
-          path: '/:catchAll(.*)*',
-          file: `${pagesDir}/404.vue`,
-          children: []
-        }
-      ]
-    },
-    {
       description: 'should generate correct routes for index pages',
       files: [
-          `${pagesDir}/index.vue`,
-          `${pagesDir}/parent/index.vue`,
-          `${pagesDir}/parent/child/index.vue`
+        `${pagesDir}/index.vue`,
+        `${pagesDir}/parent/index.vue`,
+        `${pagesDir}/parent/child/index.vue`
       ],
       output: [
         {
@@ -48,8 +36,8 @@ describe('pages:generateRoutesFromFiles', () => {
     {
       description: 'should generate correct routes for parent/child',
       files: [
-          `${pagesDir}/parent.vue`,
-          `${pagesDir}/parent/child.vue`
+        `${pagesDir}/parent.vue`,
+        `${pagesDir}/parent/child.vue`
       ],
       output: [
         {
@@ -70,8 +58,8 @@ describe('pages:generateRoutesFromFiles', () => {
     {
       description: 'should generate correct id for catchall (order 1)',
       files: [
-          `${pagesDir}/[...stories].vue`,
-          `${pagesDir}/stories/[id].vue`
+        `${pagesDir}/[...stories].vue`,
+        `${pagesDir}/stories/[id].vue`
       ],
       output: [
         {
@@ -112,7 +100,7 @@ describe('pages:generateRoutesFromFiles', () => {
     {
       description: 'should generate correct route for snake_case file',
       files: [
-          `${pagesDir}/snake_case.vue`
+        `${pagesDir}/snake_case.vue`
       ],
       output: [
         {
@@ -138,14 +126,14 @@ describe('pages:generateRoutesFromFiles', () => {
     {
       description: 'should generate correct dynamic routes',
       files: [
-          `${pagesDir}/index.vue`,
-          `${pagesDir}/[slug].vue`,
-          `${pagesDir}/[[foo]]`,
-          `${pagesDir}/[[foo]]/index.vue`,
-          `${pagesDir}/[bar]/index.vue`,
-          `${pagesDir}/nonopt/[slug].vue`,
-          `${pagesDir}/opt/[[slug]].vue`,
-          `${pagesDir}/[[sub]]/route-[slug].vue`
+        `${pagesDir}/index.vue`,
+        `${pagesDir}/[slug].vue`,
+        `${pagesDir}/[[foo]]`,
+        `${pagesDir}/[[foo]]/index.vue`,
+        `${pagesDir}/[bar]/index.vue`,
+        `${pagesDir}/nonopt/[slug].vue`,
+        `${pagesDir}/opt/[[slug]].vue`,
+        `${pagesDir}/[[sub]]/route-[slug].vue`
       ],
       output: [
         {
@@ -225,17 +213,17 @@ describe('pages:generateRoutesFromFiles', () => {
     {
       description: 'should throw empty param error for dynamic route',
       files: [
-          `${pagesDir}/[].vue`
+        `${pagesDir}/[].vue`
       ],
       error: 'Empty param'
     },
     {
       description: 'should only allow "_" & "." as special character for dynamic route',
       files: [
-          `${pagesDir}/[a1_1a].vue`,
-          `${pagesDir}/[b2.2b].vue`,
-          `${pagesDir}/[[c3@3c]].vue`,
-          `${pagesDir}/[[d4-4d]].vue`
+        `${pagesDir}/[a1_1a].vue`,
+        `${pagesDir}/[b2.2b].vue`,
+        `${pagesDir}/[[c3@3c]].vue`,
+        `${pagesDir}/[[d4-4d]].vue`
       ],
       output: [
         {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/6895

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes support for the `404.vue` shorthand (mapping to a catchall with 404 status code). This was confusing when users also had a manual catchall, such as `[...slug].vue` (as the latter would never be hit). And it also separated out the 404 error page from `error.vue` which was used to render every other error page.

### 👉 Migration

1. Rename your `404.vue` page to `[...slug].vue`.
2. Manually set the response status within that page.

```diff
  <script setup>
+   setResponseStatus(404)
  </script>
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
