### PR TITLE
docs: typo in `available`

### DIFF
--- a/docs/content/3.api/1.composables/use-nuxt-app.md
+++ b/docs/content/3.api/1.composables/use-nuxt-app.md
@@ -36,7 +36,7 @@ Hooks available in `nuxtApp` allows you to customize the runtime aspects of your
 
 `hook` function is useful for adding custom logic by hooking into the rendering lifecycle at a specific point. `hook` function is mostly used when creating Nuxt plugins.
 
-See [Runtime Hooks](/api/advanced/hooks#app-hooks-runtime) for avialble runtime hooks called by Nuxt.
+See [Runtime Hooks](/api/advanced/hooks#app-hooks-runtime) for availble runtime hooks called by Nuxt.
 
 ```js [plugins/test.ts]
 export default defineNuxtPlugin((nuxtApp) => {

--- a/docs/content/3.api/1.composables/use-nuxt-app.md
+++ b/docs/content/3.api/1.composables/use-nuxt-app.md
@@ -36,7 +36,7 @@ Hooks available in `nuxtApp` allows you to customize the runtime aspects of your
 
 `hook` function is useful for adding custom logic by hooking into the rendering lifecycle at a specific point. `hook` function is mostly used when creating Nuxt plugins.
 
-See [Runtime Hooks](/api/advanced/hooks#app-hooks-runtime) for availble runtime hooks called by Nuxt.
+See [Runtime Hooks](/api/advanced/hooks#app-hooks-runtime) for available runtime hooks called by Nuxt.
 
 ```js [plugins/test.ts]
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
Noticed a typo in line:39 under the under the hook section

Changed `avialble` to `available`

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

