### PR TITLE
fix(kit): add manually installed module to transpile

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -17,6 +17,10 @@ export async function installModule (moduleToInstall: string | NuxtModule, _inli
     nuxt
   )
 
+  if (typeof moduleToInstall === 'string') {
+    nuxt.options.build.transpile.push(moduleToInstall)
+  }
+
   nuxt.options._installedModules = nuxt.options._installedModules || []
   nuxt.options._installedModules.push({
     meta: await nuxtModule.getMeta?.(),


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/content/issues/1665

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If we add external module in `nuxt.config.ts`, that auto add to build transpile. so `installModule ` need add external module name to build transpile.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

