### PR TITLE
refactor(vite): show log when client build is starting

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -149,9 +149,10 @@ export async function buildClient (ctx: ViteBuildContext) {
     })
   } else {
     // Build
+    logger.info('Building client...')
     const start = Date.now()
     await vite.build(clientConfig)
     await ctx.nuxt.callHook('vite:compiled')
-    logger.info(`Client built in ${Date.now() - start}ms`)
+    logger.success(`Client built in ${Date.now() - start}ms`)
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As the app getting big, the building on the client does not show any state and is stuck on this line, which could be confusing. We have `Building server...` indicator, I think we should do the same for client build.

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/11247099/208075896-baf824ff-b9b4-4538-88b0-ef22fa57ebcc.png">


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

