### PR TITLE
fix(nuxt)!: only add `$f` fetch prefix to auto-keys

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -44,14 +44,13 @@ export function useFetch<
   arg2?: string
 ) {
   const [opts = {}, autoKey] = typeof arg1 === 'string' ? [{}, arg1] : [arg1, arg2]
-  const _key = opts.key || autoKey
-  if (!_key || typeof _key !== 'string') {
-    throw new TypeError('[nuxt] [useFetch] key must be a string: ' + _key)
+  const key = opts.key || (autoKey && typeof autoKey === 'string' ? '$f' + autoKey : undefined)
+  if (!key || typeof key !== 'string') {
+    throw new TypeError('[nuxt] [useFetch] key must be a string: ' + key)
   }
   if (!request) {
     throw new Error('[nuxt] [useFetch] request is missing.')
   }
-  const key = '$f' + _key
 
   const _request = computed(() => {
     let r = request

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -44,13 +44,14 @@ export function useFetch<
   arg2?: string
 ) {
   const [opts = {}, autoKey] = typeof arg1 === 'string' ? [{}, arg1] : [arg1, arg2]
-  const key = opts.key || (autoKey && typeof autoKey === 'string' ? '$f' + autoKey : undefined)
-  if (!key || typeof key !== 'string') {
-    throw new TypeError('[nuxt] [useFetch] key must be a string: ' + key)
+  const _key = opts.key || autoKey
+  if (!_key || typeof _key !== 'string') {
+    throw new TypeError('[nuxt] [useFetch] key must be a string: ' + _key)
   }
   if (!request) {
     throw new Error('[nuxt] [useFetch] request is missing.')
   }
+  const key = _key === autoKey ? '$f' + _key : _key
 
   const _request = computed(() => {
     let r = request

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -778,7 +778,7 @@ describe.skipIf(process.env.NUXT_TEST_DEV || isWindows)('payload rendering', () 
   it('renders a payload', async () => {
     const payload = await $fetch('/random/a/_payload.js', { responseType: 'text' })
     expect(payload).toMatch(
-      /export default \{data:\{\$frand_a:\[[^\]]*\]\},prerenderedAt:\d*\}/
+      /export default \{data:\{rand_a:\[[^\]]*\]\},prerenderedAt:\d*\}/
     )
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/8650

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's tricky to use `refreshNuxtData` to refresh a `useFetch` with an explicit key as there is currently an undocumented `$f` prefix added. I think we can choose only to add this prefix with an auto-key, meaning that users can manually invalidate the key more easily.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
