### PR TITLE
docs: Added an in-depth asterisk to solve a common problem with Node 

### DIFF
--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -21,13 +21,14 @@ Start with one of our starters and themes directly by opening [nuxt.new](https:/
 
 Before getting started, please make sure you have installed the recommended setup.
 
-* **Node.js**<sup>*</sup> (latest LTS version) 👉 [[Download](https://nodejs.org/en/download/)]
+* **Node.js**<sup>*</sup> (latest LTS version<sup>**</sup>) 👉 [[Download](https://nodejs.org/en/download/)]
 * **Visual Studio Code** 👉 [[Download](https://code.visualstudio.com/)]
 * **Volar Extension** 👉 [[Download](https://marketplace.visualstudio.com/items?itemName=Vue.volar)]
   * Either enable [**Take Over Mode**](https://vuejs.org/guide/typescript/overview.html#volar-takeover-mode) (recommended)
   * ... or add **TypeScript Vue Plugin (Volar)** 👉 [[Download](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin)]
 
 <sup>*</sup> If you already have Node.js installed, check with `node --version` above 16.11.
+<sup>**</sup> If you break into `0308010C:digital envelope routines::unsupported` don't be alarmed, it is a very [common Node 17+ error](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported), to solve it try using the latest stable version of Node 16
 
 ::alert{type=info}
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolve #9115 #8617 #6623

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It is a common error (`0308010C:digital envelope routines::unsupported`) when you launch some terminal script, you can solve it by passing `--openssl-legacy-provider` parameter after script or more simply by using v. 16 LTS of Node.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

