### PR TITLE
docs: make `vite` monospace too

### DIFF
--- a/docs/content/1.docs/1.getting-started/3.configuration.md
+++ b/docs/content/1.docs/1.getting-started/3.configuration.md
@@ -122,7 +122,7 @@ Name                                          | Config File               |  How
 |---------------------------------------------|---------------------------|-------------------------
 | [Nitro](https://nitro.unjs.io/)             | ~~`nitro.config.ts`~~     | Use [`nitro`](/docs/api/configuration/nuxt-config#nitro) key in `nuxt.config`
 | [PostCSS](https://postcss.org)              | ~~`postcss.config.js`~~   | Use [`postcss`](/docs/api/configuration/nuxt-config#postcss) key in `nuxt.config`
-| [Vite](https://vitejs.dev)                  | ~~`vite.config.ts`~~      | Use [vite](/docs/api/configuration/nuxt-config#vite) key in `nuxt.config`
+| [Vite](https://vitejs.dev)                  | ~~`vite.config.ts`~~      | Use [`vite`](/docs/api/configuration/nuxt-config#vite) key in `nuxt.config`
 | [webpack](https://webpack.js.org/)          | ~~`webpack.config.ts`~~   | Use [`webpack`](/docs/api/configuration/nuxt-config#webpack-1) key in `nuxt.config`
 
 Here is a list of other common config files:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

Vite was the only option that wasn't in monospace, but instead a normal link.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] ~~I have updated the documentation accordingly.~~

