### PR TITLE
fix(test-utils): do not hide Vitest output

### DIFF
--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -59,8 +59,6 @@ export async function loadFixture () {
     configFile: ctx.options.configFile
   })
 
-  kit.logger.level = ctx.options.logLevel
-
   await fsp.mkdir(ctx.nuxt.options.buildDir, { recursive: true })
 }
 

--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -64,5 +64,9 @@ export async function loadFixture () {
 
 export async function buildFixture () {
   const ctx = useTestContext()
+  // hint build info for test
+  const prevLevel = kit.logger.level
+  kit.logger.level = ctx.options.logLevel
   await kit.buildNuxt(ctx.nuxt!)
+  kit.logger.level = prevLevel
 }

--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -64,7 +64,7 @@ export async function loadFixture () {
 
 export async function buildFixture () {
   const ctx = useTestContext()
-  // hint build info for test
+  // Hide build info for test
   const prevLevel = kit.logger.level
   kit.logger.level = ctx.options.logLevel
   await kit.buildNuxt(ctx.nuxt!)

--- a/packages/test-utils/src/runtime/global-setup.ts
+++ b/packages/test-utils/src/runtime/global-setup.ts
@@ -1,6 +1,7 @@
 import { createTest, exposeContextToEnv } from '@nuxt/test-utils'
 
-const hooks = createTest(JSON.parse(process.env.NUXT_TEST_OPTIONS || '{}'))
+const options = JSON.parse(process.env.NUXT_TEST_OPTIONS || '{}')
+const hooks = createTest(options)
 
 export const setup = async () => {
   await hooks.setup()

--- a/packages/test-utils/src/runtime/global-setup.ts
+++ b/packages/test-utils/src/runtime/global-setup.ts
@@ -1,11 +1,17 @@
+import * as _kit from '@nuxt/kit'
 import { createTest, exposeContextToEnv } from '@nuxt/test-utils'
+
+// @ts-ignore type cast
+const kit: typeof _kit = _kit.default || _kit
 
 const options = JSON.parse(process.env.NUXT_TEST_OPTIONS || '{}')
 const hooks = createTest(options)
 
 export const setup = async () => {
+  kit.logger.info('Building Nuxt app...')
   await hooks.setup()
   exposeContextToEnv()
+  kit.logger.info('Running tests...')
 }
 
 export const teardown = async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

close #9434

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`kit.logger.level` was overriding globally to hide all output including Vitest

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

