### PR TITLE
feat: support redirect function for routes in `pages:extend`

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -242,7 +242,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
         meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
         alias: aliasCode,
-        redirect: route.redirect ? JSON.stringify(route.redirect) : `${metaImportName}?.redirect || undefined`,
+        redirect: route.redirect ? (typeof route.redirect === 'function' ? route.redirect : JSON.stringify(route.redirect)) : `${metaImportName}?.redirect || undefined`,
         component: genDynamicImport(file, { interopDefault: true })
       }
     }))

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -9,6 +9,7 @@ import type { Compiler, Configuration, Stats } from 'webpack'
 import type { Nuxt, NuxtApp, ResolvedNuxtTemplate } from './nuxt'
 import type { Nitro, NitroConfig } from 'nitropack'
 import type { Component, ComponentsOptions } from './components'
+import type { RouteRecordRedirectOption } from "vue-router"
 import { NuxtCompatibility, NuxtCompatibilityIssues } from '..'
 
 export type HookResult = Promise<void> | void
@@ -24,7 +25,7 @@ export type NuxtPage = {
   file: string
   meta?: Record<string, any>
   alias?: string[] | string
-  redirect?: string
+  redirect?: RouteRecordRedirectOption
   children?: NuxtPage[]
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

#8962 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi ✋ 
As mentioned in the linked issue, the `NuxtPage` type doesn't support the redirect option as a function.
This PR will fix that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

