### PR TITLE
fix(nuxt): allow overriding lower layer composables

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -72,7 +72,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
     addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
 
-    const priorities = [...nuxt.options._layers].reverse().map((layer, i) => [layer.config.srcDir, i] as const).sort(([a], [b]) => b.length - a.length)
+    const priorities = nuxt.options._layers.map((layer, i) => [layer.config.srcDir, -i] as const).sort(([a], [b]) => b.length - a.length)
 
     const regenerateImports = async () => {
       ctx.clearDynamicImports()

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -72,11 +72,17 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     addVitePlugin(TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
     addWebpackPlugin(TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
 
+    const priorities = [...nuxt.options._layers].reverse().map((layer, i) => [layer.config.srcDir, i] as const).sort(([a], [b]) => b.length - a.length)
+
     const regenerateImports = async () => {
       ctx.clearDynamicImports()
       await ctx.modifyDynamicImports(async (imports) => {
         // Scan composables/
-        imports.push(...await scanDirExports(composablesDirs))
+        const composableImports = await scanDirExports(composablesDirs)
+        for (const i of composableImports) {
+          i.priority = i.priority || priorities.find(([dir]) => i.from.startsWith(dir))?.[1]
+        }
+        imports.push(...composableImports)
         // Modules extending
         await nuxt.callHook('imports:extend', imports)
       })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -474,6 +474,10 @@ describe('extends support', () => {
       const html = await $fetch('/foo')
       expect(html).toContain('Composable | useExtendsFoo: foo')
     })
+    it('allows overriding composables', async () => {
+      const html = await $fetch('/extends')
+      expect(html).toContain('test from project')
+    })
   })
 
   describe('plugins', () => {

--- a/test/fixtures/basic/composables/override-base.ts
+++ b/test/fixtures/basic/composables/override-base.ts
@@ -1,0 +1,1 @@
+export const useOverrideableComposable = () => 'test from project'

--- a/test/fixtures/basic/extends/bar/composables/base.ts
+++ b/test/fixtures/basic/extends/bar/composables/base.ts
@@ -1,0 +1,1 @@
+export const useOverrideableComposable = () => 'test from layer'

--- a/test/fixtures/basic/pages/extends.vue
+++ b/test/fixtures/basic/pages/extends.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    {{ useOverrideableComposable() }}
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/9871

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a priority to composables scanned from directories so that higher priority layers can override lower priority layers.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
