### PR TITLE
docs: use `layout` in example of `definePageMeta`

### DIFF
--- a/docs/content/1.docs/3.api/3.utils/define-page-meta.md
+++ b/docs/content/1.docs/3.api/3.utils/define-page-meta.md
@@ -9,7 +9,7 @@ title: "definePageMeta"
 ```vue [pages/some-page.vue]
 <script setup>
   definePageMeta({
-    title: 'Articles'
+    layout: 'default'
   })
 </script>
 ```


### PR DESCRIPTION
The main example showed the usage of the `title` parameter which is not part of the `definePageMeta` interface. The example should reflect real values since in the current example it easy to confuse it with `useHead` which must actually be used to set the page title using the `title` parameter.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

