### PR TITLE
fix(vite): skip _only_ vite transform middleware

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage, ServerResponse } from 'node:http'
 import { join, relative, resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
@@ -120,13 +121,20 @@ export async function buildClient (ctx: ViteBuildContext) {
     const viteServer = await vite.createServer(clientConfig)
     ctx.clientServer = viteServer
     await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: true, isServer: false })
-    const viteRoutes = viteServer.middlewares.stack.map(m => m.route).filter(r => r.length > 1)
+    const transformHandler = viteServer.middlewares.stack.findIndex(m => m.handle instanceof Function && m.handle.name === 'viteTransformMiddleware')
+    viteServer.middlewares.stack.splice(transformHandler, 0, {
+      route: '',
+      handle: (req: IncomingMessage & { _skip_transform?: boolean }, res: ServerResponse, next: (err?: any) => void) => {
+        // 'Skip' the transform middleware
+        if (req._skip_transform) { req.url = joinURL('/__skip_vite', req.url!) }
+        next()
+      }
+    })
     const viteMiddleware = defineEventHandler(async (event) => {
       // Workaround: vite devmiddleware modifies req.url
       const originalURL = event.node.req.url!
-      if (!viteRoutes.some(route => originalURL.startsWith(route)) && !originalURL.startsWith(clientConfig.base!)) {
-        event.node.req.url = joinURL('/__url', originalURL)
-      }
+      // @ts-expect-error _skip_transform is a private property
+      event.node.req._skip_transform = !originalURL.startsWith(clientConfig.base!)
       await new Promise((resolve, reject) => {
         viteServer.middlewares.handle(event.node.req, event.node.res, (err: Error) => {
           event.node.req.url = originalURL


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/9205, resolves https://github.com/nuxt/framework/issues/9467, resolves https://github.com/nuxt/framework/issues/9107

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR avoids modifying the URL for vite middleware injected prior to `viteTransformMiddleware`, instead injecting another middleware to make the modification within the vite stack.

The underlying mechanism of skipping the vite transform hasn't changed, just the time of making the change.

cc: @patak-dev

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
