### PR TITLE
docs(configuration): clarify the location of `app.config.ts` in the source directory

### DIFF
--- a/docs/content/1.docs/1.getting-started/3.configuration.md
+++ b/docs/content/1.docs/1.getting-started/3.configuration.md
@@ -69,7 +69,7 @@ const runtimeConfig = useRuntimeConfig()
 
 ## App Configuration
 
-The `app.config.ts` file, also located at the root of a Nuxt project, is used to expose public variables that can be determined at build time. Contrary to the `runtimeConfig` option, these can not be overridden using environment variables.
+The `app.config.ts` file, located in the source directory (by default the root of the project), is used to expose public variables that can be determined at build time. Contrary to the `runtimeConfig` option, these can not be overridden using environment variables.
 
 A minimal configuration file exports the `defineAppConfig` function containing an object with your configuration. The `defineAppConfig` helper is globally available without import.
 
@@ -111,8 +111,6 @@ Types support                  | ✅ Partial       | ✅ Yes
 Configuration per Request      | ❌ No            | ✅ Yes
 Hot Module Replacement         | ❌ No            | ✅ Yes
 Non primitive JS types         | ❌ No            | ✅ Yes
-
-:ReadMore{link="/docs/guide/directory-structure/external-configuration"}
 
 ## External Configuration Files
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Resolve #9914 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current [documentation](https://nuxt.com/docs/getting-started/configuration#app-configuration) says that the `app.config.ts` is in the root directory, but in reality it is the source directory. I slightly reworded the sentence to clarify this.

I also removed a link to a non-existing page in the following section (hope this is not too unrelated).
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

