### PR TITLE
fix(nuxt): include layers in esbuild transform

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -4,6 +4,7 @@ import { createNitro, createDevServer, build, prepare, copyPublicAssets, writeTy
 import type { NitroConfig } from 'nitropack'
 import type { Nuxt } from '@nuxt/schema'
 import { resolvePath } from '@nuxt/kit'
+import escapeRE from 'escape-string-regexp'
 import defu from 'defu'
 import fsExtra from 'fs-extra'
 import { dynamicEventHandler } from 'h3'
@@ -21,6 +22,13 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     srcDir: nuxt.options.serverDir,
     dev: nuxt.options.dev,
     buildDir: nuxt.options.buildDir,
+    esbuild: {
+      options: {
+        exclude: [
+          new RegExp(`node_modules\\/(?!${nuxt.options._layers.map(l => l.cwd.match(/(?<=\/)node_modules\/(.+)$/)?.[1]).filter(Boolean).map(dir => escapeRE(dir!)).join('|')})`)
+        ]
+      }
+    },
     analyze: nuxt.options.build.analyze && {
       template: 'treemap',
       projectRoot: nuxt.options.rootDir,


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If we are using typescript files within a layer, esbuild doesn't process this and the nitro build will fail. This PR exempts layers from the node_modules exclude, but otherwise preserves it.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
