### PR TITLE
feat(nuxi): wrap and normalize all console outputs

### DIFF
--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -1,6 +1,6 @@
 import mri from 'mri'
 import { red } from 'colorette'
-import consola from 'consola'
+import consola, { ConsolaReporter } from 'consola'
 import { checkEngines } from './utils/engines'
 import { commands, Command, NuxtCommand } from './commands'
 import { showHelp } from './utils/help'
@@ -39,7 +39,29 @@ async function _main () {
 }
 
 // Wrap all console logs with consola for better DX
-consola.wrapConsole()
+consola.wrapAll()
+
+// Filter out unwanted logs
+// TODO: Use better API from consola for intercepting logs
+const wrapReporter = (reporter: ConsolaReporter) => <ConsolaReporter> {
+  log (logObj, ctx) {
+    if (!logObj.args || !logObj.args.length) { return }
+    const msg = logObj.args[0]
+    if (typeof msg === 'string' && !process.env.DEBUG) {
+      // Hide vue-router 404 warnings
+      if (msg.startsWith('[Vue Router warn]: No match found for location with path')) {
+        return
+      }
+      // Hide sourcemap warnings related to node_modules
+      if (msg.startsWith('Sourcemap') && msg.includes('node_modules')) {
+        return
+      }
+    }
+    return reporter.log(logObj, ctx)
+  }
+}
+// @ts-expect-error
+consola._reporters = consola._reporters.map(wrapReporter)
 
 process.on('unhandledRejection', err => consola.error('[unhandledRejection]', err))
 process.on('uncaughtException', err => consola.error('[uncaughtException]', err))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR uses `consola.wrapAll` instead of `consola.wrapConsole` in order to intercept all console outputs. Code running in SSR worker, writes to `stdout` and `stderr` instead of (main process) `console` object. 

Now, it is possible to use something like ``console.log('Hello `123`')`` from a Vue SFC to have beautiful output formatted by console:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/5158436/200807090-1f017f83-71e7-452c-99f5-c13ee7ef5bd2.png">

This way we can intercept console output and also improve DX for some known issues:

- Hide 404 SSR warnings thrown by vue-router `[Vue Router warn]: No match found for location with path'`
- Hide vite missing sourcemap warns originating from `node_modules`

It is possible to also use vite's custom logger (probably other custom loggers including one for SSR) but i assume it is easier to manage console logging and filtering from one place. We made console for Nuxt 2 with this purpose.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

