### PR TITLE
docs(index): fix typo in 'GitHub'

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -11,7 +11,7 @@ topButtonText: 'Announcing 3.0 stable'
 topButtonLink: '/v3'
 primaryButtonText: 'Get started'
 primaryButtonLink: '/docs/getting-started/introduction'
-secondaryButtonText: 'Open on Github'
+secondaryButtonText: 'Open on GitHub'
 secondaryButtonLink: 'https://github.com/nuxt/framework'
 ---
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed the typo in the name Github on the main page, it should be GitHub in respect to the conventions established by GitHub.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

