### PR TITLE
docs: add warning about `definePageMeta` issues with transitions and `NuxtLoadingIndicator`

### DIFF
--- a/docs/content/1.docs/1.getting-started/5.transitions.md
+++ b/docs/content/1.docs/1.getting-started/5.transitions.md
@@ -20,7 +20,7 @@ export default defineNuxtConfig({
 ```
 
 ::alert{type=warning}
-If you are using `definePageMeta` to handle dynamic layouts, the page transitions on this page will not work.
+If you are changing layouts as well as page, the page transition you set here will not run. Instead, you should set a layout transition.
 ::
 
 To start adding transition between your pages, add the following CSS to your [`app.vue`](/docs/guide/directory-structure/app):

--- a/docs/content/1.docs/1.getting-started/5.transitions.md
+++ b/docs/content/1.docs/1.getting-started/5.transitions.md
@@ -19,6 +19,10 @@ export default defineNuxtConfig({
 })
 ```
 
+::alert{type=warning}
+If you are using `definePageMeta` to handle dynamic layouts, the page transitions on this page will not work.
+::
+
 To start adding transition between your pages, add the following CSS to your [`app.vue`](/docs/guide/directory-structure/app):
 
 ::code-group

--- a/docs/content/1.docs/3.api/2.components/5.nuxt-loading-indicator.md
+++ b/docs/content/1.docs/3.api/2.components/5.nuxt-loading-indicator.md
@@ -20,7 +20,7 @@ Add `<NuxtLoadingIndicator/>` in your `app.vue` or layouts.
 :button-link[Open on StackBlitz]{href="https://stackblitz.com/github/nuxt/framework/tree/main/examples/routing/pages?terminal=dev&file=/app.vue" blank}
 
 ::alert{type=warning}
-If you are using `definePageMeta` to handle dynamic layouts, the `NuxtLoadingIndicator` will not work.
+If you are changing layouts as well as page, the page transition you set here will not run. Instead, you should set a layout transition.
 ::
 
 ## Slots

--- a/docs/content/1.docs/3.api/2.components/5.nuxt-loading-indicator.md
+++ b/docs/content/1.docs/3.api/2.components/5.nuxt-loading-indicator.md
@@ -19,6 +19,10 @@ Add `<NuxtLoadingIndicator/>` in your `app.vue` or layouts.
 
 :button-link[Open on StackBlitz]{href="https://stackblitz.com/github/nuxt/framework/tree/main/examples/routing/pages?terminal=dev&file=/app.vue" blank}
 
+::alert{type=warning}
+If you are using `definePageMeta` to handle dynamic layouts, the `NuxtLoadingIndicator` will not work.
+::
+
 ## Slots
 
 You can pass custom HTML or components through the loading indicator's default slot.


### PR DESCRIPTION
### 🔗 Linked issue

#8493 #8753 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As I discussed with @danielroe on Discord. I added a warning for the bugs on page transitions & nuxt loading indicator.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

