### PR TITLE
docs(guide): fix the link to deploy in `guide/.output`

### DIFF
--- a/docs/content/1.docs/2.guide/2.directory-structure/0.output.md
+++ b/docs/content/1.docs/2.guide/2.directory-structure/0.output.md
@@ -13,4 +13,4 @@ Nuxt creates the `.output/` directory when building your application for product
 You should not touch any files inside since the whole directory will be re-created when running `nuxt build`.
 ::
 
-Use this directory to deploy your Nuxt application to production. Learn more in our [deployment section](/docs/guide/deploy).
+Use this directory to deploy your Nuxt application to production. Learn more in our [deployment section](/docs/getting-started/deployment).


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The link to deployment-section may not have been updated, and it is now not jumping correctly.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

