### PR TITLE
fix(nuxt): remove absolute paths from routes objects

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -223,11 +223,12 @@ function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage) {
 }
 
 export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = new Set()): { imports: Set<string>, routes: string } {
+  const nuxt = useNuxt()
   return {
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((route) => {
       const file = normalize(route.file)
-      const metaImportName = genSafeVariableName(file) + 'Meta'
+      const metaImportName = genSafeVariableName(relative(nuxt.options.rootDir, file)) + 'Meta'
       metaImports.add(genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }]))
 
       let aliasCode = `${metaImportName}?.alias || []`

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -226,26 +226,31 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
   const nuxt = useNuxt()
   return {
     imports: metaImports,
-    routes: genArrayFromRaw(routes.map((route) => {
-      const file = normalize(route.file)
+    routes: genArrayFromRaw(routes.map((page) => {
+      const file = normalize(page.file)
       const metaImportName = genSafeVariableName(relative(nuxt.options.rootDir, file)) + 'Meta'
       metaImports.add(genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }]))
 
       let aliasCode = `${metaImportName}?.alias || []`
-      if (Array.isArray(route.alias) && route.alias.length) {
-        aliasCode = `${JSON.stringify(route.alias)}.concat(${aliasCode})`
+      if (Array.isArray(page.alias) && page.alias.length) {
+        aliasCode = `${JSON.stringify(page.alias)}.concat(${aliasCode})`
       }
 
-      return {
-        ...Object.fromEntries(Object.entries(route).map(([key, value]) => [key, JSON.stringify(value)])),
-        name: `${metaImportName}?.name ?? ${route.name ? JSON.stringify(route.name) : 'undefined'}`,
-        path: `${metaImportName}?.path ?? ${JSON.stringify(route.path)}`,
-        children: route.children ? normalizeRoutes(route.children, metaImports).routes : [],
-        meta: route.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(route.meta)}}` : metaImportName,
+      const route = {
+        ...Object.fromEntries(Object.entries(page).map(([key, value]) => [key, JSON.stringify(value)])),
+        file: undefined,
+        name: `${metaImportName}?.name ?? ${page.name ? JSON.stringify(page.name) : 'undefined'}`,
+        path: `${metaImportName}?.path ?? ${JSON.stringify(page.path)}`,
+        children: page.children ? normalizeRoutes(page.children, metaImports).routes : [],
+        meta: page.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(page.meta)}}` : metaImportName,
         alias: aliasCode,
-        redirect: route.redirect ? JSON.stringify(route.redirect) : `${metaImportName}?.redirect || undefined`,
+        redirect: page.redirect ? JSON.stringify(page.redirect) : `${metaImportName}?.redirect || undefined`,
         component: genDynamicImport(file, { interopDefault: true })
       }
+
+      delete route.file
+
+      return route
     }))
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/9653

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Absolute file paths were being embedded in the build by the pages integration in two places - in the meta variable as well as in the `.file` attribute (which is not used by `vue-router` as far as I can tell). We can safely relativise the former and remove the latter.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
