### PR TITLE
docs(getting-started): improve usage of `pnpm`

### DIFF
--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -78,7 +78,7 @@ npm install
 ```
 
 ```bash [pnpm]
-pnpm install #Notice the note below
+pnpm install --shamefully-hoist # or shamefully-hoist=true in .npmrc
 ```
 
 ::

--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -78,13 +78,13 @@ npm install
 ```
 
 ```bash [pnpm]
-pnpm install --shamefully-hoist # or shamefully-hoist=true in .npmrc
+pnpm install #Notice the note below
 ```
 
 ::
 
 ::alert
-**Note:** If using **pnpm**, make sure to have `.npmrc` with `shamefully-hoist=true` inside it before `pnpm install`. Or add `--shamefully-hoist` directly when `pnpm i`.
+**Note:** If using **pnpm**, make sure to have `.npmrc` with `shamefully-hoist=true` inside it before `pnpm install`. Otherwise, you have to add `--shamefully-hoist` when running `pnpm i`.
 ::
 
 ## Development Server

--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -78,7 +78,8 @@ npm install
 ```
 
 ```bash [pnpm]
-pnpm install --shamefully-hoist # or shamefully-hoist=true in .npmrc
+# Make sure you have `shamefully-hoist=true` in `.npmrc` before running pnpm install
+pnpm install
 ```
 
 ::

--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -78,13 +78,13 @@ npm install
 ```
 
 ```bash [pnpm]
-pnpm install
+pnpm install --shamefully-hoist # or shamefully-hoist=true in .npmrc
 ```
 
 ::
 
 ::alert
-**Note:** If using **pnpm**, make sure to have `.npmrc` with `shamefully-hoist=true` inside it before `pnpm install`.
+**Note:** If using **pnpm**, make sure to have `.npmrc` with `shamefully-hoist=true` inside it before `pnpm install`. Or add `--shamefully-hoist` directly when `pnpm i`.
 ::
 
 ## Development Server
@@ -102,7 +102,7 @@ npm run dev -- -o
 ```
 
 ```bash [pnpm]
-pnpm run dev -o
+pnpm dev -o
 ```
 
 ::

--- a/docs/content/1.docs/1.getting-started/2.installation.md
+++ b/docs/content/1.docs/1.getting-started/2.installation.md
@@ -85,7 +85,7 @@ pnpm install
 ::
 
 ::alert
-**Note:** If using **pnpm**, make sure to have `.npmrc` with `shamefully-hoist=true` inside it before `pnpm install`. Otherwise, you have to add `--shamefully-hoist` when running `pnpm i`.
+**Note:** If using **pnpm**, make sure to have `.npmrc` with `shamefully-hoist=true` inside it before `pnpm install`.
 ::
 
 ## Development Server


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### changes
1, Add `--shamefully-hoist` for `pnpm install`.
2, Omit `run` for pnpm script.

#### why
1, For new project, `--shamefully-hoist` is more comfortable than `.npmrc` with `shamefully-hoist=true`. And `#` does not affect the copying of the entire shell run.
2, In terms of reading order, --shamefullu-hoist is written after the shell command, and although alert is visually obvious, there is a chance that it will be missed.
3, Since yarn omits run, pnpm can actually omit run as well😜.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

