### PR TITLE
docs: recommend to install non-dge version of `@nuxt/test-utils`

### DIFF
--- a/docs/content/1.docs/1.getting-started/11.testing.md
+++ b/docs/content/1.docs/1.getting-started/11.testing.md
@@ -11,12 +11,12 @@ Test utils are still in development and the API and behavior may change. Current
 If you are a module author, you can find more specific informations in the [Module Author's guide](/docs/guide/going-further/modules#testing)
 ::
 
-In Nuxt 3, we have a rewritten version of `@nuxt/test-utils` available as `@nuxt/test-utils-edge`. We support [Vitest](https://github.com/vitest-dev/vitest) and [Jest](https://jestjs.io/) as the test runner.
+In Nuxt 3, we have a rewritten version of `@nuxt/test-utils`. We support [Vitest](https://github.com/vitest-dev/vitest) and [Jest](https://jestjs.io/) as test runners.
 
 ## Installation
 
 ```bash
-yarn add --dev @nuxt/test-utils-edge vitest
+yarn add --dev @nuxt/test-utils vitest
 ```
 
 ## Setup
@@ -25,7 +25,7 @@ In each `describe` block where you are taking advantage of the `@nuxt/test-utils
 
 ```ts
 import { describe, test } from 'vitest'
-import { setup, $fetch } from '@nuxt/test-utils-edge'
+import { setup, $fetch } from '@nuxt/test-utils'
 
 describe('My test', async () => {
   await setup({

--- a/docs/content/1.docs/2.guide/3.going-further/3.modules.md
+++ b/docs/content/1.docs/2.guide/3.going-further/3.modules.md
@@ -209,7 +209,7 @@ We can create a test file and use the `rootDir` to test the fixture.
 // basic.test.js
 import { describe, it, expect } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, $fetch } from '@nuxt/test-utils-edge'
+import { setup, $fetch } from '@nuxt/test-utils'
 
 describe('ssr', async () => {
   await setup({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #9542

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With the release of nuxt 3, we no longer need to recommend installing an edge version.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

