### PR TITLE
docs: list utils as auto-import directory

### DIFF
--- a/docs/content/1.docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/content/1.docs/2.guide/1.concepts/1.auto-imports.md
@@ -46,6 +46,7 @@ Nuxt directly auto-imports files created in defined directories:
 
 - `components/` for [Vue components](/docs/guide/directory-structure/components).
 - `composables/` for [Vue composables](/docs/guide/directory-structure/composables).
+- `utils/` for helper functions and other utilities.
 
 ## Explicit Imports
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The `utils` directory is missing in the list of directory-based auto-imports, so I added it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

