### PR TITLE
fix(nuxt): update head entry when speculation rules are updated

### DIFF
--- a/packages/nuxt/src/app/plugins/cross-origin-prefetch.client.ts
+++ b/packages/nuxt/src/app/plugins/cross-origin-prefetch.client.ts
@@ -4,26 +4,31 @@ import { defineNuxtPlugin, useHead } from '#app'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const externalURLs = ref(new Set<string>())
-  useHead({
-    script: [
-      () => ({
-        type: 'speculationrules',
-        innerHTML: JSON.stringify({
-          prefetch: [
-            {
-              source: 'list',
-              urls: [...externalURLs.value],
-              requires: ['anonymous-client-ip-when-cross-origin']
-            }
-          ]
-        })
+  function generateRules () {
+    return {
+      type: 'speculationrules',
+      key: 'speculationrules',
+      innerHTML: JSON.stringify({
+        prefetch: [
+          {
+            source: 'list',
+            urls: [...externalURLs.value],
+            requires: ['anonymous-client-ip-when-cross-origin']
+          }
+        ]
       })
-    ]
+    }
+  }
+  const head = useHead({
+    script: [generateRules()]
   })
   nuxtApp.hook('link:prefetch', (url) => {
     const { protocol } = parseURL(url)
     if (protocol && ['http:', 'https:'].includes(protocol)) {
       externalURLs.value.add(url)
+      head?.patch({
+        script: [generateRules()]
+      })
     }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously new crossorigin prefetches were not being injected into the head as it was not reactive outside a vue component. This PR fixes that by manually calling `patch` when necessary.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
