### PR TITLE
docs: use placeholder name in the installation step

### DIFF
--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -50,19 +50,19 @@ Open a terminal (if you're using [Visual Studio Code](https://code.visualstudio.
 ::code-group
 
 ```bash [npx]
-npx nuxi init nuxt-app
+npx nuxi init <project-name>
 ```
 
 ```bash [pnpm]
-pnpm dlx nuxi init nuxt-app
+pnpm dlx nuxi init <project-name>
 ```
 
 ::
 
-Open `nuxt-app` folder in Visual Studio Code:
+Open your project folder in Visual Studio Code:
 
 ```bash
-code nuxt-app
+code <project-name>
 ```
 
 Install the dependencies:


### PR DESCRIPTION
With this it should be more obvious for the user that instead of `nuxt-app` the actual project name is meant. 
This was the case and example also in the nuxt 2 docs: https://nuxtjs.org/docs/get-started/installation/

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

