### PR TITLE
fix(nuxt): await plugin asyncdata promises in nuxt hook

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -190,7 +190,7 @@ export function useAsyncData<
     if (getCurrentInstance()) {
       onServerPrefetch(() => promise)
     } else {
-      useNuxtApp().hook('app:created', () => promise)
+      nuxt.hook('app:created', () => promise)
     }
   }
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -189,6 +189,8 @@ export function useAsyncData<
     const promise = initialFetch()
     if (getCurrentInstance()) {
       onServerPrefetch(() => promise)
+    } else {
+      useNuxtApp().hook('app:created', () => promise)
     }
   }
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -187,7 +187,9 @@ export function useAsyncData<
   // Server side
   if (process.server && fetchOnServer && options.immediate) {
     const promise = initialFetch()
-    onServerPrefetch(() => promise)
+    if (getCurrentInstance()) {
+      onServerPrefetch(() => promise)
+    }
   }
 
   // Client side

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -31,6 +31,8 @@ if (process.server) {
 
     try {
       await applyPlugins(nuxt, plugins)
+      const asyncDataPromises = Object.keys(nuxt._asyncDataPromises).map((key) => nuxt._asyncDataPromises[key])
+      await Promise.all(asyncDataPromises)
       await nuxt.hooks.callHook('app:created', vueApp)
     } catch (err) {
       await nuxt.callHook('app:error', err)

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -31,8 +31,6 @@ if (process.server) {
 
     try {
       await applyPlugins(nuxt, plugins)
-      const asyncDataPromises = Object.keys(nuxt._asyncDataPromises).map((key) => nuxt._asyncDataPromises[key])
-      await Promise.all(asyncDataPromises)
       await nuxt.hooks.callHook('app:created', vueApp)
     } catch (err) {
       await nuxt.callHook('app:error', err)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -381,6 +381,7 @@ describe('plugins', () => {
   it('async plugin', async () => {
     const html = await $fetch('/plugins')
     expect(html).toContain('asyncPlugin: Async plugin works! 123')
+    expect(html).toContain('useFetch works!')
   })
 })
 
@@ -885,7 +886,7 @@ describe.skipIf(process.env.NUXT_TEST_DEV || isWindows)('payload rendering', () 
   it('renders a payload', async () => {
     const payload = await $fetch('/random/a/_payload.js', { responseType: 'text' })
     expect(payload).toMatch(
-      /export default \{data:\{rand_a:\[[^\]]*\]\},prerenderedAt:\d*\}/
+      /export default \{data:\{hey:{[^}]*},rand_a:\[[^\]]*\]\},prerenderedAt:\d*\}/
     )
   })
 

--- a/test/fixtures/basic/plugins/async-plugin.ts
+++ b/test/fixtures/basic/plugins/async-plugin.ts
@@ -1,11 +1,12 @@
 export default defineNuxtPlugin(async (/* nuxtApp */) => {
   const config1 = useRuntimeConfig()
   await new Promise(resolve => setTimeout(resolve, 100))
+  const { data } = useFetch('/api/hey', { key: 'hey' })
   const config2 = useRuntimeConfig()
   return {
     provide: {
       asyncPlugin: () => config1 && config1 === config2
-        ? 'Async plugin works! ' + config1.testConfig
+        ? 'Async plugin works! ' + config1.testConfig + (data.value?.baz ? 'useFetch works!' : 'useFetch does not work')
         : 'Async plugin failed!'
     }
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolves #9315 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Added a check for the presence of currentInstance before calling the vue hook onServerPrefetch

Fix vue warn when calling useFetch in serverPlugin

[Vue warn]: onServerPrefetch is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.

Resolves #9315
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

