### PR TITLE
fix(nuxt): swallow issues with query selectors

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -48,10 +48,12 @@ export default <RouterConfig> {
 }
 
 function _getHashElementScrollMarginTop (selector: string): number {
-  const elem = document.querySelector(selector)
-  if (elem) {
-    return parseFloat(getComputedStyle(elem).scrollMarginTop)
-  }
+  try {
+    const elem = document.querySelector(selector)
+    if (elem) {
+      return parseFloat(getComputedStyle(elem).scrollMarginTop)
+    }
+  } catch {}
   return 0
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #8732

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This swalls any issues with invalid query selectors which otherwise would completely crash a page.

Note that `vue-router` will rightly still warn:

```
[Vue Router warn]: The selector "#accesstoken=ey.4" is invalid. If you are using an id selector, make sure to escape it. You can find more information about escaping characters in selectors at https://mathiasbynens.be/notes/css-escapes or use CSS.escape (https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape).
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
