### PR TITLE
feat(nuxt): deep watch `useCookie` ref value by default

### DIFF
--- a/docs/content/1.docs/3.api/1.composables/use-cookie.md
+++ b/docs/content/1.docs/3.api/1.composables/use-cookie.md
@@ -140,11 +140,37 @@ Specifies the `boolean` or `string` value for [watch](https://vuejs.org/api/reac
 - `shallow` - Will watch cookie ref data changes for only top level properties
 - `false` Will not watch cookie ref data changes.
 
+**Example 1:**
+
+```vue
+<template>
+  <div>User score: {{ user?.score }}</div>
+</template>
+
+<script setup>
+const user = useCookie(
+  'userInfo',
+  {
+    default: () => ({ score: -1 }),
+    watch: false
+  }
+)
+
+if (user.value && user.value !== null) {
+  user.value.score++; // userInfo cookie not update with this change
+}
+</script>
+```
+
+**Example 2:**
+
 ```vue
 <template>
   <div>
-    <h1>List: {{ list }}</h1>
+    <h1>List</h1>
+    <pre>{{ list }}</pre>
     <button @click="add">Add</button>
+    <button @click="save">Save</button>
   </div>
 </template>
 
@@ -159,6 +185,14 @@ const list = useCookie(
 
 function add() {
   list.value?.push(Math.round(Math.random() * 1000))
+  // list cookie not update with this change
+}
+
+function save() {
+  if (list.value && list.value !== null) {
+    list.value = [...list.value]
+    // list cookie update with this change
+  }
 }
 </script>
 ```

--- a/docs/content/1.docs/3.api/1.composables/use-cookie.md
+++ b/docs/content/1.docs/3.api/1.composables/use-cookie.md
@@ -138,10 +138,13 @@ be returned as the cookie's value.
 
 Specifies a function that returns the cookie's default value. The function can also return a `Ref`.
 
-### `deepWatch`
+### `watch`
 
-Specifies the `boolean` value for the deep watch Cookie ref. When truthy,
-Cookie update on deep data changed; otherwise it is not. By default, you need reassign your data.
+Specifies the `boolean` or `string` value for [watch](https://vuejs.org/api/reactivity-core.html#watch) cookie ref data.
+
+- `true` or `shallow` will watch cookie ref data.
+- `false` will not watch cookie data.
+- `deep` will watch cookie ref data and data sources change.
 
 ```vue
 <template>

--- a/docs/content/1.docs/3.api/1.composables/use-cookie.md
+++ b/docs/content/1.docs/3.api/1.composables/use-cookie.md
@@ -25,16 +25,10 @@ The example below creates a cookie called `counter`. If the cookie doesn't exist
 ```vue
 <template>
   <div>
-    <h1> Counter: {{ counter || '-' }}</h1>
-    <button @click="counter = null">
-      reset
-    </button>
-    <button @click="counter--">
-      -
-    </button>
-    <button @click="counter++">
-      +
-    </button>
+    <h1>Counter: {{ counter || '-' }}</h1>
+    <button @click="counter = null">reset</button>
+    <button @click="counter--">-</button>
+    <button @click="counter++">+</button>
   </div>
 </template>
 
@@ -142,24 +136,26 @@ Specifies a function that returns the cookie's default value. The function can a
 
 Specifies the `boolean` or `string` value for [watch](https://vuejs.org/api/reactivity-core.html#watch) cookie ref data.
 
-- `true` or `shallow` will watch cookie ref data.
-- `false` will not watch cookie data.
-- `deep` will watch cookie ref data and data sources change.
+- `true` - Will watch cookie ref data changes and it's nested properties. (default)
+- `shallow` - Will watch cookie ref data changes for only top level properties
+- `false` Will not watch cookie ref data changes.
 
 ```vue
 <template>
   <div>
-    <h1> List: {{ list }}</h1>
-    <button @click="add">
-      Add
-    </button>
+    <h1>List: {{ list }}</h1>
+    <button @click="add">Add</button>
   </div>
 </template>
 
 <script setup>
-const list = useCookie('list', { default: () => [] }, {
-  deepWatch: true
-})
+const list = useCookie(
+  'list',
+  { default: () => [] },
+  {
+    watch: 'shallow'
+  }
+)
 
 function add() {
   list.value?.push(Math.round(Math.random() * 1000))

--- a/docs/content/1.docs/3.api/1.composables/use-cookie.md
+++ b/docs/content/1.docs/3.api/1.composables/use-cookie.md
@@ -138,6 +138,32 @@ be returned as the cookie's value.
 
 Specifies a function that returns the cookie's default value. The function can also return a `Ref`.
 
+### `deepWatch`
+
+Specifies the `boolean` value for the deep watch Cookie ref. When truthy,
+Cookie update on deep data changed; otherwise it is not. By default, you need reassign your data.
+
+```vue
+<template>
+  <div>
+    <h1> List: {{ list }}</h1>
+    <button @click="add">
+      Add
+    </button>
+  </div>
+</template>
+
+<script setup>
+const list = useCookie('list', { default: () => [] }, {
+  deepWatch: true
+})
+
+function add() {
+  list.value?.push(Math.round(Math.random() * 1000))
+}
+</script>
+```
+
 ## Handling Cookies in API Routes
 
 You can use `getCookie` and `setCookie` from [`h3`](https://github.com/unjs/h3) package to set cookies in server API routes.

--- a/docs/content/1.docs/3.api/1.composables/use-cookie.md
+++ b/docs/content/1.docs/3.api/1.composables/use-cookie.md
@@ -136,7 +136,7 @@ Specifies a function that returns the cookie's default value. The function can a
 
 Specifies the `boolean` or `string` value for [watch](https://vuejs.org/api/reactivity-core.html#watch) cookie ref data.
 
-- `true` - Will watch cookie ref data changes and it's nested properties. (default)
+- `true` - Will watch cookie ref data changes and its nested properties. (default)
 - `shallow` - Will watch cookie ref data changes for only top level properties
 - `false` Will not watch cookie ref data changes.
 
@@ -151,8 +151,8 @@ Specifies the `boolean` or `string` value for [watch](https://vuejs.org/api/reac
 <script setup>
 const list = useCookie(
   'list',
-  { default: () => [] },
   {
+    default: () => [],
     watch: 'shallow'
   }
 )

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -15,7 +15,7 @@ export interface CookieOptions<T = any> extends _CookieOptions {
   decode?(value: string): T
   encode?(value: T): string
   default?: () => T | Ref<T>
-  watch?: boolean | 'deep' | 'shallow'
+  watch?: boolean | 'shallow'
 }
 
 export interface CookieRef<T> extends Ref<T> {}
@@ -35,7 +35,7 @@ export function useCookie <T = string | null> (name: string, _opts?: CookieOptio
   if (process.client) {
     const callback = () => { writeClientCookie(name, cookie.value, opts as CookieSerializeOptions) }
     if (opts.watch) {
-      watch(cookie, callback, { deep: opts.watch === 'deep' })
+      watch(cookie, callback, { deep: opts.watch !== 'shallow' })
     } else {
       callback()
     }

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -15,6 +15,7 @@ export interface CookieOptions<T = any> extends _CookieOptions {
   decode?(value: string): T
   encode?(value: T): string
   default?: () => T | Ref<T>
+  deepWatch?: boolean
 }
 
 export interface CookieRef<T> extends Ref<T> {}
@@ -32,7 +33,9 @@ export function useCookie <T = string | null> (name: string, _opts?: CookieOptio
   const cookie = ref<T | undefined>(cookies[name] as any ?? opts.default?.())
 
   if (process.client) {
-    watch(cookie, () => { writeClientCookie(name, cookie.value, opts as CookieSerializeOptions) })
+    watch(cookie, () => { writeClientCookie(name, cookie.value, opts as CookieSerializeOptions) }, {
+      deep: opts.deepWatch
+    })
   } else if (process.server) {
     const nuxtApp = useNuxtApp()
     const writeFinalCookieValue = () => {

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -15,7 +15,7 @@ export interface CookieOptions<T = any> extends _CookieOptions {
   decode?(value: string): T
   encode?(value: T): string
   default?: () => T | Ref<T>
-  deepWatch?: boolean
+  watch?: boolean | 'deep' | 'shallow'
 }
 
 export interface CookieRef<T> extends Ref<T> {}
@@ -33,9 +33,12 @@ export function useCookie <T = string | null> (name: string, _opts?: CookieOptio
   const cookie = ref<T | undefined>(cookies[name] as any ?? opts.default?.())
 
   if (process.client) {
-    watch(cookie, () => { writeClientCookie(name, cookie.value, opts as CookieSerializeOptions) }, {
-      deep: opts.deepWatch
-    })
+    const callback = () => { writeClientCookie(name, cookie.value, opts as CookieSerializeOptions) }
+    if (opts.watch) {
+      watch(cookie, callback, { deep: opts.watch === 'deep' })
+    } else {
+      callback()
+    }
   } else if (process.server) {
     const nuxtApp = useNuxtApp()
     const writeFinalCookieValue = () => {

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -22,6 +22,7 @@ export interface CookieRef<T> extends Ref<T> {}
 
 const CookieDefaults: CookieOptions<any> = {
   path: '/',
+  watch: true,
   decode: val => destr(decodeURIComponent(val)),
   encode: val => encodeURIComponent(typeof val === 'string' ? val : JSON.stringify(val))
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useCookie` only change when `.value` update. we can use deep flag in watch and track all change.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

