### PR TITLE
docs: remove nuxt 2 information from `generate` schema

### DIFF
--- a/packages/schema/src/config/generate.ts
+++ b/packages/schema/src/config/generate.ts
@@ -8,60 +8,17 @@ export default defineUntypedSchema({
      * If you are using the crawler, this will be only the starting point for route generation.
      * This is often necessary when using dynamic routes.
      *
-     * It can be an array or a function.
+     * It is preferred to use `nitro.prerender.routes`.
      *
      * @example
      * ```js
      * routes: ['/users/1', '/users/2', '/users/3']
      * ```
-     *
-     * You can pass a function that returns a promise or a function that takes a callback. It should
-     * return an array of strings or objects with `route` and (optional) `payload` keys.
-     *
-     * @example
-     * ```js
-     * export default {
-     *   generate: {
-     *     async routes() {
-     *       const res = await axios.get('https://my-api/users')
-     *       return res.data.map(user => ({ route: '/users/' + user.id, payload: user }))
-     *     }
-     *   }
-     * }
-     * ```
-     * Or instead:
-     * ```js
-     * export default {
-     *   generate: {
-     *     routes(callback) {
-     *       axios
-     *         .get('https://my-api/users')
-     *         .then(res => {
-     *           const routes = res.data.map(user => '/users/' + user.id)
-     *           callback(null, routes)
-     *         })
-     *         .catch(callback)
-     *     }
-     *   }
-     * }
-     * ```
-     *
-     * If `routes()` returns a payload, it can be accessed from the Nuxt context.
-     * @example
-     * ```js
-     * export default {
-     *   async useAsyncData ({ params, error, payload }) {
-     *     if (payload) return { user: payload }
-     *     else return { user: await backend.fetchUser(params.id) }
-     *   }
-     * }
-     * ```
      */
     routes: [],
 
     /**
-     * An array of string or regular expressions that will prevent generation
-     * of routes matching them. The routes will still be accessible when `fallback` is set.
+     * This option is no longer used. Instead, use `nitro.prerender.ignore`.
      */
     exclude: []
   }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4919

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We still have some information from Nuxt 2 docs in this section of the documentation. We can also consider removing this top-level key entirely (cc: @pi0) but as a first step we should remove the misleading docs.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
