### PR TITLE
fix(vite): don't match other endpoints _beginning_ with `_nuxt`

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -6,7 +6,7 @@ import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { ServerOptions } from 'vite'
 import { logger } from '@nuxt/kit'
 import { getPort } from 'get-port-please'
-import { joinURL, withoutLeadingSlash, withoutTrailingSlash } from 'ufo'
+import { joinURL, withoutLeadingSlash, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import defu from 'defu'
 import type { OutputOptions } from 'rollup'
 import { defineEventHandler } from 'h3'
@@ -130,11 +130,12 @@ export async function buildClient (ctx: ViteBuildContext) {
         next()
       }
     })
+    const base = withTrailingSlash(clientConfig.base)
     const viteMiddleware = defineEventHandler(async (event) => {
       // Workaround: vite devmiddleware modifies req.url
       const originalURL = event.node.req.url!
       // @ts-expect-error _skip_transform is a private property
-      event.node.req._skip_transform = !originalURL.startsWith(clientConfig.base!)
+      event.node.req._skip_transform = !originalURL.startsWith(base)
       await new Promise((resolve, reject) => {
         viteServer.middlewares.handle(event.node.req, event.node.res, (err: Error) => {
           event.node.req.url = originalURL

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -894,6 +894,16 @@ describe('component islands', () => {
   })
 })
 
+describe.runIf(process.env.NUXT_TEST_DEV && !process.env.TEST_WITH_WEBPACK)('vite plugins', () => {
+  it('does not override vite plugins', async () => {
+    expect(await $fetch('/vite-plugin-without-path')).toBe('vite-plugin without path')
+    expect(await $fetch('/__nuxt-test')).toBe('vite-plugin with __nuxt prefix')
+  })
+  it('does not allow direct access to nuxt source folder', async () => {
+    expect(await $fetch('/app.config')).toContain('404')
+  })
+})
+
 describe.skipIf(process.env.NUXT_TEST_DEV || isWindows)('payload rendering', () => {
   it('renders a payload', async () => {
     const payload = await $fetch('/random/a/_payload.js', { responseType: 'text' })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -100,6 +100,28 @@ export default defineNuxtConfig({
         export: 'namedExport',
         filePath: '~/other-components-folder/named-export'
       })
+    },
+    'vite:extendConfig' (config) {
+      config.plugins!.push({
+        name: 'nuxt:server',
+        configureServer (server) {
+          server.middlewares.use((req, res, next) => {
+            if (req.url === '/vite-plugin-without-path') {
+              res.end('vite-plugin without path')
+              return
+            }
+            next()
+          })
+
+          server.middlewares.use((req, res, next) => {
+            if (req.url === '/__nuxt-test') {
+              res.end('vite-plugin with __nuxt prefix')
+              return
+            }
+            next()
+          })
+        }
+      })
     }
   },
   experimental: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When adding a vite middleware _starting with_ `/_nuxt` we were wrongly skipping the vite transform. This PR adds a trailing slash to confirm.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

