### PR TITLE
fix(nuxi): exclude `dist` from type checking

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -31,7 +31,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
       ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : []
     ],
     exclude: [
-      // nitro generate output
+      // nitro generate output: https://github.com/nuxt/framework/blob/main/packages/nuxt/src/core/nitro.ts#L186
       relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist'))
     ]
   })

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -29,7 +29,11 @@ export const writeTypes = async (nuxt: Nuxt) => {
       join(relative(nuxt.options.buildDir, nuxt.options.rootDir), '**/*'),
       ...nuxt.options.srcDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.srcDir), '**/*')] : [],
       ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : []
-    ]
+    ],
+    exclude: [
+      // nitro generate output
+      resolve(nuxt.options.rootDir, 'dist')
+    ].map(p => relative(nuxt.options.buildDir, p))
   })
 
   const aliases: Record<string, string> = {

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -32,8 +32,8 @@ export const writeTypes = async (nuxt: Nuxt) => {
     ],
     exclude: [
       // nitro generate output
-      resolve(nuxt.options.rootDir, 'dist')
-    ].map(p => relative(nuxt.options.buildDir, p))
+      relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist'))
+    ]
   })
 
   const aliases: Record<string, string> = {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/8847

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`.nuxt/dist`, `.output`, `.netlify`, etc. aren't caught because they start with `.`, but the 'dist' folder does get caught by TS when type-checking a project. Excluding it should improve type-checking performance, and also resolve the linked issue.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
