### PR TITLE
fix(nuxt): defer render-blocking prefetches until after load

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -213,7 +213,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
               })
             }
             if (nuxtApp.isHydrating) {
-              nuxtApp.hook('app:suspense:resolve', registerCallback)
+              nuxtApp.hooks.hookOnce('app:suspense:resolve', registerCallback)
             } else {
               registerCallback()
             }

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -193,23 +193,30 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         const shouldPrefetch = props.prefetch !== false && props.noPrefetch !== true && typeof to.value === 'string' && props.target !== '_blank' && !isSlowConnection()
         if (shouldPrefetch) {
           const nuxtApp = useNuxtApp()
-          const observer = useObserver()
           let idleId: number
           let unobserve: Function | null = null
           onMounted(() => {
-            idleId = requestIdleCallback(() => {
-              if (el?.value?.tagName) {
-                unobserve = observer!.observe(el.value, async () => {
-                  unobserve?.()
-                  unobserve = null
-                  await Promise.all([
-                    nuxtApp.hooks.callHook('link:prefetch', to.value as string).catch(() => {}),
-                    !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
-                  ])
-                  prefetched.value = true
-                })
-              }
-            })
+            const observer = useObserver()
+            function registerCallback () {
+              idleId = requestIdleCallback(() => {
+                if (el?.value?.tagName) {
+                  unobserve = observer!.observe(el.value, async () => {
+                    unobserve?.()
+                    unobserve = null
+                    await Promise.all([
+                      nuxtApp.hooks.callHook('link:prefetch', to.value as string).catch(() => {}),
+                      !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
+                    ])
+                    prefetched.value = true
+                  })
+                }
+              })
+            }
+            if (nuxtApp.isHydrating) {
+              nuxtApp.hook('app:suspense:resolve', registerCallback)
+            } else {
+              registerCallback()
+            }
           })
           onBeforeUnmount(() => {
             if (idleId) { cancelIdleCallback(idleId) }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -142,6 +142,8 @@ export function createNuxtApp (options: CreateOptions) {
 
         if (hydratingCount === 0) {
           nuxtApp.isHydrating = false
+          // @ts-expect-error private flag
+          globalThis.__hydrated = true
           return nuxtApp.callHook('app:suspense:resolve')
         }
       }

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -69,7 +69,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       viteJsxPlugin(),
       devStyleSSRPlugin({
         srcDir: ctx.nuxt.options.srcDir,
-        buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, buildAssetsDir)
+        buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, ctx.nuxt.options.app.buildAssetsDir)
       }),
       viteNodePlugin(ctx)
     ],
@@ -88,8 +88,8 @@ export async function buildClient (ctx: ViteBuildContext) {
   // We want to respect users' own rollup output options
   clientConfig.build!.rollupOptions = defu(clientConfig.build!.rollupOptions!, {
     output: {
-      chunkFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(buildAssetsDir, '[name].[hash].js')),
-      entryFileNames: ctx.nuxt.options.dev ? 'entry.js' : withoutLeadingSlash(join(buildAssetsDir, '[name].[hash].js'))
+      chunkFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js')),
+      entryFileNames: ctx.nuxt.options.dev ? 'entry.js' : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js'))
     } as OutputOptions
   }) as any
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Two related performance bugs:

1. When loading a page with links, these pages are prefetched immediately, which will delay the DOM Content Loaded event. This PR defers initialising observer until component is mounted, and additionally waits until the entire app is hydrated.

2. If we are rendering a page with inlined styles, vite will immediately inject a preload for the very same CSS chunk that is inlined; we can use control of the chunk preloader to skip loading those chunks.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
