### PR TITLE
feat(nuxt): add `await nextTick()` to all .client components onMounted hook

### DIFF
--- a/packages/nuxt/src/components/client.ts
+++ b/packages/nuxt/src/components/client.ts
@@ -1,0 +1,88 @@
+import { pathToFileURL } from 'node:url'
+import MagicString from 'magic-string'
+import { walk } from 'estree-walker'
+import { createUnplugin } from 'unplugin'
+import { parseURL } from 'ufo'
+import type { ArrowFunctionExpression, CallExpression, ExpressionStatement, Identifier, Property, FunctionDeclaration, BlockStatement } from 'estree'
+import { genImport } from 'knitwork'
+
+type AcornNode<N> = N & {start: number, end: number}
+
+interface ClientNextTickPluginnOptions {
+    sourcemap?: boolean
+  }
+
+/**
+ * this plugin adds an `await nextTick();` to all onMounted hook callbacks for a .client component
+ *
+ * This is needed due to the nature of `createClientOnly()` that modifies a component to be rendered once mounted
+ * which means that the `onMounted` hook is already ran when rendering the template for the first time
+ *
+ * @see https://github.com/nuxt/framework/issues/9185
+ */
+export const clientNextTickPlugin = createUnplugin((options: ClientNextTickPluginnOptions) => {
+  return {
+    name: 'nuxt:client-nextTick',
+    enforce: 'post',
+    transformInclude (id) {
+      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      return pathname.endsWith('.client.vue') || pathname.endsWith('.client.ts') || pathname.endsWith('.client.js')
+    },
+    transform (code, id) {
+      // webpack twice transformed workaround
+      if (code.includes(genImport('vue', [{ name: 'nextTick', as: '__nextTick' }]))) { return }
+
+      const s = new MagicString(code)
+      const imports = new Set<string>()
+
+      walk(this.parse(code, {
+        sourceType: 'module',
+        ecmaVersion: 'latest'
+      }), {
+        enter (_node) {
+          const node = _node as Property
+          // find setup() as a property
+          if (node.type === 'Property' &&
+                (node.key as Identifier).name === 'setup' &&
+                (node.value.type === 'FunctionExpression' || node.value.type === 'ArrowFunctionExpression')
+          ) {
+            const setupBody = node.value.body as BlockStatement
+            const onMountedExpression = setupBody.body.find((node) => {
+              return node.type === 'ExpressionStatement' &&
+                 node.expression.type === 'CallExpression' &&
+                 (node.expression.callee as Identifier).name === 'onMounted'
+            }) as ExpressionStatement
+
+            if (onMountedExpression) {
+              const [onMountedCallbackExpression] = (onMountedExpression.expression as CallExpression).arguments
+
+              if (onMountedCallbackExpression.type === 'ArrowFunctionExpression' || onMountedCallbackExpression.type === 'FunctionExpression') {
+                const isAsync = onMountedCallbackExpression.async
+                imports.add(genImport('vue', [{ name: 'nextTick', as: '__nextTick' }]))
+                s.appendRight((onMountedCallbackExpression.body as AcornNode<ArrowFunctionExpression|FunctionDeclaration>).start + 1, 'await __nextTick();')
+
+                // convert onMounted callback to async
+                if (!isAsync) {
+                  s.appendLeft((onMountedCallbackExpression as AcornNode<ArrowFunctionExpression|FunctionDeclaration>).start, 'async ')
+                }
+              }
+            }
+          }
+        }
+      })
+
+      if (imports.size) {
+        s.prepend([...imports, ''].join('\n'))
+      }
+
+      if (s.hasChanged()) {
+        return {
+          code: s.toString(),
+          map: options.sourcemap
+            ? s.generateMap({ source: id, includeContent: true })
+            : undefined
+        }
+      }
+    }
+  }
+})

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -7,6 +7,7 @@ import { componentsPluginTemplate, componentsTemplate, componentsTypeTemplate } 
 import { scanComponents } from './scan'
 import { loaderPlugin } from './loader'
 import { TreeShakeTemplatePlugin } from './tree-shake'
+import { clientNextTickPlugin } from './client'
 
 const isPureObjectOrString = (val: any) => (!Array.isArray(val) && typeof val === 'object') || typeof val === 'string'
 const isDirectory = (p: string) => { try { return statSync(p).isDirectory() } catch (_e) { return false } }
@@ -190,6 +191,9 @@ export default defineNuxtModule<ComponentsOptions>({
         sourcemap: nuxt.options.sourcemap[mode],
         getComponents,
         mode
+      }),
+      clientNextTickPlugin.vite({
+        sourcemap: nuxt.options.sourcemap[mode]
       }))
       if (nuxt.options.experimental.treeshakeClientOnly && isServer) {
         config.plugins.push(TreeShakeTemplatePlugin.vite({
@@ -206,6 +210,9 @@ export default defineNuxtModule<ComponentsOptions>({
           sourcemap: nuxt.options.sourcemap[mode],
           getComponents,
           mode
+        }),
+        clientNextTickPlugin.webpack({
+          sourcemap: nuxt.options.sourcemap[mode]
         }))
         if (nuxt.options.experimental.treeshakeClientOnly && mode === 'server') {
           config.plugins.push(TreeShakeTemplatePlugin.webpack({

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -221,6 +221,9 @@ describe('pages', () => {
     expect(await page.locator('.string-stateful-script').innerHTML()).toContain('1')
     expect(await page.locator('.string-stateful').innerHTML()).toContain('1')
 
+    // ensure .client component onMounted hook is executed after the first tick
+    expect(await page.locator('[data-test-id=mount-hook-ref-1]').innerHTML()).toContain('HTMLInputElement')
+
     // ensure directives are reactive
     await page.locator('button#show-all').click()
     await Promise.all(hiddenSelectors.map(selector => page.locator(selector).isVisible()))

--- a/test/fixtures/basic/components/client/MountHookRef.client.vue
+++ b/test/fixtures/basic/components/client/MountHookRef.client.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+// this component test the onMounted hook being executed after the component is being rendered
+const input = ref<HTMLInputElement | null>(null)
+const refValue = ref<string>('unknown')
+
+onMounted(() => {
+  refValue.value = input.value ? 'HTMLInputElement' : 'null'
+})
+</script>
+
+<template>
+  <div>
+    <input ref="input" v-model="refValue" type="text">
+    <pre>FocusInputBroken ref: <span data-test-id="mount-hook-ref-1">{{ refValue }}</span></pre>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/client-only-components.vue
+++ b/test/fixtures/basic/pages/client-only-components.vue
@@ -37,6 +37,7 @@
       class="string-stateful-script-should-be-hidden"
     />
     <ClientNoState v-show="show" class="no-state-hidden" />
+    <ClientMountHookRef />
 
     <button class="test-ref-1" @click="stringStatefulComp.add">
       increment count


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/framework/issues/9185
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: ! 

This PR transforms all `onMounted` hooks in `.client` components to add an `await nextTick()`.

This is due to the result of `createClientOnly` that renders the component only after being mounted. 

If an user try to access the DOM or a ref in `onMounted`, this would fail since the component is only rendering the `.server` part or a simple `<div>` at the time the component is being rendered.

Note that it only transforms `onMounted` hooks `.client` files, this issue still can be reproduced if `onMounted` is called from a composable within a `.client` component.

@fkammer also mentionned adding `await nextTick()` in the docs for `.client` components.

 Let me know what you think about it.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

