### PR TITLE
docs(examples): fix `runtimeConfig` usage in config-extends example

### DIFF
--- a/examples/advanced/config-extends/base/nuxt.config.ts
+++ b/examples/advanced/config-extends/base/nuxt.config.ts
@@ -2,10 +2,12 @@ export default defineNuxtConfig({
   imports: {
     dirs: ['utils']
   },
-  publicRuntimeConfig: {
-    theme: {
-      primaryColor: 'base_primary',
-      secondaryColor: 'base_secondary'
+  runtimeConfig: {
+    public: {
+      theme: {
+        primaryColor: 'base_primary',
+        secondaryColor: 'base_secondary'
+      }
     }
   }
 })

--- a/examples/advanced/config-extends/nuxt.config.ts
+++ b/examples/advanced/config-extends/nuxt.config.ts
@@ -3,9 +3,11 @@ export default defineNuxtConfig({
     './ui',
     './base'
   ],
-  publicRuntimeConfig: {
-    theme: {
-      primaryColor: 'user_primary'
+  runtimeConfig: {
+    public: {
+      theme: {
+        primaryColor: 'user_primary'
+      }
     }
   },
   modules: [


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The`runtimeConfig` part of the example doesn't work.
Deprecated `publicRuntimeConfig` prop isn't supported since [v3.0.0-rc.14](https://github.com/nuxt/framework/releases/tag/v3.0.0-rc.14) (due to #9029).

Changing `publicRuntimeConfig` to `runtimeConfig.public` in **nuxt.config.ts**.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

