### PR TITLE
fix(nuxt): preserve render errors

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -176,13 +176,11 @@ export default defineRenderHandler(async (event) => {
       // Use explicitly thrown error in preference to subsequent rendering errors
       throw ssrContext.payload?.error || err
     }
+    throw err
   })
   await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext })
 
   // Handle errors
-  if (!_rendered) {
-    return undefined!
-  }
   if (ssrContext.payload?.error && !ssrError) {
     throw ssrContext.payload.error
   }

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -171,12 +171,9 @@ export default defineRenderHandler(async (event) => {
     writeEarlyHints(event, link)
   }
 
-  const _rendered = await renderer.renderToString(ssrContext).catch((err) => {
-    if (!ssrError) {
-      // Use explicitly thrown error in preference to subsequent rendering errors
-      throw ssrContext.payload?.error || err
-    }
-    throw err
+  const _rendered = await renderer.renderToString(ssrContext).catch((error) => {
+    // Use explicitly thrown error in preference to subsequent rendering errors
+    throw (!ssrError && ssrContext.payload?.error) || error
   })
   await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #8706

Nitro Renderer is expected always to return a response or throw an error. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

