### PR TITLE
fix(schema): add hookable dependency

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -16,8 +16,8 @@
   "devDependencies": {
     "@types/lodash.template": "^4",
     "@types/semver": "^7",
-    "@vitejs/plugin-vue": "^3.2.0",
     "@unhead/schema": "^1.0.13",
+    "@vitejs/plugin-vue": "^3.2.0",
     "nitropack": "^1.0.0",
     "unbuild": "latest",
     "vite": "~3.2.5"
@@ -26,6 +26,7 @@
     "c12": "^1.1.0",
     "create-require": "^1.1.1",
     "defu": "^6.1.1",
+    "hookable": "^5.4.2",
     "jiti": "^1.16.0",
     "pathe": "^1.0.0",
     "pkg-types": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,7 @@ importers:
       c12: ^1.1.0
       create-require: ^1.1.1
       defu: ^6.1.1
+      hookable: ^5.4.2
       jiti: ^1.16.0
       nitropack: ^1.0.0
       pathe: ^1.0.0
@@ -533,6 +534,7 @@ importers:
       c12: 1.1.0
       create-require: 1.1.1
       defu: 6.1.1
+      hookable: 5.4.2
       jiti: 1.16.0
       pathe: 1.0.0
       pkg-types: 1.0.1


### PR DESCRIPTION
fix the phantom dependency issue

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

relate #5411

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add `hookable`. It's only added in `nuxt` package. I only need `defineNuxtModule` from `@nuxt/kit`. Then `hookable` pkg is missing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

