### PR TITLE
docs: add a bit more detail in the `definePageMeta` warning to specify it needs to be in a page

### DIFF
--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -38,7 +38,7 @@ export interface PageMeta {
 }
 
 declare module 'vue-router' {
-  interface RouteMeta extends UnwrapRef<PageMeta> { }
+  interface RouteMeta extends UnwrapRef<PageMeta> {}
 }
 
 const warnRuntimeUsage = (method: string) =>

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -38,14 +38,14 @@ export interface PageMeta {
 }
 
 declare module 'vue-router' {
-  interface RouteMeta extends UnwrapRef<PageMeta> {}
+  interface RouteMeta extends UnwrapRef<PageMeta> { }
 }
 
 const warnRuntimeUsage = (method: string) =>
   console.warn(
     `${method}() is a compiler-hint helper that is only usable inside ` +
-      'the script block of a single file component. Its arguments should be ' +
-      'compiled away and passing it at runtime has no effect.'
+    'the script block of a single file component which is also a page. Its arguments should be ' +
+    'compiled away and passing it at runtime has no effect.'
   )
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
This addresses #3175 - a bit more detail on having to be in a page