### PR TITLE
fix(test-utils): detect project root using `nuxt.config` with `.mjs` and `.cjs` extensions

### DIFF
--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -11,6 +11,7 @@ const isNuxtApp = (dir: string) => {
     existsSync(resolve(dir, 'pages')) ||
     existsSync(resolve(dir, 'nuxt.config.js')) ||
     existsSync(resolve(dir, 'nuxt.config.mjs')) ||
+    existsSync(resolve(dir, 'nuxt.config.cjs')) ||
     existsSync(resolve(dir, 'nuxt.config.ts'))
   )
 }

--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -10,6 +10,7 @@ const isNuxtApp = (dir: string) => {
   return existsSync(dir) && (
     existsSync(resolve(dir, 'pages')) ||
     existsSync(resolve(dir, 'nuxt.config.js')) ||
+    existsSync(resolve(dir, 'nuxt.config.mjs')) ||
     existsSync(resolve(dir, 'nuxt.config.ts'))
   )
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
N/A

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using `test-utils` with a project that has `.mjs` config file and no `pages` folder (ex: doc-driven), user'd have to explicitly set `options.rootDir` to make vitest works, otherwise it'll throw error.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

