### PR TITLE
feat(nuxt): support for extending error.vue in layers

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'node:fs'
-import { dirname, resolve } from 'pathe'
+import { dirname, resolve, join } from 'pathe'
 import defu from 'defu'
 import type { Nuxt, NuxtApp, NuxtPlugin, NuxtTemplate, ResolvedNuxtTemplate } from '@nuxt/schema'
 import { findPath, resolveFiles, normalizePlugin, normalizeTemplate, compileTemplate, templateUtils, tryResolveModule, resolvePath, resolveAlias } from '@nuxt/kit'
@@ -75,11 +75,8 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // Resolve error component
   if (!app.errorComponent) {
     app.errorComponent = await findPath(
-      [
-        ...nuxt.options._layers.map(layer => `${layer.config.srcDir}/error`),
-        resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
-      ]
-    )
+      nuxt.options._layers.map(layer => join(layer.config.srcDir, 'error')),
+    ) ?? resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
   }
 
   // Resolve layouts/ from all config layers

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -75,7 +75,10 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // Resolve error component
   if (!app.errorComponent) {
     app.errorComponent = await findPath(
-      nuxt.options._layers.map(layer => `${layer.config.srcDir}/error`)
+      [
+        ...nuxt.options._layers.map(layer => `${layer.config.srcDir}/error`),
+        resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
+      ]
     )
   }
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -75,7 +75,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // Resolve error component
   if (!app.errorComponent) {
     app.errorComponent = await findPath(
-      nuxt.options._layers.map(layer => join(layer.config.srcDir, 'error')),
+      nuxt.options._layers.map(layer => join(layer.config.srcDir, 'error'))
     ) ?? resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
   }
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -74,7 +74,9 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve error component
   if (!app.errorComponent) {
-    app.errorComponent = (await findPath(['~/error'])) || resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
+    app.errorComponent = await findPath(
+      nuxt.options._layers.map(layer => `${layer.config.srcDir}/error`)
+    )
   }
 
   // Resolve layouts/ from all config layers

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -74,9 +74,9 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve error component
   if (!app.errorComponent) {
-    app.errorComponent = await findPath(
+    app.errorComponent = (await findPath(
       nuxt.options._layers.map(layer => join(layer.config.srcDir, 'error'))
-    ) ?? resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
+    )) ?? resolve(nuxt.options.appDir, 'components/nuxt-error-page.vue')
   }
 
   // Resolve layouts/ from all config layers


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/framework/issues/9520
Related: https://github.com/nuxt/framework/issues/3222

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds layer/`extends` support for `error.vue`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

