### PR TITLE
fix(vite): add extend layers to `fs.allow`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -85,7 +85,8 @@ export async function bundle (nuxt: Nuxt) {
           watch: { ignored: isIgnored },
           fs: {
             allow: [
-              nuxt.options.appDir
+              nuxt.options.appDir,
+              ...nuxt.options._layers.map(l => l.config.rootDir)
             ]
           }
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Reported by @Atinux 

![image](https://user-images.githubusercontent.com/5158436/201897770-d259b711-547c-42ad-b754-6ac871b769aa.png)

This allows extending from local dirs without explicitly adding to `vite.fs.allowlist` in `nuxt.config`

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

