### PR TITLE
fix(nuxt): add `build.transpile` strings to nitro inline list

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -82,6 +82,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
               '@nuxt/',
               nuxt.options.buildDir
             ]),
+        ...nuxt.options.build.transpile.filter(i => typeof i === 'string'),
         'nuxt/dist',
         'nuxt3/dist',
         distDir


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/836

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This automatically adds any string-based packages in `build.transpile` to be inlined in nitro as well, to improve DX for module authors and users.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
