### PR TITLE
refactor(nuxt): fix typo in internal rollup plugin names

### DIFF
--- a/packages/nuxt/src/core/plugins/dev-only.ts
+++ b/packages/nuxt/src/core/plugins/dev-only.ts
@@ -12,7 +12,7 @@ export const DevOnlyPlugin = createUnplugin((options: DevOnlyPluginOptions) => {
   const DEVONLY_COMP_RE = /<dev-?only>(:?[\s\S]*)<\/dev-?only>/gmi
 
   return {
-    name: 'nuxt:server-devonly:transfrom',
+    name: 'nuxt:server-devonly:transform',
     enforce: 'pre',
     transformInclude (id) {
       const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))

--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -13,7 +13,7 @@ export const TreeShakePlugin = createUnplugin((options: TreeShakePluginOptions) 
   const COMPOSABLE_RE = new RegExp(`($\\s+)(${options.treeShake.join('|')})(?=\\()`, 'gm')
 
   return {
-    name: 'nuxt:server-treeshake:transfrom',
+    name: 'nuxt:server-treeshake:transform',
     enforce: 'post',
     transformInclude (id) {
       const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -12,7 +12,7 @@ export const UnctxTransformPlugin = (nuxt: Nuxt) => {
   nuxt.hook('app:resolve', (_app) => { app = _app })
 
   return createUnplugin((options: { sourcemap?: boolean } = {}) => ({
-    name: 'unctx:transfrom',
+    name: 'unctx:transform',
     enforce: 'post',
     transformInclude (id) {
       id = normalize(id).replace(/\?.*$/, '')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolves #9200

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I've fixed typo in 3 files where the `transfrom` was written instead of `transform`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.

