### PR TITLE
fix(nuxt): set is loading state for  `<NuxtLoadingIndicator>` after throttle

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
+++ b/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
@@ -68,16 +68,16 @@ function useLoadingIndicator (opts: {
   function start () {
     clear()
     progress.value = 0
-    isLoading.value = true
-    if (opts.throttle) {
-      if (process.client) {
-        _throttle = setTimeout(_startTimer, opts.throttle)
-      }
+    if (opts.throttle && process.client) {
+      _throttle = setTimeout(() => {
+        isLoading.value = true
+        _startTimer()
+      }, opts.throttle)
     } else {
+      isLoading.value = true
       _startTimer()
     }
   }
-
   function finish () {
     progress.value = 100
     _hide()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously, animation will always trigger despite throttle being declared due to `isLoading.value` being `true` outside of the `setTimeout` function. Now the loading indicator only shows up if the page takes more than the configured throttle time, which is the intended purpose of it. Default is `200ms`. Setting it to 0 will always trigger the loading animation.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

