### PR TITLE
docs: add missing space

### DIFF
--- a/docs/content/1.docs/1.getting-started/6.data-fetching.md
+++ b/docs/content/1.docs/1.getting-started/6.data-fetching.md
@@ -240,7 +240,7 @@ const { data } = await useFetch('/api/me', { headers })
 ```
 
 ::alert{type="warning"}
-Be very careful before proxying headers to an external API and just include headers that you need.
+Be very careful before proxying headers to an external API and just include headers that you need. 
 
 Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:
 

--- a/docs/content/1.docs/1.getting-started/6.data-fetching.md
+++ b/docs/content/1.docs/1.getting-started/6.data-fetching.md
@@ -240,9 +240,7 @@ const { data } = await useFetch('/api/me', { headers })
 ```
 
 ::alert{type="warning"}
-Be very careful before proxying headers to an external API and just include headers that you need. 
-
-Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:
+Be very careful before proxying headers to an external API and just include headers that you need. Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:
 
 * `host`, `accept`
 * `content-length`, `content-md5`, `content-type`


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #9275

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There was a missing space between two sentences in the doc, added it to make the documentation more consistent & clean. Minor mistakes can be bad for first impressions to new users, hence why I fixed it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

