### PR TITLE
fix(kit): support applying `.nuxtignore` within external layers

### DIFF
--- a/packages/kit/src/ignore.ts
+++ b/packages/kit/src/ignore.ts
@@ -24,7 +24,8 @@ export function isIgnored (pathname: string): boolean {
     }
   }
 
-  const relativePath = relative(nuxt.options.rootDir, pathname)
+  const layer = nuxt.options._layers?.find(layer => pathname.startsWith(layer.cwd))
+  const relativePath = relative(layer?.cwd ?? nuxt.options.rootDir, pathname)
   if (relativePath.startsWith('..')) {
     return false
   }

--- a/packages/kit/src/ignore.ts
+++ b/packages/kit/src/ignore.ts
@@ -24,8 +24,9 @@ export function isIgnored (pathname: string): boolean {
     }
   }
 
-  const layer = nuxt.options._layers?.find(layer => pathname.startsWith(layer.cwd))
-  const relativePath = relative(layer?.cwd ?? nuxt.options.rootDir, pathname)
+  const cwds = nuxt.options._layers?.map(layer => layer.cwd).sort((a, b) => b.length - a.length)
+  const layer = cwds?.find(cwd => pathname.startsWith(cwd))
+  const relativePath = relative(layer ?? nuxt.options.rootDir, pathname)
   if (relativePath.startsWith('..')) {
     return false
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/8634

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for applying `.nuxtignore` in relation to the root directory of each layer.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
