### PR TITLE
docs: update `generate` doc to include `--dotenv`

### DIFF
--- a/docs/content/1.docs/3.api/5.commands/generate.md
+++ b/docs/content/1.docs/3.api/5.commands/generate.md
@@ -14,3 +14,4 @@ The `generate` command pre-renders every route of your application and stores th
 Option        | Default          | Description
 -------------------------|-----------------|------------------
 `rootDir` | `.` | The root directory of the application to generate
+`--dotenv` | `.` | Point to another `.env` file to load, **relative** to the root directory.

--- a/docs/content/1.docs/3.api/5.commands/generate.md
+++ b/docs/content/1.docs/3.api/5.commands/generate.md
@@ -6,7 +6,7 @@ description: Pre-renders every route of the application and stores the result in
 # `nuxi generate`
 
 ```{bash}
-npx nuxi generate [rootDir]
+npx nuxi generate [rootDir] [--dotenv]
 ```
 
 The `generate` command pre-renders every route of your application and stores the result in plain HTML files that you can deploy on any static hosting services. The command triggers the `nuxi build` command with the `prerender` argument set to `true`

--- a/packages/nuxi/src/commands/generate.ts
+++ b/packages/nuxi/src/commands/generate.ts
@@ -4,7 +4,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'generate',
-    usage: 'npx nuxi generate [rootDir]',
+    usage: 'npx nuxi generate [rootDir] [--dotenv]',
     description: 'Build Nuxt and prerender static routes'
   },
   async invoke (args) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/framework/issues/9966 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: , this PR adds the `--dotenv` arg to the documentation for the generate command. I think the `generate` command already support the `--dotenv` arg since it pass all its arguments to the `build` command.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

