### PR TITLE
docs: add warning about `.client` onMounted hook

### DIFF
--- a/docs/content/1.docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/content/1.docs/2.guide/2.directory-structure/1.components.md
@@ -205,7 +205,7 @@ This feature only works with Nuxt auto-imports and `#components` imports. Explic
 ::
 
 ::alert{type=warning}
-`.client` components are rendered only after being mounted. To access to the rendered template using `onMounted()`, add `await nextTick()` from `vue` in the callback of the `onMounted()` hook. 
+`.client` components are rendered only after being mounted. To access to the rendered template using `onMounted()`, add `await nextTick()` from `vue` in the callback of the `onMounted()` hook.
 ::
 
 ## .server Components

--- a/docs/content/1.docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/content/1.docs/2.guide/2.directory-structure/1.components.md
@@ -204,6 +204,10 @@ If a component is meant to be rendered only client-side, you can add the `.clien
 This feature only works with Nuxt auto-imports and `#components` imports. Explicitly importing these components from their real paths does not convert them into client-only components.
 ::
 
+::alert{type=warning}
+`.client` components are rendered only after being mounted. To access to the rendered template using `onMounted()`, add `await nextTick()` from `vue` in the callback of the `onMounted()` hook. 
+::
+
 ## .server Components
 
 `.server` components are fallback components of `.client` components.

--- a/docs/content/1.docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/content/1.docs/2.guide/2.directory-structure/1.components.md
@@ -205,7 +205,7 @@ This feature only works with Nuxt auto-imports and `#components` imports. Explic
 ::
 
 ::alert{type=warning}
-`.client` components are rendered only after being mounted. To access to the rendered template using `onMounted()`, add `await nextTick()` from `vue` in the callback of the `onMounted()` hook.
+`.client` components are rendered only after being mounted. To access the rendered template using `onMounted()`, add `await nextTick()` in the callback of the `onMounted()` hook.
 ::
 
 ## .server Components


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolves https://github.com/nuxt/framework/issues/9185
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
hi :wave: This PR warns about the `onMounted` hooks on .client components.

Since the `createClientOnly` only render the component after being mounted, we don't have any access to the rendered template defined on the .vue file before the nextTick
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

